### PR TITLE
include requirements files for certain installations

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,3 @@
+pylint==1.8.2
+pytest==3.3.2
+coverage==4.5.1

--- a/esri-requirements.txt
+++ b/esri-requirements.txt
@@ -1,0 +1,3 @@
+arcpy==XXX
+urllib3==1.22
+certifi==2018.1.18


### PR DESCRIPTION
small PR to suggest the use of requirements files for different installation types.

It would be preferable to do this using a conda-specific tool, but `pip install -r esri-requirements.txt` works pretty well too

Feel free to delete if this if you are not interested