### PR TITLE
WIP Feature/simplify coordinate init

### DIFF
--- a/dist/aws/handler.py
+++ b/dist/aws/handler.py
@@ -79,7 +79,7 @@ def handler(event, context, get_deps=True, ret_pipeline=False):
     # Need to set matplotlib backend to 'Agg' before importing it elsewhere
     import matplotlib 
     matplotlib.use('agg')
-    from podpac import Coordinate
+    from podpac import coordinate
     from podpac.core.pipeline import Pipeline
     try:
         pipeline = Pipeline(source=pipeline)
@@ -87,7 +87,7 @@ def handler(event, context, get_deps=True, ret_pipeline=False):
         w, s, e, n = np.array(bbox, float)     
         dwe = (w-e)/width/2.
         dns = (n-s)/height/2.
-        coord = Coordinate(lat=(n-dns, s+dns, height),
+        coord = coordinate(lat=(n-dns, s+dns, height),
                            lon=(w+dwe, e-dwe, width),
                            time=np.datetime64(time), 
                            order=['time', 'lat', 'lon'])

--- a/podpac/__init__.py
+++ b/podpac/__init__.py
@@ -1,5 +1,5 @@
 from podpac.core.units import Units, UnitsDataArray, UnitsNode
-from podpac.core.coordinate import Coordinate, Coord, MonotonicCoord, UniformCoord, coord_linspace
+from podpac.core.coordinate import coordinate
 from podpac.core.node import Node, Style
 from podpac.core.algorithm.algorithm import Algorithm, Arithmetic, SinCoords
 from podpac.core.algorithm.stats import Min, Max, Sum, Count, Mean, Median, Variance, StandardDeviation, Skew, Kurtosis

--- a/podpac/__init__.py
+++ b/podpac/__init__.py
@@ -1,15 +1,10 @@
 from podpac.core.units import Units, UnitsDataArray, UnitsNode
-from podpac.core.coordinate import (
-    Coordinate, Coord, MonotonicCoord, UniformCoord, coord_linspace)
+from podpac.core.coordinate import Coordinate, Coord, MonotonicCoord, UniformCoord, coord_linspace
 from podpac.core.node import Node, Style
-from podpac.core.algorithm.algorithm import (
-    Algorithm, Arithmetic, SinCoords)
-from podpac.core.algorithm.stats import (
-    Min, Max, Sum, Count, Mean, Median,
-    Variance, StandardDeviation, Skew, Kurtosis)
+from podpac.core.algorithm.algorithm import Algorithm, Arithmetic, SinCoords
+from podpac.core.algorithm.stats import Min, Max, Sum, Count, Mean, Median, Variance, StandardDeviation, Skew, Kurtosis
 from podpac.core.algorithm.coord_select import ExpandCoordinates
-from podpac.core.algorithm.signal import (
-    Convolution, SpatialConvolution, TimeConvolution)
+from podpac.core.algorithm.signal import Convolution, SpatialConvolution, TimeConvolution
 from podpac.core.data.data import DataSource
 from podpac.core.compositor import Compositor, OrderedCompositor
 from podpac.core.pipeline import Pipeline, PipelineError, PipelineNode

--- a/podpac/core/algorithm/algorithm.py
+++ b/podpac/core/algorithm/algorithm.py
@@ -5,6 +5,7 @@ Algorithm Summary
 from __future__ import division, unicode_literals, print_function, absolute_import
 
 import inspect
+from collections import OrderedDict
 import numpy as np
 import xarray as xr
 import traitlets as tl
@@ -176,7 +177,7 @@ class CoordData(Algorithm):
        
         c = ec[coord_name]
         data = c.coordinates
-        coords = Coordinate(order=[coord_name], **{coord_name: c})
+        coords = Coordinate(OrderedDict(**{coord_name:c}))
         return self.initialize_coord_array(coords, init_type='data', fillval=data)
 
 
@@ -281,9 +282,9 @@ class Arithmetic(Algorithm):
         return d
         
 if __name__ == "__main__":
+    import podpac
     a = SinCoords()
-    coords = Coordinate(lat=[-90, 90, 1.], lon=[-180, 180, 1.], 
-                        order=['lat', 'lon'])
+    coords = podpac.coordinate(lat=[-90, 90, 1.], lon=[-180, 180, 1.], order=['lat', 'lon'])
     o = a.execute(coords)
     a2 = Arithmetic(A=a, B=a)
     o2 = a2.execute(coords, params={'eqn': '2*abs(A) - B'})

--- a/podpac/core/algorithm/coord_select.py
+++ b/podpac/core/algorithm/coord_select.py
@@ -4,6 +4,7 @@ Coord Select Summary
 
 from __future__ import division, unicode_literals, print_function, absolute_import
 
+from collections import OrderedDict
 import traitlets as tl
 
 from podpac.core.coordinate import Coordinate, UniformCoord
@@ -122,15 +123,12 @@ class ExpandCoordinates(Algorithm):
         ValueError
             Description
         """
-        kwargs = {}
+        coords = OrderedDict()
         for dim in self.input_coordinates.dims:
-            ec = self.get_expanded_coord(dim)
-            if ec.size == 0:
-                raise ValueError("Expanded/selected coordinates do not"
-                                 " intersect with source data.")
-            kwargs[dim] = ec
-        kwargs['order'] = self.input_coordinates.dims
-        return Coordinate(**kwargs)
+            coords[dim] = self.get_expanded_coord(dim)
+            if coords[dim].size == 0:
+                raise ValueError("Expanded/selected coordinates do not intersect with source data.")
+        return Coordinate(coords, **self.input_coordinates.kwargs)
    
     def algorithm(self):
         """Summary
@@ -215,8 +213,9 @@ class SelectCoordinates(ExpandCoordinates):
 if __name__ == '__main__':
     from podpac.core.algorithm.algorithm import Arange
     from podpac.core.data.data import DataSource
+    import podpac
     
-    coords = Coordinate(
+    coords = podpac.coordinate(
         time='2017-09-01',
         lat=(45., 66., 4),
         lon=(-80., -70., 5),
@@ -259,7 +258,7 @@ if __name__ == '__main__':
     # time expansion using native coordinates
     class Test(DataSource):
         def get_native_coordinates(self):
-            return Coordinate(
+            return podpac.coordinate(
                 time=('2010-01-01', '2018-01-01', '4,h'),
                 lat=(-180., 180., 1800),
                 lon=(-80., -70., 1800),

--- a/podpac/core/algorithm/signal.py
+++ b/podpac/core/algorithm/signal.py
@@ -285,17 +285,18 @@ class SpatialConvolution(Convolution):
 
 if __name__ == '__main__':
     from podpac.core.algorithm.algorithm import Arange
+    import podpac
 
-    coords = Coordinate(
+    coords = podpac.coordinate(
         time=('2017-09-01', '2017-10-31', '1,D'),
         lat=[45., 66., 30], lon=[-80., -70., 40],
         order=['time', 'lat', 'lon'])
 
-    coords_spatial = Coordinate(
+    coords_spatial = podpac.coordinate(
         lat=[45., 66., 30], lon=[-80., -70., 40],
         order=['lat', 'lon'])
     
-    coords_time = Coordinate(
+    coords_time = podpac.coordinate(
         time=('2017-09-01', '2017-10-31', '1,D'),
         order=['time'])
 

--- a/podpac/core/algorithm/stats.py
+++ b/podpac/core/algorithm/stats.py
@@ -5,6 +5,7 @@ Stats Summary
 from __future__ import division, unicode_literals, print_function, absolute_import
 
 import warnings
+from collections import OrderedDict
 from operator import mul
 from functools import reduce
 
@@ -13,7 +14,7 @@ import numpy as np
 import scipy.stats
 import traitlets as tl
 
-from podpac.core.coordinate import Coordinate
+from podpac.core.coordinate import coordinate, Coordinate
 from podpac.core.node import Node
 from podpac.core.algorithm.algorithm import Algorithm
 
@@ -122,21 +123,13 @@ class Reduce(Algorithm):
         TYPE
             Description
         """
-        coordinates = self.input_coordinates
-        dims = self.dims
-        kwargs = {}
-        order = []
-        for dim in coordinates.dims:
+        
+        coords = OrderedDict()
+        for dim in self.input_coordinates.dims:
             if dim in self.dims:
                 continue
-            
-            kwargs[dim] = coordinates[dim]
-            order.append(dim)
-        
-        if order:
-            kwargs['order'] = order
-
-        return Coordinate(**kwargs)
+            coord[dim] = self.input_coordinates[dim]
+        return Coordinate(coords, **self.input_coordinates.kwargs)
 
     @property
     def chunk_size(self):
@@ -1015,7 +1008,7 @@ class GroupReduce(Algorithm):
         native_time_mask = np.in1d(N, E)
 
         # use requested spatial coordinates and filtered native times
-        coords = Coordinate(
+        coords = coordinate(
             time=native_time.data[native_time_mask],
             lat=self.evaluated_coordinates['lat'],
             lon=self.evaluated_coordinates['lon'],
@@ -1108,7 +1101,7 @@ if __name__ == '__main__':
     # smap = SMAP(product='SPL4SMAU.003')
     # coords = smap.native_coordinates
     
-    # coords = Coordinate(
+    # coords = coordinate(
     #     time=coords.coords['time'][:6],
     #     lat=[45., 66., 5], lon=[-80., -70., 4],
     #     order=['time', 'lat', 'lon'])
@@ -1200,7 +1193,7 @@ if __name__ == '__main__':
     # Grouping
     # =========================================================================
 
-    # coords = Coordinate(
+    # coords = coordinate(
     #     time=np.array(map(np.datetime64, ['2017-10-01', '2017-10-02', '2017-10-03', '2015-10-03'])),
     #     lat=[45., 66., 5], lon=[-80., -70., 4],
     #     order=['time', 'lat', 'lon'])

--- a/podpac/core/algorithm/test/test_algorithm.py
+++ b/podpac/core/algorithm/test/test_algorithm.py
@@ -6,7 +6,7 @@ from pint.errors import DimensionalityError
 from pint import UnitRegistry
 ureg = UnitRegistry()
 
-from podpac.core.coordinate import Coordinate
+import podpac
 from podpac.core.algorithm.algorithm import Algorithm, SinCoords, Arithmetic
 
 class TestAlgorithm(object):
@@ -15,7 +15,7 @@ class TestAlgorithm(object):
         
     def TestSinCoords(self):
         a = SinCoords()
-        coords = Coordinate(lat=[-90, 90, 1.], lon=[0, 360, 2.])
+        coords = podpac.coordinate(lat=[-90, 90, 1.], lon=[0, 360, 2.])
         o = a.execute(coords)
         
     

--- a/podpac/core/authentication.py
+++ b/podpac/core/authentication.py
@@ -21,7 +21,7 @@ try:
 except:
     class Dum(object):
         def __init__(self, *args, **kwargs):
-            pass
+            raise RuntimeError("requests package required; please install requests to use this feature")
     requests = Dum()
     requests.Session = Dum
 

--- a/podpac/core/compositor.py
+++ b/podpac/core/compositor.py
@@ -10,7 +10,7 @@ import numpy as np
 import traitlets as tl
 
 # Internal imports
-from podpac.core.coordinate import Coordinate
+from podpac.core.coordinate import Coordinate, coordinate
 from podpac.core.node import Node
 
 class Compositor(Node):
@@ -157,13 +157,12 @@ class Compositor(Node):
         # WARNING: this assumes
         #              native_coords = source_coords + shared_coordinates
         #         NOT  native_coords = shared_coords + source_coords
-        if self.is_source_coordinates_complete \
-                and len(self.source_coordinates.shape) == 1:
-            coords_subset = list(self.source_coordinates.intersect(coordinates,
-                    pad=1).coords.values())[0]
+        if self.is_source_coordinates_complete and len(self.source_coordinates.shape) == 1:
+            coords_subset = list(self.source_coordinates.intersect(coordinates, pad=1).coords.values())[0]
             coords_dim = list(self.source_coordinates.dims)[0]
             for s, c in zip(src_subset, coords_subset):
-                nc = Coordinate(**{coords_dim: c}) + self.shared_coordinates
+                # TODO convert this to direct Coordinate()
+                nc = coordinate(**{coords_dim: c}) + self.shared_coordinates
                 # Switching from _trait_values to hasattr because "native_coordinates"
                 # sometimes not showing up in _trait_values in other locations
                 # Not confirmed here

--- a/podpac/core/coordinate/__init__.py
+++ b/podpac/core/coordinate/__init__.py
@@ -13,3 +13,4 @@ from podpac.core.coordinate.coordinate import BaseCoordinate
 from podpac.core.coordinate.coordinate import Coordinate
 from podpac.core.coordinate.coordinate import CoordinateGroup
 from podpac.core.coordinate.coordinate import convert_xarray_to_podpac
+from podpac.core.coordinate.coordinate import coordinate

--- a/podpac/core/coordinate/coord.py
+++ b/podpac/core/coordinate/coord.py
@@ -1316,7 +1316,7 @@ def coord_linspace(start, stop, num, **kwargs):
         Description
     """
 
-    if not isinstance(num, (int, np.long, np.integer)):
+    if not isinstance(num, (int, np.long, np.integer)) or isinstance(num, np.timedelta64):
         raise TypeError("num must be an integer, not '%s'" % type(num))
     start = make_coord_value(start)
     stop = make_coord_value(stop)

--- a/podpac/core/coordinate/coord.py
+++ b/podpac/core/coordinate/coord.py
@@ -86,7 +86,7 @@ class BaseCoord(tl.HasTraits):
              "coordinate. If segment=0.5, then the coordinate is specified at "
              "the center of this line segement.")
     
-    extents = tl.Any(allow_none=True, default_value=None, 
+    extents = tl.Any(allow_none=True, default_value=None,
         help="Custom bounding box of the grid when ctype='segment'. Useful "
              "when specifying non-uniform segment coordinates")
     
@@ -210,7 +210,7 @@ class BaseCoord(tl.HasTraits):
             d = np.abs(self.delta)
             return [add_coord(b[0], -p * d), add_coord(b[1], (1-p) * d)]
 
-    _cached_bounds = tl.Instance(np.ndarray, allow_none=True)    
+    _cached_bounds = tl.Instance(np.ndarray, allow_none=True)
     @property
     def bounds(self):
         '''
@@ -272,7 +272,7 @@ class BaseCoord(tl.HasTraits):
     @property
     def is_descending(self):
         '''
-        True if the coordinates are monotonically descending, False if 
+        True if the coordinates are monotonically descending, False if
         monotonically ascending, and None for non-monotonic coordinates.
         
         Raises
@@ -716,7 +716,7 @@ class Coord(BaseCoord):
 
     @property
     def rasterio_regularity(self):
-        """True if size is 1, else False 
+        """True if size is 1, else False
         
         Returns
         -------
@@ -728,7 +728,7 @@ class Coord(BaseCoord):
 
     @property
     def scipy_regularity(self):
-        """True 
+        """True
         
         Returns
         -------
@@ -899,14 +899,14 @@ class MonotonicCoord(Coord):
                     coords = np.concatenate(concat_list)
                 elif concat_list[1][-1] > concat_list[0][0]: # need to reverse
                     coords = np.concatenate(concat_list[::-1])
-                else: 
+                else:
                     overlap = True
             else:
                 if concat_list[0][-1] < concat_list[1][0]: # then we're good!
                     coords = np.concatenate(concat_list)
                 elif concat_list[1][-1] < concat_list[0][0]: # need to reverse
                     coords = np.concatenate(concat_list[::-1])
-                else: 
+                else:
                     overlap = True
                 
             if not overlap:
@@ -1139,7 +1139,7 @@ class UniformCoord(BaseCoord):
 
     @property
     def rasterio_regularity(self):
-        """True 
+        """True
         
         Returns
         -------
@@ -1151,7 +1151,7 @@ class UniformCoord(BaseCoord):
 
     @property
     def scipy_regularity(self):
-        """True 
+        """True
         
         Returns
         -------

--- a/podpac/core/coordinate/coordinate.py
+++ b/podpac/core/coordinate/coordinate.py
@@ -12,10 +12,10 @@ from __future__ import division, unicode_literals, print_function, absolute_impo
 import copy
 import sys
 import itertools
+from collections import OrderedDict
 
 import numpy as np
 import traitlets as tl
-from collections import OrderedDict
 from xarray.core.coordinates import DataArrayCoordinates
 
 from podpac.core.coordinate.coord import BaseCoord, Coord, MonotonicCoord, UniformCoord, coord_linspace

--- a/podpac/core/coordinate/coordinate.py
+++ b/podpac/core/coordinate/coordinate.py
@@ -765,7 +765,6 @@ class CoordinateGroup(BaseCoordinate):
 # helper functions
 # =============================================================================
 
-# JXM TODO is this used outside of this module?
 def stack_coords(coords, dims_map):
     """
     Stack the coordinates according to the given dims_map.

--- a/podpac/core/coordinate/coordinate.py
+++ b/podpac/core/coordinate/coordinate.py
@@ -13,6 +13,7 @@ import copy
 import sys
 import itertools
 from collections import OrderedDict
+import warnings
 
 import numpy as np
 import traitlets as tl
@@ -208,7 +209,7 @@ class Coordinate(BaseCoordinate):
     def delta(self):
         """ used in interpolation, to be deprecated """
 
-        warnings.warning("delta will be removed before v0.0.1", DeprecationWarning)
+        warnings.warn("delta will be removed before v0.0.1", DeprecationWarning)
 
         try:
             return np.array([c.delta for c in self._coords.values()]).squeeze()

--- a/podpac/core/coordinate/coordinate.py
+++ b/podpac/core/coordinate/coordinate.py
@@ -47,7 +47,7 @@ class BaseCoordinate(tl.HasTraits):
 
 class Coordinate(BaseCoordinate):
     """
-    Multidimensional Coordinates.    
+    Multidimensional Coordinates.
 
     Attributes
     ----------
@@ -480,7 +480,7 @@ class Coordinate(BaseCoordinate):
                 unstacked_dims += _unstack_dims(self.dims_map[arg])
 
         if unstacked_dims:
-            self.drop_dims(*unstacked_dims) 
+            self.drop_dims(*unstacked_dims)
     
     def add_unique(self, other):
         """
@@ -675,7 +675,7 @@ class CoordinateGroup(BaseCoordinate):
         else:
             for c in self._items:
                 c.unstack(stack_dims)
-            return self            
+            return self
 
     def intersect(self, other, coord_ref_sys=None, pad=1, ind=False):
         return CoordinateGroup([c.intersect(other) for c in self._items])
@@ -939,7 +939,7 @@ def coordinate(order=None, coord_ref_sys="WGS84", segment_position=0.5, ctype='s
 # TODO convert to unit testing
 # =============================================================================
 
-if __name__ == '__main__': 
+if __name__ == '__main__':
     
     coord = coord_linspace(1, 10, 10)
     coord_cent = coord_linspace(4, 7, 4)
@@ -992,13 +992,13 @@ if __name__ == '__main__':
     # print (c.replace_coords(c2))
     # print (c.replace_coords(c2.unstack()))
     # print (c.unstack().replace_coords(c2))
-    # print (c.unstack().replace_coords(c2.unstack()))  
+    # print (c.unstack().replace_coords(c2.unstack()))
     
     # c = UniformCoord(1, 10, 2)
     # np.testing.assert_equal(c.coordinates, np.arange(1., 10, 2))
     
     # c = UniformCoord(10, 1, -2)
-    # np.testing.assert_equal(c.coordinates, np.arange(10., 1, -2))    
+    # np.testing.assert_equal(c.coordinates, np.arange(10., 1, -2))
 
     # try:
     #     c = UniformCoord(10, 1, 2)

--- a/podpac/core/coordinate/coordinate.py
+++ b/podpac/core/coordinate/coordinate.py
@@ -767,7 +767,10 @@ def stack_coords(coords, dims_map):
 
     # make stacked coords dict
     stacked_coords = OrderedDict()
-    for key in set(dims_map.values()):
+    for key in dims_map.values():
+        if key in stacked_coords:
+            continue
+
         if key in dims_map:
             stacked_coords[key] = coords[key]
 

--- a/podpac/core/coordinate/coordinate.py
+++ b/podpac/core/coordinate/coordinate.py
@@ -772,13 +772,12 @@ def stack_coords(coords, dims_map):
             stacked_coords[key] = coords[key]
 
         else:
-
             cs = [coords[dim] for dim in _unstack_dims(key)]
             
             # validate stacked dimensions sizes
             sizes = [c.size for c in cs]
             if any(size != sizes[0] for size in sizes):
-                raise ValueError("Stacked dimensions size mismatch in '%s' (%s must all match)" % (dim, sizes))
+                raise ValueError("Stacked dimensions size mismatch in '%s' (%s must all match)" % (key, sizes))
                 
             stacked_coords[key] = cs
 

--- a/podpac/core/coordinate/coordinate.py
+++ b/podpac/core/coordinate/coordinate.py
@@ -84,8 +84,7 @@ class Coordinate(BaseCoordinate):
     _coords = tl.Instance(OrderedDict)
     dims_map = tl.Dict()
 
-    def __init__(self, coords=None, order=None, coord_ref_sys="WGS84",
-                 segment_position=0.5, ctype='segment', **kwargs):
+    def __init__(self, coords=None, order=None, coord_ref_sys="WGS84", segment_position=0.5, ctype='segment', **kwargs):
         """
         Initialize a multidimensional coords object.
 
@@ -140,9 +139,7 @@ class Coordinate(BaseCoordinate):
             if sys.version < '3.6':
                 if order is None:
                     if len(kwargs) > 1:
-                        raise TypeError(
-                            "Need to specify the order of the coordinates "
-                            "using 'order'.")
+                        raise TypeError("Need to specify the order of the using 'order'.")
                     else:
                         order = kwargs.keys()
                 
@@ -159,8 +156,7 @@ class Coordinate(BaseCoordinate):
             else:
                 coords = OrderedDict(kwargs)
         elif not isinstance(coords, OrderedDict):
-            raise TypeError(
-                "coords must be an OrderedDict, not %s" % type(coords))
+            raise TypeError("coords must be an OrderedDict, not %s" % type(coords))
 
         self.dims_map = self.get_dims_map(coords)
         _coords = self.unstack_dict(coords)
@@ -176,8 +172,7 @@ class Coordinate(BaseCoordinate):
 
             # make coord helper
             if isinstance(val, tuple):
-                if (isinstance(val[2], (int, np.long, np.integer)) and
-                    not isinstance(val[2], (np.timedelta64))):
+                if isinstance(val[2], (int, np.long, np.integer)) and not isinstance(val[2], (np.timedelta64)):
                     _coords[key] = coord_linspace(*val, **kw)
                 else:
                     _coords[key] = UniformCoord(*val, **kw)
@@ -225,16 +220,13 @@ class Coordinate(BaseCoordinate):
                 if self.dims_map[key] not in stack_dims:
                     stack_dims[self.dims_map[key]] = val.size
                 elif val.size != stack_dims[self.dims_map[key]]:
-                    raise ValueError(
-                        "Stacked dimensions size mismatch for '%s' in '%s' "
-                        "(%d != %d)" % (key, self.dims_map[key], val.size,
-                                        stack_dims[self.dims_map[key]]))
+                    raise ValueError("Stacked dimensions size mismatch for '%s' in '%s'(%d != %d)" % (
+                        key, self.dims_map[key], val.size, stack_dims[self.dims_map[key]]))
         return proposal['value']
         
     def _validate_dim(self, dim, seen_dims):
         if dim not in self._valid_dims:
-            raise ValueError("Invalid dimension '%s', expected one of %s" % (
-                dim, self._valid_dims))
+            raise ValueError("Invalid dimension '%s', expected one of %s" % (dim, self._valid_dims))
         if dim in seen_dims:
             raise ValueError("The dimension '%s' cannot be repeated." % dim)
         seen_dims.append(dim)
@@ -311,21 +303,18 @@ class Coordinate(BaseCoordinate):
                     if isinstance(val[i], tuple):
                         if len(val) != len(keys) + 1:
                             raise ValueError("missing size for stacked uniform coordinates")
-                        if (not isinstance(val[-1], (int, np.long, np.integer)) or
-                            isinstance(val[-1], (np.timedelta64))):
+                        if not isinstance(val[-1], (int, np.long, np.integer)) or isinstance(val[-1], np.timedelta64):
                             raise TypeError("invalid size for stacked uniform coordinates \
                                              (expected integer, not '%s')" % type(val[-1]))
                         new_crds[k] += (val[-1],)
                     
                     if check_dim_repeat and k in seen_dims:
-                        raise ValueError(
-                            "The dimension '%s' cannot be repeated." % dim)
+                        raise ValueError("The dimension '%s' cannot be repeated." % dim)
                     seen_dims.append(k)
             else:
                 new_crds[key] = val
                 if check_dim_repeat and key in seen_dims:
-                    raise ValueError(
-                        "The dimension '%s' cannot be repeated." % key)
+                    raise ValueError("The dimension '%s' cannot be repeated." % key)
                 seen_dims.append(key)
 
         return new_crds
@@ -483,19 +472,18 @@ class Coordinate(BaseCoordinate):
                     d[dim] = self._coords[dim]
                 continue
             
-            intersect = self._coords[dim].intersect(
-                other._coords[dim], coord_ref_sys, ind=ind or self.is_stacked,
-                pad=spad)
+            ind
+            intersect = self._coords[dim].intersect(other._coords[dim], coord_ref_sys, ind=ind or self.is_stacked, pad=spad)
             
             if ind or self.is_stacked:
                 I.append(intersect)
             else:
                 d[dim] = intersect
         
+        if ind and not self.is_stacked:
+            return I
+        
         if ind or self.is_stacked:
-            if not self.is_stacked:
-                return I
-
             # Need to handle the stacking
             I2 = [np.ones(s, bool) for s in self.shape]
             for i, d in enumerate(self.dims):
@@ -533,10 +521,10 @@ class Coordinate(BaseCoordinate):
         '''
 
         return {
-                'coord_ref_sys': self.coord_ref_sys,
-                'segment_position': self.segment_position,
-                'ctype': self.ctype
-                }
+            'coord_ref_sys': self.coord_ref_sys,
+            'segment_position': self.segment_position,
+            'ctype': self.ctype
+            }
     
     def replace_coords(self, other, copy=True):
         '''
@@ -662,8 +650,7 @@ class Coordinate(BaseCoordinate):
         try:
             return np.array([c.delta for c in self._coords.values()]).squeeze()
         except ValueError as e:
-            return np.array([c.delta for c in self._coords.values()], 
-                    object).squeeze()
+            return np.array([c.delta for c in self._coords.values()], object).squeeze()
     
     @property
     def dims(self):
@@ -696,30 +683,24 @@ class Coordinate(BaseCoordinate):
             if k in self.dims_map:  # not stacked
                 crds[k] = self._coords[k].coordinates
             else:
-                coordinates = [self._coords[kk].coordinates
-                               for kk in k.split('_')]
-                dtype = [(str(kk), coordinates[i].dtype) 
-                         for i, kk in enumerate(k.split('_'))]
+                coordinates = [self._coords[kk].coordinates for kk in k.split('_')]
+                dtype = [(str(kk), coordinates[i].dtype) for i, kk in enumerate(k.split('_'))]
                 n_coords = len(coordinates)
                 s_coords = len(coordinates[0])
-                crds[k] = np.array([[tuple([coordinates[j][i]
-                                     for j in range(n_coords)])]
-                                   for i in range(s_coords)],
-                    dtype=dtype).squeeze()
+                c = [[tuple([coordinates[j][i] for j in range(n_coords)])] for i in range(s_coords)]
+                crds[k] = np.array(c, dtype=dtype).squeeze()
         return crds
     
-    #@property
-    #def gdal_transform(self):
-        #if self['lon'].regularity == 'regular' \
-               #and self['lat'].regularity == 'regular':
-            #lon_bounds = self['lon'].area_bounds
-            #lat_bounds = self['lat'].area_bounds
+    # @property
+    # def gdal_transform(self):
+    #     if self['lon'].regularity == 'regular' and self['lat'].regularity == 'regular':
+    #         lon_bounds = self['lon'].area_bounds
+    #         lat_bounds = self['lat'].area_bounds
         
-            #transform = [lon_bounds[0], self['lon'].delta, 0,
-                         #lat_bounds[0], 0, -self['lat'].delta]
-        #else:
-            #raise NotImplementedError
-        #return transform
+    #         transform = [lon_bounds[0], self['lon'].delta, 0, lat_bounds[0], 0, -self['lat'].delta]
+    #     else:
+    #         raise NotImplementedError
+    #     return transform
     
     @property
     def gdal_crs(self):
@@ -731,8 +712,7 @@ class Coordinate(BaseCoordinate):
             Description
         """
 
-        crs = {'WGS84': 'EPSG:4326',
-               'SPHER_MERC': 'EPSG:3857'}
+        crs = {'WGS84': 'EPSG:4326', 'SPHER_MERC': 'EPSG:3857'}
         return crs[self.coord_ref_sys.upper()]
     
     def add_unique(self, other):
@@ -771,20 +751,15 @@ class Coordinate(BaseCoordinate):
     
     def _add(self, other, unique=False):
         if not isinstance(other, Coordinate):
-            raise TypeError(
-                "Unsupported type '%s', can only add Coordinate object" % (
-                    other.__class__.__name__))
+            raise TypeError("Unsupported type '%s', can only add Coordinate object" % (other.__class__.__name__))
         new_coords = copy.deepcopy(self._coords)
         dims_map = self.dims_map
         for key in other._coords:
             if key in self._coords:
                 if dims_map[key] != other.dims_map[key]:
-                    raise ValueError(
-                        "Cannot add coordinates with different stacking. "
-                        "%s != %s." % (dims_map[key], other.dims_map[key])
-                    )
-                if np.all(np.array(self._coords[key].coords) !=
-                        np.array(other._coords[key].coords)) or not unique:
+                    raise ValueError("Cannot add coordinates with different stacking. %s != %s." % (
+                        dims_map[key], other.dims_map[key]))
+                if np.all(np.array(self._coords[key].coords) != np.array(other._coords[key].coords)) or not unique:
                     new_coords[key] = self._coords[key] + other._coords[key]
             else:
                 dims_map[key] = other.dims_map[key]
@@ -813,10 +788,7 @@ class Coordinate(BaseCoordinate):
         # TODO assumes the input shape dimension and order matches
         # TODO replace self[k].coords[slc] with self[k][slc] (and implement the slice)
 
-        slices = [
-            map(lambda i: slice(i, i+n), range(0, m, n))
-            for m, n
-            in zip(self.shape, shape)]
+        slices = [map(lambda i: slice(i, i+n), range(0, m, n)) for m, n in zip(self.shape, shape)]
 
         for l in itertools.product(*slices):
             kwargs = {k:self.coords[k][slc] for k, slc in zip(self.dims, l)}
@@ -873,8 +845,7 @@ class Coordinate(BaseCoordinate):
                 self['lat'].bounds[0],
                 self['lon'].bounds[0],
                 self['lat'].bounds[1],
-                self['lon'].bounds[1]
-            )
+                self['lon'].bounds[1])
         else:
             return 'NA'
 
@@ -895,8 +866,7 @@ class CoordinateGroup(BaseCoordinate):
         dims = set(items[0].dims_map)
         for g in items:
             if set(g.dims_map) != dims:
-                raise ValueError(
-                    "Mismatching dims: '%s != %s" % (dims, set(g.dims)))
+                raise ValueError("Mismatching dims: '%s != %s" % (dims, set(g.dims)))
 
         return items
 
@@ -921,8 +891,7 @@ class CoordinateGroup(BaseCoordinate):
             return [item[dim] for item in self._items[k]]
         
         else:
-            raise IndexError(
-                "invalid CoordinateGroup index type '%s'" % type(key))
+            raise IndexError("invalid CoordinateGroup index type '%s'" % type(key))
 
     def __len__(self):
         return len(self._items)
@@ -932,8 +901,7 @@ class CoordinateGroup(BaseCoordinate):
 
     def append(self, c):
         if not isinstance(c, Coordinate):
-            raise TypeError(
-                "Can only append Coordinate objects, not '%s'" % type(c))
+            raise TypeError("Can only append Coordinate objects, not '%s'" % type(c))
         
         self._items.append(c)
    
@@ -941,8 +909,7 @@ class CoordinateGroup(BaseCoordinate):
         """ stack all """
 
         if copy:
-            return CoordinateGroup(
-                [c.stack(stack_dims, copy=True) for c in self._items])
+            return CoordinateGroup([c.stack(stack_dims, copy=True) for c in self._items])
         else:
             for c in self._items:
                 c.stack(stack_dims)
@@ -951,8 +918,7 @@ class CoordinateGroup(BaseCoordinate):
     def unstack(self, copy=True):
         """ unstack all"""
         if copy:
-            return CoordinateGroup(
-                [c.unstack(stack_dims, copy=True) for c in self._items])
+            return CoordinateGroup([c.unstack(stack_dims, copy=True) for c in self._items])
         else:
             for c in self._items:
                 c.unstack(stack_dims)

--- a/podpac/core/coordinate/test/test_coordinate.py
+++ b/podpac/core/coordinate/test/test_coordinate.py
@@ -7,8 +7,8 @@ import traitlets as tl
 import numpy as np
 from six import string_types
 
-from podpac.core.coordinate import Coordinate, CoordinateGroup
-from podpac.core.coordinate import BaseCoordinate, Coord
+from podpac.core.coordinate import Coordinate, CoordinateGroup, coordinate
+from podpac.core.coordinate import BaseCoordinate, Coord, coord_linspace
 
 def allclose_structured(a, b):
     return all(np.allclose(a[name], b) for name in a.dtype.names)
@@ -27,302 +27,162 @@ class TestBaseCoordinate(object):
             c.intersect(c)
 
 class TestCoordinate(object):
-    @pytest.mark.skipif(sys.version >= '3.6', reason="Python <3.6 compatibility")
-    def test_order(self):
-        # required
-        with pytest.raises(TypeError):
-            Coordinate(lat=0.25, lon=0.3)
-
-        # not required
-        Coordinate(lat=0.25)
-        
-        # not required
-        Coordinate(coords=OrderedDict(lat=0.25, lon=0.3))
-
-        # invalid
-        with pytest.raises(ValueError):
-            Coordinate(lon=0.3, lat=0.25, order=['lat', 'lon', 'time'])
-
-        # invalid
-        with pytest.raises(ValueError):
-            Coordinate(lon=0.3, lat=0.25, order=['lat'])
-
-        # valid
-        c = Coordinate(lon=0.3, lat=0.25, order=['lat', 'lon'])
-        assert c.dims == ['lat', 'lon']
-        
-        c = Coordinate(lon=0.3, lat=0.25, order=['lon', 'lat'])
-        assert c.dims == ['lon', 'lat']
-
-    @pytest.mark.skipif(sys.version < '3.6', reason="Python >=3.6 required")
-    def test_order_detect(self):
-        coord = Coordinate(lat=0.25, lon=0.3)
-        assert coord.dims == ['lat', 'lon']
-
-        coord = Coordinate(lon=0.3, lat=0.25)
-        assert coord.dims == ['lon', 'lat']
-
-        # in fact, ignore order
-        coord = Coordinate(lon=0.3, lat=0.25, order=['lat', 'lon'])
-        assert coord.dims == ['lon', 'lat']
-
     def _common_checks(self, coord, expected_dims, expected_shape, stacked):
-        # note: check stacked dims_map manually
-
         assert coord.dims == expected_dims
         assert coord.shape == expected_shape
         assert coord.is_stacked == stacked
-        
-        # dims map and coords
         assert isinstance(coord.dims_map, dict)
         assert isinstance(coord.coords, OrderedDict)
-        for dim in expected_dims:
-            if not coord.is_stacked:
-                assert coord.dims_map[dim] == dim
-            assert isinstance(coord.coords[dim], np.ndarray)
 
         # additional properties
-        assert isinstance(coord.kwargs, dict)
         assert isinstance(coord.latlon_bounds_str, string_types)
+        assert isinstance(repr(coord), string_types)
+
+    def _unstacked_checks(self, coord, expected_dims, expected_coords):
+        for dim, c in zip(expected_dims, expected_coords):
+            assert coord.dims_map[dim] == dim
+            assert coord[dim] is c
+            assert isinstance(coord.coords[dim], np.ndarray)
+            if c.is_datetime:
+                np.testing.assert_array_equal(coord.coords[dim], c.coordinates)
+            else:
+                np.testing.assert_allclose(coord.coords[dim], c.coordinates)
+
+    def _stacked_checks(self, coord, key, expected_dims, expected_coords):
+        for dim, c in zip(expected_dims, expected_coords):
+            assert coord.dims_map[dim] == key
+            coord[dim] is c
+            assert isinstance(coord.coords[key][dim], np.ndarray)
+            if c.is_datetime:
+                np.testing.assert_array_equal(coord.coords[key][dim], c.coordinates)
+            else:
+                np.testing.assert_allclose(coord.coords[key][dim], c.coordinates)
 
     def test_coords_empty(self):
         coord = Coordinate()
         
+        assert coord.dims == []
+        assert coord.shape == ()
+        assert coord.is_stacked == False
+        assert isinstance(coord.dims_map, dict)
+
         self._common_checks(coord, [], (), False)
         assert len(coord.dims_map.keys()) == 0
         assert len(coord.coords.keys()) == 0
 
-    def test_coords_single_latlon(self):
-        coord = Coordinate(lat=0.25, lon=0.3, order=['lat', 'lon'])
-        
-        self._common_checks(coord, ['lat', 'lon'], (1, 1), False)
-        np.testing.assert_allclose(coord.coords['lat'], [0.25])
-        np.testing.assert_allclose(coord.coords['lon'], [0.3])
+    def test_coords_single(self):
+        lat = coord_linspace(0, 5, 10)
 
-    def test_coords_single_datetime(self):
-        coord = Coordinate(time='2018-01-01')
+        d = OrderedDict()
+        d['lat'] = lat
+        coord = Coordinate(d)
 
-        self._common_checks(coord, ['time'], (1,), False)
-        np.testing.assert_array_equal(coord.coords['time'], np.datetime64('2018-01-01'))
+        self._common_checks(coord, ['lat'], (10,), False)
+        self._unstacked_checks(coord, ['lat'], [lat])
 
-    def test_coords_single_time_dependent(self):
-        coord = Coordinate(lat=0.25, lon=0.3, time='2018-01-01', order=['lat', 'lon', 'time'])
-        
-        self._common_checks(coord, ['lat', 'lon', 'time'], (1, 1, 1), False)
-        np.testing.assert_allclose(coord.coords['lat'], [0.25])
-        np.testing.assert_allclose(coord.coords['lon'], [0.3])
-        np.testing.assert_array_equal(coord.coords['time'], np.datetime64('2018-01-01'))
+    def test_coords_unstacked(self):
+        lat = coord_linspace(0, 5, 10)
+        lon = coord_linspace(10, 20, 100)
+        time = coord_linspace('2018-01-01', '2018-01-05', 5)
 
-    def test_coords_single_latlon_stacked(self):
-        coord = Coordinate(lat_lon=[0.25, 0.3])
-        
-        self._common_checks(coord, ['lat_lon'], (1,), True)
-        assert coord.dims_map['lat'] == 'lat_lon'
-        assert coord.dims_map['lon'] == 'lat_lon'
-        np.testing.assert_allclose(coord.coords['lat_lon']['lat'], [0.25])
-        np.testing.assert_allclose(coord.coords['lat_lon']['lon'], [0.3])
+        d = OrderedDict()
+        d['lat'] = lat
+        d['lon'] = lon
+        d['time'] = time
+        coord = Coordinate(d)
 
-    def test_coords_single_time_dependent_stacked(self):
-        coord = Coordinate(lat_lon=[0.25, 0.3], time='2018-01-01', order=['lat_lon', 'time'])
-        
-        self._common_checks(coord, ['lat_lon', 'time'], (1, 1), True)
-        assert coord.dims_map['lat'] == 'lat_lon'
-        assert coord.dims_map['lon'] == 'lat_lon'
-        assert coord.dims_map['time'] == 'time'
-        np.testing.assert_allclose(coord.coords['lat_lon']['lat'], [0.25])
-        np.testing.assert_allclose(coord.coords['lat_lon']['lon'], [0.3])
-        np.testing.assert_array_equal(coord.coords['time'], np.datetime64('2018-01-01'))
+        self._common_checks(coord, ['lat', 'lon', 'time'], (10, 100, 5), False)
+        self._unstacked_checks(coord, ['lat', 'lon', 'time'], [lat, lon, time])
 
-    def test_coords_latlon_coord(self):
-        coord = Coordinate(lat=[0.2, 0.4, 0.5], lon=[0.3, -0.1], order=['lat', 'lon'])
-        
-        self._common_checks(coord, ['lat', 'lon'], (3, 2), False)
-        np.testing.assert_allclose(coord.coords['lat'], [0.2, 0.4, 0.5])
-        np.testing.assert_allclose(coord.coords['lon'], [0.3, -0.1])
+    def test_coords_stacked(self):
+        lat = coord_linspace(0, 5, 5)
+        lon = coord_linspace(10, 20, 5)
+        time = coord_linspace('2018-01-01', '2018-01-05', 5)
 
-    def test_coords_latlon_coord_stacked(self):
-        coord = Coordinate(lat_lon=[[0.2, 0.4, 0.5], [0.3, -0.1, 0.2]])
-        
-        self._common_checks(coord, ['lat_lon'], (3,), True)
-        assert coord.dims_map['lat'] == 'lat_lon'
-        assert coord.dims_map['lon'] == 'lat_lon'
-        np.testing.assert_allclose(coord.coords['lat_lon']['lat'], [0.2, 0.4, 0.5])
-        np.testing.assert_allclose(coord.coords['lat_lon']['lon'], [0.3, -0.1, 0.2])
+        d = OrderedDict()
+        d['lat_lon_time'] = (lat, lon, time)
+        coord = Coordinate(d)
 
-        # length must match
+        self._common_checks(coord, ['lat_lon_time'], (5,), True)
+        self._stacked_checks(coord, 'lat_lon_time', ['lat', 'lon', 'time'], [lat, lon, time])
+
+    def test_coords_stacked_partial(self):
+        lat = coord_linspace(0, 5, 15)
+        lon = coord_linspace(10, 20, 15)
+        time = coord_linspace('2018-01-01', '2018-01-05', 5)
+
+        d = OrderedDict()
+        d['lat_lon'] = (lat, lon)
+        d['time'] = time
+        coord = Coordinate(d)
+
+        self._common_checks(coord, ['lat_lon', 'time'], (15, 5,), True)
+        self._stacked_checks(coord, 'lat_lon', ['lat', 'lon'], [lat, lon])
+        self._unstacked_checks(coord, ['time'], [time])
+
+    @pytest.mark.skipif(sys.version >= '3.6', reason="Python <3.6 compatibility")
+    def test_coords_invalid_ordereddict(self):
+        # invalid type (must be OrderedDict)
+        with pytest.raises(TypeError):
+            Coordinate({})
+
+    def test_coords_invalid(self):
+        # invalid type (must be dict)
+        with pytest.raises(TypeError):
+            Coordinate([])
+
+    def test_coords_stacked_invalid(self):
+        lat = coord_linspace(0, 5, 5)
+        lon = coord_linspace(10, 20, 5)
+        time = coord_linspace('2018-01-01', '2018-01-05', 5)
+
+        # invalid stacking
+        d = OrderedDict()
+        d['lat_lon'] = (lat, lon, time)
         with pytest.raises(ValueError):
-            Coordinate(lat_lon=[[0.2, 0.4, 0.5], [0.3, -0.1]])
+            Coordinate(d)
 
-    def test_coords_datetime_coord(self):
-        coord = Coordinate(time=['2018-01-01', '2018-01-02', '2018-02-01'])
-
-        self._common_checks(coord, ['time'], (3,), False)
-        np.testing.assert_array_equal(
-            coord.coords['time'],
-            np.array(['2018-01-01', '2018-01-02', '2018-02-01']).astype(np.datetime64))
-
-    def test_coords_time_dependent_coord_stacked(self):
-        coord = Coordinate(
-            lat_lon=[[0.2, 0.4, 0.5], [0.3, -0.1, 0.2]],
-            time=['2018-01-01', '2018-01-02', '2018-02-01'],
-            order=['lat_lon', 'time'])
-        
-        self._common_checks(coord, ['lat_lon', 'time'], (3, 3), True)
-        assert coord.dims_map['lat'] == 'lat_lon'
-        assert coord.dims_map['lon'] == 'lat_lon'
-        assert coord.dims_map['time'] == 'time'
-        np.testing.assert_allclose(coord.coords['lat_lon']['lat'], [0.2, 0.4, 0.5])
-        np.testing.assert_allclose(coord.coords['lat_lon']['lon'], [0.3, -0.1, 0.2])
-        np.testing.assert_array_equal(
-            coord.coords['time'],
-            np.array(['2018-01-01', '2018-01-02', '2018-02-01']).astype(np.datetime64))
-
-    def test_coords_latlon_uniform_num(self):
-        coord = Coordinate(lat=(0.1, 0.4, 4), lon=(-0.3, -0.1, 3), order=['lat', 'lon'])
-        
-        self._common_checks(coord, ['lat', 'lon'], (4, 3), False)
-        np.testing.assert_allclose(coord.coords['lat'], [0.1, 0.2, 0.3, 0.4])
-        np.testing.assert_allclose(coord.coords['lon'], [-0.3, -0.2, -0.1])
-        
-    def test_coords_latlon_uniform_step(self):
-        coord = Coordinate(lat=(0.1, 0.4, 0.1), lon=(-0.3, -0.1, 0.1), order=['lat', 'lon'])
-        
-        self._common_checks(coord, ['lat', 'lon'], (4, 3), False)
-        np.testing.assert_allclose(coord.coords['lat'], [0.1, 0.2, 0.3, 0.4])
-        np.testing.assert_allclose(coord.coords['lon'], [-0.3, -0.2, -0.1])
-
-    def test_coords_latlon_uniform_stacked(self):
-        coord = Coordinate(lat_lon=[(0.1, 0.4), (-0.3, -0.0), 4])
-        
-        self._common_checks(coord, ['lat_lon'], (4,), True)
-        assert coord.dims_map['lat'] == 'lat_lon'
-        assert coord.dims_map['lon'] == 'lat_lon'
-        np.testing.assert_allclose(coord.coords['lat_lon']['lat'], [0.1, 0.2, 0.3, 0.4])
-        np.testing.assert_allclose(coord.coords['lat_lon']['lon'], [-0.3, -0.2, -0.1, 0.0])
-
-        # step not allowed
-        with pytest.raises(TypeError):
-            Coordinate(lat_lon=[(0.1, 0.4), (-0.3, -0.0), 0.1])
-
-        # timedelta not allowed
-        with pytest.raises(TypeError):
-            Coordinate(lat_lon=[(0.1, 0.4), (-0.3, -0.0), np.timedelta64(1, 'D')])
-
-        # size required
+        d = OrderedDict()
+        d['lat_lon_time'] = (lat, lon)
         with pytest.raises(ValueError):
-            Coordinate(lat_lon=[(0.1, 0.4), (-0.3, -0.0)])
+            Coordinate(d)
 
-    def test_coords_datetime_uniform_num(self):
-        coord = Coordinate(time=('2018-01-01', '2018-01-03', 3))
-
-        self._common_checks(coord, ['time'], (3,), False)
-        np.testing.assert_array_equal(
-            coord.coords['time'],
-            np.array(['2018-01-01', '2018-01-02', '2018-01-03']).astype(np.datetime64))
-
-    def test_coords_datetime_uniform_step(self):
-        coord = Coordinate(time=('2018-01-01', '2018-01-03', '1,D'))
-
-        self._common_checks(coord, ['time'], (3,), False)
-        np.testing.assert_array_equal(
-            coord.coords['time'],
-            np.array(['2018-01-01', '2018-01-02', '2018-01-03']).astype(np.datetime64))
-
-    def test_coords_explicit_coords(self):
-        c1 = Coordinate(lat=[0.25, 0.35], lon=[0.3, 0.4], order=['lat', 'lon'])
-        
-        coords = OrderedDict()
-        coords['lat'] = [0.25, 0.35]
-        coords['lon'] = Coord([0.3, 0.4])
-        c2 = Coordinate(coords=coords)
-        
-        assert c1.dims == c2.dims
-        np.testing.assert_allclose(c1.coords['lat'], c2.coords['lat'])
-        np.testing.assert_allclose(c1.coords['lon'], c2.coords['lon'])
-        
-        with pytest.raises(TypeError):
-            Coordinate(coords=[0.25])
-
-        with pytest.raises(TypeError):
-            Coordinate(coords={'lat': 0.25, 'lon': 0.3})
-
-        # invalid value
-        # TODO how to trigger the TypeError in _validate_val
-
-    def test_coords_explicit_coord(self):
-        coord = Coordinate(lat=Coord([0.2, 0.4, 0.5]), lon=[0.3, -0.1], order=['lat', 'lon'])
-        
-        self._common_checks(coord, ['lat', 'lon'], (3, 2), False)
-        np.testing.assert_allclose(coord.coords['lat'], [0.2, 0.4, 0.5])
-        np.testing.assert_allclose(coord.coords['lon'], [0.3, -0.1])
-
-    def test_coords_explicit_coord_stacked(self):
-        coord = Coordinate(lat_lon=[Coord([0.2, 0.4, 0.5]), Coord([0.3, -0.1, 0.2])])
-        
-        self._common_checks(coord, ['lat_lon'], (3,), True)
-        assert coord.dims_map['lat'] == 'lat_lon'
-        assert coord.dims_map['lon'] == 'lat_lon'
-        np.testing.assert_allclose(coord.coords['lat_lon']['lat'], [0.2, 0.4, 0.5])
-        np.testing.assert_allclose(coord.coords['lat_lon']['lon'], [0.3, -0.1, 0.2])
-
-        # length must match
+        # dimension repeated
+        d = OrderedDict()
+        d['lat_lon'] = (lat, lon)
+        d['lat'] = lat
         with pytest.raises(ValueError):
-            coord = Coordinate(lat_lon=[Coord([0.2, 0.4, 0.5]), Coord([0.3, -0.1])])
+            Coordinate(d)
 
-    def test_coords_invalid_dims(self):
+        d = OrderedDict()
+        d['lat_lat'] = (lat, lon)
+        d['time'] = time
+        with pytest.raises(ValueError):
+            Coordinate(d)
+
+        d = OrderedDict()
+        d['lat_time'] = (lat, time)
+        d['lon_time'] = (lon, time)
+        with pytest.raises(ValueError):
+            Coordinate(d)
+
+    def test_coords_invalid_dim(self):
+        lat = coord_linspace(0, 5, 5)
+        
         # invalid dimension
+        d = OrderedDict()
+        d['latitude'] = lat
         with pytest.raises(ValueError):
-            coord = Coordinate(abc=[0.2, 0.4, 0.5])
+            Coordinate(d)
 
-        # repeated dimension
-        # TODO how to trigger the repeated dim ValueError in _validate_dim
+    def test_coords_invalid_value(self):
         
-    @pytest.mark.skip(reason="unsupported (deprecated or future feature)")
-    def test_unstacked_dependent(self):
-        coord = Coordinate(
-            lat=xr.DataArray(
-                np.meshgrid(np.linspace(0, 1, 4), np.linspace(0, -1, 5))[0], 
-                dims=['lat', 'lon']),
-            lon=xr.DataArray(
-                np.meshgrid(np.linspace(0, 1, 4), np.linspace(0, -1, 5))[0], 
-                dims=['lat', 'lon']),
-            order=['lat', 'lon'])
-        np.testing.assert_allclose(np.array(coord.intersect(coord)._coords['lat'].bounds),
-                                          np.array(coord._coords['lat'].bounds))     
-        
-    @pytest.mark.skip(reason="unsupported (deprecated or future feature)")
-    def test_stacked_dependent(self):
-        coord = Coordinate(
-            lat=[
-                xr.DataArray(
-                         np.meshgrid(np.linspace(0, 1, 4), np.linspace(0, -1, 5))[0],
-                         dims=['lat-lon', 'time']), 
-                xr.DataArray(
-                    np.meshgrid(np.linspace(0, 1, 4), np.linspace(0, -1, 5))[1],
-                             dims=['lat-lon', 'time'])        
-                ], 
-            lon=[
-                xr.DataArray(
-                    np.meshgrid(np.linspace(0, 1, 4), np.linspace(0, -1, 5))[0],
-                    dims=['lat-lon', 'time']), 
-                xr.DataArray(
-                    np.meshgrid(np.linspace(0, 1, 4), np.linspace(0, -1, 5))[1],
-                    dims=['lat-lon', 'time']),
-                
-                ], 
-            order=['lat', 'lon'])
-        np.testing.assert_allclose(np.array(coord.intersect(coord)._coords['lat'].bounds),
-                                          np.array(coord._coords['lat'].bounds))        
-        coord = Coordinate(
-            lat=xr.DataArray(np.meshgrid(np.linspace(0, 1, 4), np.linspace(0, -1, 5)),
-                             dims=['stack', 'lat-lon', 'time']), 
-            lon=xr.DataArray(np.meshgrid(np.linspace(0, 1, 4), np.linspace(0, -1, 5)),
-                         dims=['stack', 'lat-lon', 'time']), 
-            order=['lat', 'lon']
-        )
-        np.testing.assert_allclose(np.array(coord.intersect(coord)._coords['lat'].bounds),
-                                          np.array(coord._coords['lat'].bounds))
-
+        # invalid value, must be BaseCoord
+        d = OrderedDict()
+        d['lat'] = np.linspace(0, 5, 5)
+        with pytest.raises(TypeError):
+            Coordinate(d)
+    
     def test_ctype(self):
         # default
         coord = Coordinate()
@@ -338,16 +198,6 @@ class TestCoordinate(object):
         with pytest.raises(tl.TraitError):
             Coordinate(ctype='abc')
 
-        # propagation
-        coord = Coordinate(lat=[0.2, 0.4])
-        coord._coords['lat'].ctype == 'segment'
-
-        coord = Coordinate(lat=[0.2, 0.4], ctype='segment')
-        coord._coords['lat'].ctype == 'segment'
-
-        coord = Coordinate(lat=[0.2, 0.4], ctype='point')
-        coord._coords['lat'].ctype == 'point'
-
     def test_segment_position(self):
         # default
         coord = Coordinate()
@@ -359,13 +209,6 @@ class TestCoordinate(object):
 
         with pytest.raises(tl.TraitError):
             Coordinate(segment_position='abc')
-
-        # propagation
-        coord = Coordinate(lat=[0.2, 0.4])
-        coord._coords['lat'].segment_position == 0.5
-
-        coord = Coordinate(lat=[0.2, 0.4], segment_position=0.3)
-        coord._coords['lat'].segment_position == 0.3
         
     def test_coord_ref_sys(self):
         # default
@@ -378,224 +221,349 @@ class TestCoordinate(object):
         assert coord.coord_ref_sys == 'SPHER_MERC'
         assert coord.gdal_crs == 'EPSG:3857'
 
-        # propagation
-        coord = Coordinate(lat=[0.2, 0.4])
-        coord._coords['lat'].coord_ref_sys == 'WGS84'
-
-        coord = Coordinate(lat=[0.2, 0.4], coord_ref_sys='SPHER_MERC')
-        coord._coords['lat'].coord_ref_sys == 'SPHER_MERC'
-
-    def test_get_shape(self):
-        pass
-
-    def test_intersect(self):
-        pass
-
-    def test_drop_dims(self):
-        pass
-
-    def test_transpose(self):
-        pass
-
-    def test_iterchunks(self):
-        pass
-
-    def test_add(self):
-        pass
-
-    def test_add_unique(self):
-        pass
-
-class TestCoordIntersection(object):
-    @pytest.mark.skip(reason="coordinate refactor")
-    def test_regular(self):
-        coord = Coord(coords=(1, 10, 10))
-        coord_left = Coord(coords=(-2, 7, 10))
-        coord_right = Coord(coords=(4, 13, 10))
-        coord_cent = Coord(coords=(4, 7, 4))
-        coord_cover = Coord(coords=(-2, 13, 15))
+    def test_kwargs(self):
+        # default
+        coord = Coordinate()
+        assert isinstance(coord.kwargs, dict)
+        assert coord.ctype == 'segment'
+        assert coord.segment_position == 0.5
+        assert coord.kwargs['coord_ref_sys'] == 'WGS84'
         
-        c = coord.intersect(coord).coordinates
-        np.testing.assert_allclose(c, coord.coordinates)
-        c = coord.intersect(coord_cover).coordinates
-        np.testing.assert_allclose(c, coord.coordinates)        
-        
-        c = coord.intersect(coord_left).coordinates
-        np.testing.assert_allclose(c, coord.coordinates[:8])                
-        c = coord.intersect(coord_right).coordinates
-        np.testing.assert_allclose(c, coord.coordinates[2:])
-        c = coord.intersect(coord_cent).coordinates
-        np.testing.assert_allclose(c, coord.coordinates[2:8])
+        # init
+        coord = Coordinate(ctype='point', segment_position=0.3, coord_ref_sys='SPHER_MERC')
+        assert isinstance(coord.kwargs, dict)
+        assert coord.ctype == 'point'
+        assert coord.segment_position == 0.3
+        assert coord.kwargs['coord_ref_sys'] == 'SPHER_MERC'
 
-@pytest.mark.skip(reason="new/experimental feature; spec uncertain")
-class TestCoordinateGroup(object):
-    def test_init(self):
-        c1 = Coordinate(
-            lat=(0, 10, 5),
-            lon=(0, 20, 5),
+    # def test_get_shape(self):
+    #     pass
+
+    # def test_intersect(self):
+    #     pass
+
+    # def test_drop_dims(self):
+    #     pass
+
+    # def test_transpose(self):
+    #     pass
+
+    # def test_iterchunks(self):
+    #     pass
+
+    # def test_add(self):
+    #     pass
+
+    # def test_add_unique(self):
+    #     pass
+
+# class TestCoordIntersection(object):
+#     @pytest.mark.skip(reason="coordinate refactor")
+#     def test_regular(self):
+#         coord = Coord(coords=(1, 10, 10))
+#         coord_left = Coord(coords=(-2, 7, 10))
+#         coord_right = Coord(coords=(4, 13, 10))
+#         coord_cent = Coord(coords=(4, 7, 4))
+#         coord_cover = Coord(coords=(-2, 13, 15))
+        
+#         c = coord.intersect(coord).coordinates
+#         np.testing.assert_allclose(c, coord.coordinates)
+#         c = coord.intersect(coord_cover).coordinates
+#         np.testing.assert_allclose(c, coord.coordinates)        
+        
+#         c = coord.intersect(coord_left).coordinates
+#         np.testing.assert_allclose(c, coord.coordinates[:8])                
+#         c = coord.intersect(coord_right).coordinates
+#         np.testing.assert_allclose(c, coord.coordinates[2:])
+#         c = coord.intersect(coord_cent).coordinates
+#         np.testing.assert_allclose(c, coord.coordinates[2:8])
+
+# @pytest.mark.skip(reason="new/experimental feature; spec uncertain")
+# class TestCoordinateGroup(object):
+#     def test_init(self):
+#         c1 = Coordinate(
+#             lat=(0, 10, 5),
+#             lon=(0, 20, 5),
+#             time='2018-01-01',
+#             order=('lat', 'lon', 'time'))
+
+#         c2 = Coordinate(
+#             lat=(10, 20, 15),
+#             lon=(10, 20, 15),
+#             time='2018-01-01',
+#             order=('lat', 'lon', 'time'))
+
+#         c3 = Coordinate(
+#             lat=(10, 20, 15),
+#             lon=(10, 20, 15),
+#             time='2018-01-01',
+#             order=('time', 'lat', 'lon'))
+
+#         c4 = Coordinate(
+#             lat_lon=((0, 10), (0, 20), 5),
+#             time='2018-01-01',
+#             order=('lat_lon', 'time'))
+
+#         c5 = Coordinate(
+#             lat=(0, 20, 15),
+#             lon=(0, 20, 15),
+#             order=('lat', 'lon'))
+
+#         c6 = Coordinate(
+#             lat=(10, 20, 15),
+#             lon=(10, 20, 15),
+#             order=('lat', 'lon'))
+
+#         # empty init
+#         g = CoordinateGroup()
+#         g = CoordinateGroup([])
+        
+#         # basic init (with mismatched stacking, ordering, shapes)
+#         g = CoordinateGroup([c1])
+#         g = CoordinateGroup([c1, c2, c3, c4])
+#         g = CoordinateGroup([c5, c6])
+        
+#         # list is required
+#         with pytest.raises(tl.TraitError):
+#             CoordinateGroup(c1)
+        
+#         # Coord objects not valid
+#         with pytest.raises(tl.TraitError):
+#             CoordinateGroup([c1['lat']])
+
+#         # CoordinateGroup objects not valid (no nesting)
+#         g = CoordinateGroup([c1, c2])
+#         with pytest.raises(tl.TraitError):
+#             CoordinateGroup([g])
+
+#         # dimensions must match
+#         with pytest.raises(ValueError):
+#             CoordinateGroup([c1, c5])
+
+#     def test_len(self):
+#         c1 = Coordinate(
+#             lat=(0, 10, 5),
+#             lon=(0, 20, 5),
+#             time='2018-01-01',
+#             order=('lat', 'lon', 'time'))
+
+#         c2 = Coordinate(
+#             lat=(10, 20, 15),
+#             lon=(10, 20, 15),
+#             time='2018-01-01',
+#             order=('lat', 'lon', 'time'))
+
+#         g = CoordinateGroup()
+#         assert len(g) == 0
+        
+#         g = CoordinateGroup([])
+#         assert len(g) == 0
+        
+#         g = CoordinateGroup([c1])
+#         assert len(g) == 1
+        
+#         g = CoordinateGroup([c1, c2])
+#         assert len(g) == 2
+
+#     def test_dims(self):
+#         c1 = Coordinate(
+#             lat=(0, 10, 5),
+#             lon=(0, 20, 5),
+#             time='2018-01-01',
+#             order=('lat', 'lon', 'time'))
+
+#         c2 = Coordinate(
+#             lat=(10, 20, 15),
+#             lon=(10, 20, 15),
+#             time='2018-01-01',
+#             order=('lat', 'lon', 'time'))
+
+#         c3 = Coordinate(
+#             lat=(10, 20, 15),
+#             lon=(10, 20, 15),
+#             time='2018-01-01',
+#             order=('time', 'lat', 'lon'))
+
+#         c4 = Coordinate(
+#             lat_lon=((0, 10), (0, 20), 5),
+#             time='2018-01-01',
+#             order=('lat_lon', 'time'))
+
+#         c5 = Coordinate(
+#             lat=(0, 20, 15),
+#             lon=(0, 20, 15),
+#             order=('lat', 'lon'))
+
+#         c6 = Coordinate(
+#             lat=(10, 20, 15),
+#             lon=(10, 20, 15),
+#             order=('lat', 'lon'))
+
+#         g = CoordinateGroup()
+#         assert len(g.dims) == 0
+
+#         g = CoordinateGroup([c1])
+#         assert g.dims == {'lat', 'lon', 'time'}
+
+#         g = CoordinateGroup([c1, c2, c3, c4])
+#         assert g.dims == {'lat', 'lon', 'time'}
+
+#         g = CoordinateGroup([c4])
+#         assert g.dims == {'lat', 'lon', 'time'}
+
+#         g = CoordinateGroup([c5, c6])
+#         assert g.dims == {'lat', 'lon'}
+
+#     @pytest.mark.skip(reason="unwritten test")
+#     def test_iter(self):
+#         pass
+
+#     @pytest.mark.skip(reason="unwritten test")
+#     def test_getitem(self):
+#         pass
+
+#     @pytest.mark.skip(reason="unwritten test")
+#     def test_intersect(self):
+#         pass
+
+#     @pytest.mark.skip(reason="unwritten test")
+#     def test_add(self):
+#         pass
+
+#     @pytest.mark.skip(reason="unwritten test")
+#     def test_iadd(self):
+#         pass
+
+#     @pytest.mark.skip(reason="unwritten test")
+#     def test_append(self):
+#         pass
+
+#     @pytest.mark.skip(reason="unwritten test")
+#     def test_stack(self):
+#         pass
+
+#     @pytest.mark.skip(reason="unwritten test")
+#     def test_unstack(self):
+#         pass
+
+#     @pytest.mark.skip(reason="unwritten test")
+#     def test_iterchunks(self):
+#         pass
+
+class TestCoordinateInitialization(object):
+    def test_coord(self):
+        coord = coordinate(lat=Coord([1., 2.]))
+
+    def test_value(self):
+        coord = coordinate(
+            lat=1.,
+            lon=10.,
+            time='2018-01-02',
+            order=['lat', 'lon', 'time'])
+    
+    def test_array(self):
+        coord = coordinate(
+            lat=[1., 3., 2.],
+            lon=[10., 30., 20.],
+            time=['2018-01-01', '2018-01-03', '2018-01-02'],
+            order=['lat', 'lon', 'time'])
+
+    def test_monotonic(self):
+        coord = coordinate(
+            lat=[1., 2., 3.],
+            lon=[1., 2., 3.],
+            time=['2018-01-01', '2018-01-02', '2018-01-03'],
+            order=['lat', 'lon', 'time'])
+
+    def test_uniform(self):
+        coord = coordinate(
+            lat=(1., 5., 0.5),
+            lon=(10., 50., 0.5),
+            time=('2018-01-01', '2018-01-05', '1,D'),
+            order=['lat', 'lon', 'time'])
+
+    def test_coord_linspace(self):
+        coord = coordinate(
+            lat=(1., 5., 10),
+            lon=(10., 50., 20),
+            time=('2018-01-01', '2018-01-05', 5),
+            order=['lat', 'lon', 'time'])
+
+    def test_stacked(self):
+        coord = coordinate(
+            lat_lon=([1, 2, 3], [10, 20, 30]),
             time='2018-01-01',
-            order=('lat', 'lon', 'time'))
+            order=['lat_lon', 'time'])
 
-        c2 = Coordinate(
-            lat=(10, 20, 15),
-            lon=(10, 20, 15),
-            time='2018-01-01',
-            order=('lat', 'lon', 'time'))
+        coord = coordinate(
+            lat_lon_time=([1, 2, 3], [10, 20, 30], ['2018-01-01', '2018-01-02', '2018-01-03']))
 
-        c3 = Coordinate(
-            lat=(10, 20, 15),
-            lon=(10, 20, 15),
-            time='2018-01-01',
-            order=('time', 'lat', 'lon'))
-
-        c4 = Coordinate(
-            lat_lon=((0, 10), (0, 20), 5),
-            time='2018-01-01',
-            order=('lat_lon', 'time'))
-
-        c5 = Coordinate(
-            lat=(0, 20, 15),
-            lon=(0, 20, 15),
-            order=('lat', 'lon'))
-
-        c6 = Coordinate(
-            lat=(10, 20, 15),
-            lon=(10, 20, 15),
-            order=('lat', 'lon'))
-
-        # empty init
-        g = CoordinateGroup()
-        g = CoordinateGroup([])
-        
-        # basic init (with mismatched stacking, ordering, shapes)
-        g = CoordinateGroup([c1])
-        g = CoordinateGroup([c1, c2, c3, c4])
-        g = CoordinateGroup([c5, c6])
-        
-        # list is required
-        with pytest.raises(tl.TraitError):
-            CoordinateGroup(c1)
-        
-        # Coord objects not valid
-        with pytest.raises(tl.TraitError):
-            CoordinateGroup([c1['lat']])
-
-        # CoordinateGroup objects not valid (no nesting)
-        g = CoordinateGroup([c1, c2])
-        with pytest.raises(tl.TraitError):
-            CoordinateGroup([g])
-
-        # dimensions must match
+        # mismatched size
         with pytest.raises(ValueError):
-            CoordinateGroup([c1, c5])
+            coordinate(
+                lat_lon=([1, 2, 3], [10, 20, 30, 40, 50]))
 
-    def test_len(self):
-        c1 = Coordinate(
-            lat=(0, 10, 5),
-            lon=(0, 20, 5),
+        # missing dim / extra value
+        with pytest.raises(ValueError):
+            coordinate(
+                lat_lon=([1, 2, 3], [10, 20, 30], ['2018-01-01', '2018-01-02', '2018-01-03']))
+
+        # extra dim / missing value
+        with pytest.raises(ValueError):
+            coordinate(
+                lat_lon_time=([1, 2, 3], [10, 20, 30]))
+
+    def test_stacked_linspace(self):
+        coord = coordinate(
+            lat_lon=((1., 5.), (10., 50.), 30),
             time='2018-01-01',
-            order=('lat', 'lon', 'time'))
+            order=['lat_lon', 'time'])
 
-        c2 = Coordinate(
-            lat=(10, 20, 15),
-            lon=(10, 20, 15),
-            time='2018-01-01',
-            order=('lat', 'lon', 'time'))
+        coord = coordinate(
+            lat_lon_time=((1., 5.), (10., 50.), ('2018-01-01', '2018-01-05'), 5))
 
-        g = CoordinateGroup()
-        assert len(g) == 0
+        # linspace requires integer
+        with pytest.raises(TypeError):
+            coordinate(
+                lat_lon=((1., 5.), (10., 50.), 0.5))
+
+        # missing dim / extra value
+        with pytest.raises(ValueError):
+            coordinate(
+                lat_lon=((1., 5.), (10., 50.), ('2018-01-01', '2018-01-05'), 5))
+
+        # extra dim / missing value
+        with pytest.raises(ValueError):
+            coord = coordinate(
+                lat_lon_time=((1., 5.), (10., 50.), 5))
+
+    def test_order(self):
+        c = coordinate(lon=0.3, lat=0.25, order=['lat', 'lon'])
+        assert c.dims == ['lat', 'lon']
         
-        g = CoordinateGroup([])
-        assert len(g) == 0
-        
-        g = CoordinateGroup([c1])
-        assert len(g) == 1
-        
-        g = CoordinateGroup([c1, c2])
-        assert len(g) == 2
+        c = coordinate(lon=0.3, lat=0.25, order=['lon', 'lat'])
+        assert c.dims == ['lon', 'lat']
 
-    def test_dims(self):
-        c1 = Coordinate(
-            lat=(0, 10, 5),
-            lon=(0, 20, 5),
-            time='2018-01-01',
-            order=('lat', 'lon', 'time'))
+        # extra or missing dimensions
+        with pytest.raises(ValueError):
+            coordinate(lon=0.3, lat=0.25, order=['lat', 'lon', 'time'])
 
-        c2 = Coordinate(
-            lat=(10, 20, 15),
-            lon=(10, 20, 15),
-            time='2018-01-01',
-            order=('lat', 'lon', 'time'))
+        with pytest.raises(ValueError):
+            coordinate(lon=0.3, lat=0.25, order=['lat'])
+    
+    @pytest.mark.skipif(sys.version >= '3.6', reason="Python <3.6 compatibility")
+    def test_order_required(self):
+        # not required
+        coordinate(lat=0.25)
 
-        c3 = Coordinate(
-            lat=(10, 20, 15),
-            lon=(10, 20, 15),
-            time='2018-01-01',
-            order=('time', 'lat', 'lon'))
+        # required
+        with pytest.raises(TypeError):
+            coordinate(lat=0.25, lon=0.3)
 
-        c4 = Coordinate(
-            lat_lon=((0, 10), (0, 20), 5),
-            time='2018-01-01',
-            order=('lat_lon', 'time'))
+    @pytest.mark.skipif(sys.version < '3.6', reason="Python >=3.6 required")
+    def test_order_detect(self):
+        coord = coordinate(lat=0.25, lon=0.3)
+        assert coord.dims == ['lat', 'lon']
 
-        c5 = Coordinate(
-            lat=(0, 20, 15),
-            lon=(0, 20, 15),
-            order=('lat', 'lon'))
-
-        c6 = Coordinate(
-            lat=(10, 20, 15),
-            lon=(10, 20, 15),
-            order=('lat', 'lon'))
-
-        g = CoordinateGroup()
-        assert len(g.dims) == 0
-
-        g = CoordinateGroup([c1])
-        assert g.dims == {'lat', 'lon', 'time'}
-
-        g = CoordinateGroup([c1, c2, c3, c4])
-        assert g.dims == {'lat', 'lon', 'time'}
-
-        g = CoordinateGroup([c4])
-        assert g.dims == {'lat', 'lon', 'time'}
-
-        g = CoordinateGroup([c5, c6])
-        assert g.dims == {'lat', 'lon'}
-
-    @pytest.mark.skip(reason="unwritten test")
-    def test_iter(self):
-        pass
-
-    @pytest.mark.skip(reason="unwritten test")
-    def test_getitem(self):
-        pass
-
-    @pytest.mark.skip(reason="unwritten test")
-    def test_intersect(self):
-        pass
-
-    @pytest.mark.skip(reason="unwritten test")
-    def test_add(self):
-        pass
-
-    @pytest.mark.skip(reason="unwritten test")
-    def test_iadd(self):
-        pass
-
-    @pytest.mark.skip(reason="unwritten test")
-    def test_append(self):
-        pass
-
-    @pytest.mark.skip(reason="unwritten test")
-    def test_stack(self):
-        pass
-
-    @pytest.mark.skip(reason="unwritten test")
-    def test_unstack(self):
-        pass
-
-    @pytest.mark.skip(reason="unwritten test")
-    def test_iterchunks(self):
-        pass
-
+        coord = coordinate(lon=0.3, lat=0.25)
+        assert coord.dims == ['lon', 'lat']

--- a/podpac/core/coordinate/util.py
+++ b/podpac/core/coordinate/util.py
@@ -15,6 +15,8 @@ import numbers
 import numpy as np
 from six import string_types
 
+CRS2GDAL = {'WGS84': 'EPSG:4326', 'SPHER_MERC': 'EPSG:3857'}
+
 def get_timedelta(s):
     """
     Make a numpy timedelta from a podpac timedelta string.

--- a/podpac/core/data/test/test_data_types.py
+++ b/podpac/core/data/test/test_data_types.py
@@ -9,7 +9,7 @@ from podpac.core.data.type import NumpyArray
 
 class TestBasicInterpolation(object):
     def setup_method(self, method):
-        self.coord_src = podpac.Coordinate(
+        self.coord_src = podpac.coordinate(
             lat=(45, 0, 16),
             lon=(-70., -65., 16),
             time=(0, 1, 2),
@@ -39,7 +39,7 @@ class TestBasicInterpolation(object):
             interpolation='bilinear')
 
     def test_raster_to_raster(self):
-        coord_dst = podpac.Coordinate(
+        coord_dst = podpac.coordinate(
             lat=(5., 40., 50),
             lon=(-68., -66., 100),
             order=['lat', 'lon'])
@@ -55,7 +55,7 @@ class TestBasicInterpolation(object):
         np.testing.assert_array_almost_equal(oLon.data[..., 0], LON)
         
     def test_raster_to_points(self):
-        coord_dst = podpac.Coordinate(lat_lon=((5., 40), (-68., -66), 60))
+        coord_dst = podpac.coordinate(lat_lon=((5., 40), (-68., -66), 60))
         oLat = self.nasLat.execute(coord_dst)
         oLon = self.nasLon.execute(coord_dst)
         

--- a/podpac/core/data/type.py
+++ b/podpac/core/data/type.py
@@ -69,6 +69,7 @@ except:
 import podpac
 from podpac.core import authentication
 from podpac.core.utils import cached_property, clear_cache
+from podpac.core.coordinate import Coordinate
 
 
 class NumpyArray(podpac.DataSource):
@@ -304,7 +305,7 @@ class RasterioSource(podpac.DataSource):
            affine[3] != 0.0:
             raise NotImplementedError("Have not implemented rotated coords")
 
-        return podpac.Coordinate(lat=(top, bottom, dlat),
+        return podpac.coordinate(lat=(top, bottom, dlat),
                                  lon=(left, right, dlon),
                                  order=['lat', 'lon'])
 
@@ -457,7 +458,7 @@ class WCS(podpac.DataSource):
         return self.source + '?' + self.get_capabilities_qs.format(
             version=self.version, layer=self.layer_name)
 
-    wcs_coordinates = tl.Instance(podpac.Coordinate)
+    wcs_coordinates = tl.Instance(Coordinate)
     @tl.default('wcs_coordinates')
     def get_wcs_coordinates(self):
         """Summary
@@ -510,14 +511,14 @@ class WCS(podpac.DataSource):
 
         timedomain = capabilities.find("wcs:temporaldomain")
         if timedomain is None:
-            return podpac.Coordinate(lat=(top, bottom, size[1]),
+            return podpac.coordinate(lat=(top, bottom, size[1]),
                                          lon=(left, right, size[0]), order=['lat', 'lon'])
         
         date_re = re.compile('[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}')
         times = str(timedomain).replace('<gml:timeposition>', '').replace('</gml:timeposition>', '').split('\n')
         times = np.array([t for t in times if date_re.match(t)], np.datetime64)
         
-        return podpac.Coordinate(time=times,
+        return podpac.coordinate(time=times,
                                  lat=(top, bottom, size[1]),
                                  lon=(left, right, size[0]),                        
                                  order=['time', 'lat', 'lon'])
@@ -550,7 +551,7 @@ class WCS(podpac.DataSource):
                              max(ev[c].coords[:2]), abs(ev[c].delta))
                 else:
                     cs.append(wcs_c[c])
-            c = podpac.Coordinate(cs)
+            c = podpac.coordinate(cs)
             return c
         else:
             return self.wcs_coordinates
@@ -766,7 +767,7 @@ class ReprojectedSource(podpac.DataSource, podpac.Algorithm):
     source = tl.Instance(podpac.Node)
     # Specify either one of the next two
     coordinates_source = tl.Instance(podpac.Node, allow_none=True)
-    reprojected_coordinates = tl.Instance(podpac.Coordinate)
+    reprojected_coordinates = tl.Instance(Coordinate)
 
     @tl.default('reprojected_coordinates')
     def get_reprojected_coordinates(self):
@@ -807,7 +808,7 @@ class ReprojectedSource(podpac.DataSource, podpac.Algorithm):
                 coords[d] = rc.stack_dict()[d]
             else:
                 coords[d] = sc.stack_dict()[d]
-        return podpac.Coordinate(coords)
+        return Coordinate(coords)
 
     def get_data(self, coordinates, coordinates_slice):
         """Summary
@@ -1015,9 +1016,9 @@ if __name__ == '__main__':
     
     s3.s3_data
     
-    #coord_src = podpac.Coordinate(lat=(45, 0, 16), lon=(-70., -65., 16), time=(0, 1, 2),
+    #coord_src = podpac.coordinate(lat=(45, 0, 16), lon=(-70., -65., 16), time=(0, 1, 2),
                                     #order=['lat', 'lon', 'time'])
-    #coord_dst = podpac.Coordinate(lat=(50., 0., 50), lon=(-71., -66., 100),
+    #coord_dst = podpac.coordinate(lat=(50., 0., 50), lon=(-71., -66., 100),
                                     #order=['lat', 'lon'])
     #LON, LAT, TIME = np.meshgrid(coord_src['lon'].coordinates,
                                     #coord_src['lat'].coordinates,
@@ -1027,19 +1028,19 @@ if __name__ == '__main__':
     #source = LAT + 0*LON + 0*TIME
     #nas = NumpyArray(source=source.astype(float), 
                         #native_coordinates=coord_src, interpolation='bilinear')
-    ##coord_pts = podpac.Coordinate(lat_lon=(coord_src.coords['lat'], coord_src.coords['lon']))
+    ##coord_pts = podpac.coordinate(lat_lon=(coord_src.coords['lat'], coord_src.coords['lon']))
     ##o3 = nas.execute(coord_pts)
     #o = nas.execute(coord_dst)
-    ##coord_pt = podpac.Coordinate(lat=10., lon=-67.)
+    ##coord_pt = podpac.coordinate(lat=10., lon=-67.)
     ##o2 = nas.execute(coord_pt)
     from podpac.datalib.smap import SMAPSentinelSource
     s3.node_class = SMAPSentinelSource
 
-    #coordinates = podpac.Coordinate(lat=(45, 0, 16), lon=(-70., -65., 16),
+    #coordinates = podpac.coordinate(lat=(45, 0, 16), lon=(-70., -65., 16),
                                     #order=['lat', 'lon'])
-    coordinates = podpac.Coordinate(lat=(39.3, 39., 64), lon=(-77.0, -76.7, 64), time='2017-09-03T12:00:00', 
+    coordinates = podpac.coordinate(lat=(39.3, 39., 64), lon=(-77.0, -76.7, 64), time='2017-09-03T12:00:00', 
                                     order=['lat', 'lon', 'time'])    
-    reprojected_coordinates = podpac.Coordinate(lat=(45, 0, 3), lon=(-70., -65., 3),
+    reprojected_coordinates = podpac.coordinate(lat=(45, 0, 3), lon=(-70., -65., 3),
                                                 order=['lat', 'lon']),
     #                                           'TopographicWetnessIndexComposited3090m'),
     #          )
@@ -1056,7 +1057,7 @@ if __name__ == '__main__':
                                     interpolation='nearest')    
     o2 = reprojected.execute(coordinates)
 
-    coordinates_zoom = podpac.Coordinate(lat=(24.8, 30.6, 64), lon=(-85.0, -77.5, 64), time='2017-08-08T12:00:00', 
+    coordinates_zoom = podpac.coordinate(lat=(24.8, 30.6, 64), lon=(-85.0, -77.5, 64), time='2017-08-08T12:00:00', 
                                          order=['lat', 'lon', 'time'])
     o3 = wcs.execute(coordinates_zoom)
 

--- a/podpac/core/data/type.py
+++ b/podpac/core/data/type.py
@@ -99,8 +99,7 @@ class NumpyArray(podpac.DataSource):
             Description
         """
         s = coordinates_slice
-        d = self.initialize_coord_array(coordinates, 'data',
-                                        fillval=self.source[s])
+        d = self.initialize_coord_array(coordinates, 'data', fillval=self.source[s])
         return d
 
 class PyDAP(podpac.DataSource):
@@ -126,8 +125,7 @@ class PyDAP(podpac.DataSource):
         Description
     """
     
-    auth_session = tl.Instance(authentication.SessionWithHeaderRedirection,
-                               allow_none=True)
+    auth_session = tl.Instance(authentication.SessionWithHeaderRedirection, allow_none=True)
     auth_class = tl.Type(authentication.SessionWithHeaderRedirection)
     username = tl.Unicode(None, allow_none=True)
     password = tl.Unicode(None, allow_none=True)
@@ -195,9 +193,8 @@ class PyDAP(podpac.DataSource):
         NotImplementedError
             Description
         """
-        raise NotImplementedError("DAP has no mechanism for creating coordinates"
-                                  ", so this is left up to child class "
-                                  "implementations.")
+        raise NotImplementedError(
+            "DAP has no mechanism for creating coordinates, so this is left up to child class implementations.")
 
 
     def get_data(self, coordinates, coordinates_slice):
@@ -216,8 +213,7 @@ class PyDAP(podpac.DataSource):
             Description
         """
         data = self.dataset[self.datakey][tuple(coordinates_slice)]
-        d = self.initialize_coord_array(coordinates, 'data',
-                                        fillval=data.reshape(coordinates.shape))
+        d = self.initialize_coord_array(coordinates, 'data', fillval=data.reshape(coordinates.shape))
         return d
     
     @property
@@ -301,13 +297,10 @@ class RasterioSource(podpac.DataSource):
         else:
             affine = self.dataset.transform
         left, bottom, right, top = self.dataset.bounds
-        if affine[1] != 0.0 or\
-           affine[3] != 0.0:
+        if affine[1] != 0.0 or affine[3] != 0.0:
             raise NotImplementedError("Have not implemented rotated coords")
 
-        return podpac.coordinate(lat=(top, bottom, dlat),
-                                 lon=(left, right, dlon),
-                                 order=['lat', 'lon'])
+        return podpac.coordinate(lat=(top, bottom, dlat), lon=(left, right, dlon), order=['lat', 'lon'])
 
     def get_data(self, coordinates, coodinates_slice):
         """Summary
@@ -326,12 +319,8 @@ class RasterioSource(podpac.DataSource):
         """
         data = self.initialize_coord_array(coordinates)
         
-        data.data.ravel()[:] = self.dataset.read(
-            self.band, window=((slc[0].start, slc[0].stop),
-                               (slc[1].start, slc[1].stop)),
-            out_shape=tuple(coordinates.shape)
-            ).ravel()
-            
+        window = (slc[0].start, slc[0].stop), (slc[1].start, slc[1].stop)
+        data.data.ravel()[:] = self.dataset.read(self.band, window=window, out_shape=coordinates.shape).ravel()
         return data
     
     @cached_property
@@ -381,8 +370,7 @@ class RasterioSource(podpac.DataSource):
     
     @tl.observe('source')
     def _clear_band_description(self, change):
-        clear_cache(self, change, ['band_descriptions', 'band_count',
-                                   'band_keys'])
+        clear_cache(self, change, ['band_descriptions', 'band_count', 'band_keys'])
 
     def get_band_numbers(self, key, value):
         """Summary
@@ -455,8 +443,7 @@ class WCS(podpac.DataSource):
         TYPE
             Description
         """
-        return self.source + '?' + self.get_capabilities_qs.format(
-            version=self.version, layer=self.layer_name)
+        return self.source + '?' + self.get_capabilities_qs.format(version=self.version, layer=self.layer_name)
 
     wcs_coordinates = tl.Instance(Coordinate)
     @tl.default('wcs_coordinates')
@@ -491,7 +478,8 @@ class WCS(podpac.DataSource):
         else:
             raise Exception("Do not have a URL request library to get WCS data.")
 
-        if lxml is not None: # could skip using lxml and always use html.parser instead, which seems to work but lxml might be faster
+        # could skip using lxml and always use html.parser instead, which seems to work but lxml might be faster
+        if lxml is not None:
             capabilities = bs4.BeautifulSoup(capabilities, 'lxml')
         else:
             capabilities = bs4.BeautifulSoup(capabilities, 'html.parser')
@@ -511,8 +499,7 @@ class WCS(podpac.DataSource):
 
         timedomain = capabilities.find("wcs:temporaldomain")
         if timedomain is None:
-            return podpac.coordinate(lat=(top, bottom, size[1]),
-                                         lon=(left, right, size[0]), order=['lat', 'lon'])
+            return podpac.coordinate(lat=(top, bottom, size[1]), lon=(left, right, size[0]), order=['lat', 'lon'])
         
         date_re = re.compile('[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}')
         times = str(timedomain).replace('<gml:timeposition>', '').replace('</gml:timeposition>', '').split('\n')
@@ -544,11 +531,9 @@ class WCS(podpac.DataSource):
                     # This is rough, we have to use a regular grid for WCS calls,
                     # Otherwise we have to do multiple WCS calls...
                     # TODO: generalize/fix this
-                    cs[c] = (min(ev[c].coords),
-                             max(ev[c].coords), abs(ev[c].delta))
+                    cs[c] = (min(ev[c].coords), max(ev[c].coords), abs(ev[c].delta))
                 elif c in ev.dims and isinstance(ev[c], podpac.UniformCoord):
-                    cs[c] = (min(ev[c].coords[:2]),
-                             max(ev[c].coords[:2]), abs(ev[c].delta))
+                    cs[c] = (min(ev[c].coords[:2]), max(ev[c].coords[:2]), abs(ev[c].delta))
                 else:
                     cs.append(wcs_c[c])
             c = podpac.coordinate(cs)
@@ -786,8 +771,7 @@ class ReprojectedSource(podpac.DataSource, podpac.Algorithm):
         try:
             return self.coordinates_source.native_coordinates
         except AttributeError:
-            raise Exception("Either reprojected_coordinates or coordinates"
-                            "_source must be specified")
+            raise Exception("Either reprojected_coordinates or coordinates_source must be specified")
 
     def get_native_coordinates(self):
         """Summary
@@ -805,9 +789,9 @@ class ReprojectedSource(podpac.DataSource, podpac.Algorithm):
         rc = self.reprojected_coordinates
         for d in sc.dims:
             if d in rc.dims:
-                coords[d] = rc.stack_dict()[d]
+                coords[d] = rc.stacked_dict[d]
             else:
-                coords[d] = sc.stack_dict()[d]
+                coords[d] = sc.stacked_dict[d]
         return Coordinate(coords)
 
     def get_data(self, coordinates, coordinates_slice):

--- a/podpac/core/node.py
+++ b/podpac/core/node.py
@@ -202,7 +202,7 @@ class Node(tl.HasTraits):
         else:
             nv = None
         if ev is not None and nv is not None:
-            return nv.get_shape(ev)
+            return nv.replace_coords(ev).shape
         elif ev is not None and nv is None:
             return ev.shape
         elif nv is not None:
@@ -297,6 +297,9 @@ class Node(tl.HasTraits):
         if coords is None:
             coords = self.evaluated_coordinates
         
+        if coords is None:
+            coords = Coordinate()
+
         if not isinstance(coords, Coordinate):
             coords = Coordinate(coords)
 

--- a/podpac/core/node.py
+++ b/podpac/core/node.py
@@ -34,14 +34,14 @@ from podpac.core.coordinate import Coordinate
 from podpac.core.utils import common_doc
 
 COMMON_DOC = {
-    'native_coordinates': 
+    'native_coordinates':
         '''The native set of coordinates for a node. This attribute may be `None` for some nodes.''',
-    'evaluated_coordinates': 
+    'evaluated_coordinates':
         '''The set of coordinates requested by a user. The Node will be executed using these coordinates.''',
     'params': 'Default is None. Runtime parameters that modify any default node parameters.',
     'hash_return': 'A unique hash capturing the coordinates and parameters used to execute the node. ',
     'outdir': 'Optional output directory. Uses settings.CACHE_DIR by default',
-    'arr_init_type': 
+    'arr_init_type':
         '''How to initialize the array. Options are:
                 nan: uses np.full(..., np.nan) (Default option)
                 empty: uses np.empty
@@ -58,7 +58,7 @@ COMMON_DOC = {
     'arr_units' : "Default is self.units The Units for the data contained in the DataArray.",
     'arr_dtype' :"Default is np.float. Datatype used by default",
     'arr_kwargs' : "Dictioary of any additional keyword arguments that will be passed to UnitsDataArray.",
-    'arr_return' : 
+    'arr_return' :
         """UnitsDataArray
             Unit-aware xarray DataArray of the desired size initialized using the method specified.
             """
@@ -129,13 +129,13 @@ class Node(tl.HasTraits):
         Flag indicating if nodes as part of a pipeline should be automatically evaluated when
         the root node is evaluated. This attribute is planned for deprecation in the future.
     native_coordinates : podpac.Coordinate, optional
-        {native_coordinates} 
+        {native_coordinates}
     node_defaults : dict
-        Dictionary of defaults values for attributes of a Node. 
+        Dictionary of defaults values for attributes of a Node.
     output : podpac.UnitsDataArray
-        Output data from the last evaluation of the node. 
+        Output data from the last evaluation of the node.
     params : dict
-        Dictionary of parameters that control the output of a node. For example, these can be coefficients in an 
+        Dictionary of parameters that control the output of a node. For example, these can be coefficients in an
         equation, or the interpolation type. This attribute is planned for deprecation in the future.
     style : podpac.Style
         Object discribing how the output of a node should be displayed. This attribute is planned for deprecation in the
@@ -175,8 +175,8 @@ class Node(tl.HasTraits):
         Parameters
         -----------
         coords: podpac.Coordinates, optional
-            Requested coordinates that help determine the shape of the output. Uses self.evaluated_coordinates if not 
-            supplied. 
+            Requested coordinates that help determine the shape of the output. Uses self.evaluated_coordinates if not
+            supplied.
 
         Returns
         -------
@@ -186,13 +186,13 @@ class Node(tl.HasTraits):
         Raises
         ------
         NodeException
-            If the shape cannot be automatically determined, this exception is raised. 
+            If the shape cannot be automatically determined, this exception is raised.
         """
 
         # Changes here likely will also require changes in initialize_output_array
-        if coords is None: 
+        if coords is None:
             ev = self.evaluated_coordinates
-        else: 
+        else:
             ev = coords
         #nv = self._trait_values.get('native_coordinates',  None)
         # Switching from _trait_values to hasattr because "native_coordinates"
@@ -263,8 +263,8 @@ class Node(tl.HasTraits):
         params : dict, optional
             Default is None. Runtime parameters that modify any default node parameters.
         output : podpac.UnitsDataArray, optional
-            Default is None. Optional input array used to store the output data. When supplied, the node will not 
-            allocate its own memory for the output array. This array needs to have the correct dimensions and 
+            Default is None. Optional input array used to store the output data. When supplied, the node will not
+            allocate its own memory for the output array. This array needs to have the correct dimensions and
             coordinates.
         method : str, optional
             Default is None. How the node will be executed: serial, parallel, on aws, locally, etc. Currently only local
@@ -273,18 +273,18 @@ class Node(tl.HasTraits):
         Raises
         ------
         NotImplementedError
-            Children need to implement this method, otherwise this error is raised. 
+            Children need to implement this method, otherwise this error is raised.
         """
         raise NotImplementedError
 
     def get_output_coords(self, coords=None):
-        """Returns the output coordinates based on the user-requested coordinates. This is jointly determined by 
+        """Returns the output coordinates based on the user-requested coordinates. This is jointly determined by
         the input or evaluated coordinates and the native_coordinates (if present).
 
         Parameters
         ----------
         coords : podpac.Coordinates, optional
-            Requested coordinates that help determine the coordinates of the output. Uses self.evaluated_coordinates if 
+            Requested coordinates that help determine the coordinates of the output. Uses self.evaluated_coordinates if
             not supplied.
 
         Returns
@@ -549,7 +549,7 @@ class Node(tl.HasTraits):
         Returns
         -------
         OrderedDict
-            Dictionary-formatted definition of a PODPAC pipeline. 
+            Dictionary-formatted definition of a PODPAC pipeline.
         """
 
         from podpac.core.pipeline import make_pipeline_definition
@@ -566,8 +566,8 @@ class Node(tl.HasTraits):
             
         Notes
         ------
-        This definition can be used to create Pipeline Nodes. It also serves as a light-weight transport mechanism to 
-        share algorithms and pipelines, or run code on cloud services. 
+        This definition can be used to create Pipeline Nodes. It also serves as a light-weight transport mechanism to
+        share algorithms and pipelines, or run code on cloud services.
         """
         return json.dumps(self.pipeline_definition, indent=4)
 
@@ -679,7 +679,7 @@ class Node(tl.HasTraits):
         outdir : None, optional
             {outdir}
         format : str, optional
-            The file format. Currently only `pickle` is supported. 
+            The file format. Currently only `pickle` is supported.
 
         Raises
         ------
@@ -699,7 +699,7 @@ class Node(tl.HasTraits):
             raise NotImplementedError
 
     def load(self, name, coordinates, params, outdir=None):
-        """Retrieves a cached file from disk. 
+        """Retrieves a cached file from disk.
 
         Parameters
         ----------
@@ -742,7 +742,7 @@ class Node(tl.HasTraits):
         Parameters
         ----------
         format : str, optional
-            Default is 'png'. Type of image. 
+            Default is 'png'. Type of image.
         vmin : number, optional
             Minimum value of colormap
         vmax : vmax, optional
@@ -751,7 +751,7 @@ class Node(tl.HasTraits):
         Returns
         -------
         str
-            Base64 encoded image. 
+            Base64 encoded image.
         """
         matplotlib.use('agg')
         from matplotlib.image import imsave

--- a/podpac/core/node.py
+++ b/podpac/core/node.py
@@ -30,7 +30,7 @@ except:
 
 from podpac import settings
 from podpac import Units, UnitsDataArray
-from podpac import Coordinate
+from podpac.core.coordinate import Coordinate
 from podpac.core.utils import common_doc
 
 COMMON_DOC = {
@@ -296,7 +296,8 @@ class Node(tl.HasTraits):
         # Changes here likely will also require changes in shape
         if coords is None:
             coords = self.evaluated_coordinates
-        if not isinstance(coords, (Coordinate)):
+        
+        if not isinstance(coords, Coordinate):
             coords = Coordinate(coords)
 
         #if self._trait_values.get("native_coordinates", None) is not None:

--- a/podpac/core/pipeline.py
+++ b/podpac/core/pipeline.py
@@ -14,7 +14,6 @@ import re
 import numpy as np
 import traitlets as tl
 
-from podpac.core.coordinate import Coordinate
 from podpac.core.node import Node
 from podpac.core.data.data import DataSource
 from podpac.core.algorithm.algorithm import Algorithm
@@ -689,7 +688,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     # TODO coordinate arguments and coordinate file path argument
-    coords = Coordinate(
+    coords = podpac.coordinate(
         lat=[43.759843545782765, 43.702536630730286, 64],
         lon=[-72.3940658569336, -72.29999542236328, 32],
         time='2015-04-11T06:00:00',

--- a/podpac/core/test/test_compositor.py
+++ b/podpac/core/test/test_compositor.py
@@ -20,10 +20,11 @@ class TestCompositor(object):
         # Because of this, the results are cached after the first run
         smap.native_coordinates 
 
-        coordinates_point = \
-            podpac.Coordinate(lat=39., lon=-77, 
-                              time=('2017-09-01', '2017-10-31', '1,D'), 
-                              order=['lat', 'lon', 'time'])
+        coordinates_point = podpac.coordinate(
+            lat=39.,
+            lon=-77,
+            time=('2017-09-01', '2017-10-31', '1,D'),
+            order=['lat', 'lon', 'time'])
         smap.threaded = True
         output = smap.execute(coordinates_point)
         smap.threaded = False

--- a/podpac/core/test/test_node.py
+++ b/podpac/core/test/test_node.py
@@ -6,16 +6,15 @@ from pint.errors import DimensionalityError
 from pint import UnitRegistry
 ureg = UnitRegistry()
 
-from podpac.core.node import *
+import podpac
+from podpac.core.node import Node
 from podpac.core.units import UnitsDataArray
 
 class TestNodeOutputArrayCreation(object):
     @classmethod
     def setup_class(cls):
-        from podpac import Coordinate
-        cls.c1 = Coordinate(lat_lon=((0, 1), (0, 1), 10), time=(0, 1, 2),
-                            order=['lat_lon', 'time'])
-        cls.c2 = Coordinate(lat_lon=((0.5, 1.5), (0.1, 1.1), 15))
+        cls.c1 = podpac.coordinate(lat_lon=((0, 1), (0, 1), 10), time=(0, 1, 2), order=['lat_lon', 'time'])
+        cls.c2 = podpac.coordinate(lat_lon=((0.5, 1.5), (0.1, 1.1), 15))
         
     def test_output_creation_stacked_native(self):
         n = Node(native_coordinates=self.c1)

--- a/podpac/core/test/test_node.py
+++ b/podpac/core/test/test_node.py
@@ -36,5 +36,5 @@ class TestNodeOutputArrayCreation(object):
         assert((15, 2) == s2)
         n.evaluated_coordinates = self.c2.unstack()
         s3 = n.initialize_output_array().shape
-        assert((15, 15, 2) == s3)    
+        assert((15, 15, 2) == s3)
         

--- a/podpac/datalib/airmoss.py
+++ b/podpac/datalib/airmoss.py
@@ -60,8 +60,7 @@ class AirMOSS_Source(datatype.PyDAP):
         lats = (ds['lat'][0], ds['lat'][-1],
                 ds['lat'][1] - ds['lat'][0])
 
-        coords = podpac.Coordinate(time=np.array(times), lat=lats, lon=lons,
-                                   coord_order=['time', 'lat', 'lon'])
+        coords = podpac.coordinate(time=np.array(times), lat=lats, lon=lons, coord_order=['time', 'lat', 'lon'])
         self.cache_obj(coords, 'native.coordinates')
 
         return coords
@@ -132,8 +131,7 @@ class AirMOSS_Site(podpac.GridCompositor):
         lats = (ds['lat'][0], ds['lat'][-1],
                 ds['lat'][1] - ds['lat'][0])
 
-        coords = podpac.Coordinate(time=np.array(times), lat=lats, lon=lons,
-                                   coord_order=['time', 'lat', 'lon'])
+        coords = podpac.coordinate(time=np.array(times), lat=lats, lon=lons, coord_order=['time', 'lat', 'lon'])
         self.cache_obj(coords, 'native.coordinates')
 
         return coords
@@ -215,8 +213,7 @@ if __name__ == '__main__':
                        site='BermsP')
     print(ams.native_coordinates)
 
-    source = ('https://thredds.daac.ornl.gov/thredds/dodsC/ornldaac/1421/'
-              'L4RZSM_BermsP_20121025_v5.nc4')
+    source = 'https://thredds.daac.ornl.gov/thredds/dodsC/ornldaac/1421/L4RZSM_BermsP_20121025_v5.nc4'
     am = AirMOSS_Source(source=source, interpolation='nearest_preview')
     coords = am.native_coordinates
     print(coords)
@@ -225,7 +222,7 @@ if __name__ == '__main__':
     lat, lon = am.native_coordinates.coords['lat'], am.native_coordinates.coords['lon']
     lat = lat[::10][np.isfinite(lat[::10])]
     lon = lon[::10][np.isfinite(lon[::10])]
-    coords = podpac.Coordinate(lat=lat, lon=lon, order=['lat', 'lon'])
+    coords = podpac.coordinate(lat=lat, lon=lon, order=['lat', 'lon'])
     o = am.execute(coords)
 
     print('Done')

--- a/podpac/datalib/smap.py
+++ b/podpac/datalib/smap.py
@@ -215,8 +215,7 @@ class SMAPSource(datatype.PyDAP):
         lats[lats == self.no_data_vals[0]] = np.nan
         lons = np.nanmean(lons, axis=0)
         lats = np.nanmean(lats, axis=1)
-        coords = podpac.Coordinate(lat=lats, lon=lons, time=np.array(times),
-                                   order=['time', 'lat', 'lon'])
+        coords = podpac.coordinate(lat=lats, lon=lons, time=np.array(times), order=['time', 'lat', 'lon'])
         self.cache_obj(coords, 'native.coordinates')
         return coords
 
@@ -329,8 +328,7 @@ class SMAPProperties(SMAPSource):
         lats[lats == self.no_data_vals[0]] = np.nan
         lons = np.nanmean(lons, axis=0)
         lats = np.nanmean(lats, axis=1)
-        coords = podpac.Coordinate(lat=lats, lon=lons,
-                                   order=['lat', 'lon'])
+        coords = podpac.coordinate(lat=lats, lon=lons, order=['lat', 'lon'])
         self.cache_obj(coords, 'native.coordinates')
         return coords
 
@@ -494,14 +492,14 @@ class SMAPDateFolder(podpac.OrderedCompositor):
         times, latlon, _ = self.get_available_coords_sources()
 
         if latlon is not None and latlon.size > 0:
-            crds = podpac.Coordinate(
+            crds = podpac.coordinate(
                 time_lat_lon=(times,
                               podpac.Coord(latlon[:, 0], delta=self.latlon_delta),
                               podpac.Coord(latlon[:, 1], delta=self.latlon_delta)
                               )
                 )
         else:
-            crds = podpac.Coordinate(time=times)
+            crds = podpac.coordinate(time=times)
         self.cache_obj(crds, 'source.coordinates')
         return crds
 
@@ -691,7 +689,7 @@ class SMAP(podpac.OrderedCompositor):
         TYPE
             Description
         """
-        return podpac.Coordinate(time=self.get_available_times_dates()[0])
+        return podpac.coordinate(time=self.get_available_times_dates()[0])
 
     def get_available_times_dates(self):
         """Summary
@@ -844,7 +842,7 @@ if __name__ == '__main__':
     #eds.update_login()
         # follow the prompts
     from podpac.core.data.type import WCS
-    coords = podpac.Coordinate(time='2015-04-06T06',
+    coords = podpac.coordinate(time='2015-04-06T06',
                                lat=(-34.5, -35.25, 30), lon=(145.75, 146.5, 30),
                                order=['time', 'lat', 'lon'])
    
@@ -860,11 +858,11 @@ if __name__ == '__main__':
     # GET THE TOP WORKING FOR RACHEL
 
    
-    coordinates_world = \
-        podpac.Coordinate(lat=(-90, 90, 1.),
-                          lon=(-180, 180, 1.),
-                          time=['2017-11-18T00:00:00', '2017-11-19T00:00:00'],
-                          order=['lat', 'lon', 'time'])
+    coordinates_world = podpac.coordinate(
+        lat=(-90, 90, 1.),
+        lon=(-180, 180, 1.),
+        time=['2017-11-18T00:00:00', '2017-11-19T00:00:00'],
+        order=['lat', 'lon', 'time'])
     sentinel = SMAP(interpolation='nearest_preview', product='SPL2SMAP_S.001')
     smap = SMAP(product='SPL4SMAU.003')
     pnc2, srcs2 = smap.get_partial_native_coordinates_sources()
@@ -884,11 +882,11 @@ if __name__ == '__main__':
     
     smd = SMAPDateFolder(product='SPL2SMAP_S.001', folder_date='2017.02.08')
     crds = smd.get_source_coordinates()
-    c = podpac.Coordinate(lat=0, lon=0)
+    c = podpac.coordinate(lat=0, lon=0)
     a = crds.intersect(c)
-    c2 = podpac.Coordinate(lat=30, lon=119)
+    c2 = podpac.coordinate(lat=30, lon=119)
     a2 = crds.intersect(c2)
-    c3 = podpac.Coordinate(lat=30.5, lon=119.5)
+    c3 = podpac.coordinate(lat=30.5, lon=119.5)
     a3 = crds.intersect(c3)
     
     
@@ -912,7 +910,7 @@ if __name__ == '__main__':
     sm.dataset
     sm.native_coordinates
     
-    coords = podpac.Coordinate(lat=sm.native_coordinates['lat'].coordinates[::10],
+    coords = podpac.coordinate(lat=sm.native_coordinates['lat'].coordinates[::10],
                               lon=sm.native_coordinates['lon'].coordinates[::10],
                               time=sm.native_coordinates['time'], 
                               order=['lat', 'lon', 'time'])
@@ -946,20 +944,20 @@ if __name__ == '__main__':
     coords = smap.native_coordinates
     print (coords)
     print (coords['time'].area_bounds)
-    coord_pt = podpac.Coordinate(lat=10., lon=-67., order=['lat', 'lon'])  # Not covered
+    coord_pt = podpac.coordinate(lat=10., lon=-67., order=['lat', 'lon'])  # Not covered
     o = smap.execute(coord_pt)
-    ##coord_pt = podpac.Coordinate(lat=66., lon=-72.)  
+    ##coord_pt = podpac.coordinate(lat=66., lon=-72.)  
     ##o = smap.execute(coord_pt)
     
-    ##coords = podpac.Coordinate(lat=[45., 66., 50], lon=[-80., -70., 20])  
+    ##coords = podpac.coordinate(lat=[45., 66., 50], lon=[-80., -70., 20])  
     lat, lon = smap.native_coordinates.coords['lat'], smap.native_coordinates.coords['lon']
     lat = lat[::10][np.isfinite(lat[::10])]
     lon = lon[::10][np.isfinite(lon[::10])]
-    coords = podpac.Coordinate(lat=lat, lon=lon, order=['lat', 'lon'])
+    coords = podpac.coordinate(lat=lat, lon=lon, order=['lat', 'lon'])
     
     o = smap.execute(coords)    
     
-    #t_coords = podpac.Coordinate(time=np.datetime64('2015-12-11T06'))
+    #t_coords = podpac.coordinate(time=np.datetime64('2015-12-11T06'))
     #o2 = smap.execute(t_coords)
         
     smap = SMAP(product='SPL4SMAU.003')
@@ -968,12 +966,12 @@ if __name__ == '__main__':
     print (coords)
     #print (coords['time'].area_bounds)
     
-    coords = podpac.Coordinate(time=coords.coords['time'][:3],
+    coords = podpac.coordinate(time=coords.coords['time'][:3],
                                lat=[45., 66., 50], lon=[-80., -70., 20],
                                order=['time', 'lat', 'lon'])  
 
     o = smap.execute(coords)    
-    coords2 = podpac.Coordinate(time=coords.coords['time'][1:2],
+    coords2 = podpac.coordinate(time=coords.coords['time'][1:2],
                                lat=[45., 66., 50], lon=[-80., -70., 20],
                                order=['time', 'lat', 'lon'])      
     o2 = smap.execute(coords2) 


### PR DESCRIPTION
@mpu-creare would you have a look at this and let me know what you think?

 * The `Coordinate` object is initialized only with a dictionary (OrderedDict in Python 2) that maps unstacked dims to a BaseCoord object and stacked dims to a tuple of BaseCoord objects. Generally we use the Coordinate object directly within podpac.

 * The `coordinate` function is for user-friendly coordinate creation. It takes named dimension arguments, parses the coordinate values, and returns a `Coordinate` object. Users will generally use this function to crete Coordinates -- it is the only thing from the coordinate submodule that is available in the top-level namespace as `podpac.coordinate`.

I think this makes the code, testing, and docs much simpler. I've updated much of the Coordinate testing.

The one thing I'm hesitant about is the names `Coordinate` and `coordinate` since they are so similar. I wondered if something like `MultiCoordinate` and 'coordinate' would be better to avoid confusion. Sort of like `np.array` vs `np.ndarray`, you know? What do you think about that?