### PR TITLE
Feature/node sub attributes

### DIFF
--- a/podpac/core/coordinates/array_coordinates1d.py
+++ b/podpac/core/coordinates/array_coordinates1d.py
@@ -90,7 +90,7 @@ class ArrayCoordinates1d(Coordinates1d):
         return cls(x.data, name=x.name)
 
     @classmethod
-    def from_json(cls, d):
+    def from_definition(cls, d):
         coords = d.pop('values')
         return cls(coords, **d)
 
@@ -193,7 +193,7 @@ class ArrayCoordinates1d(Coordinates1d):
         return area_bounds
 
     @property
-    def json(self):
+    def definition(self):
         d = OrderedDict()
         if self.dtype == float:
             d['values'] = self.coords.tolist()

--- a/podpac/core/coordinates/coordinates.py
+++ b/podpac/core/coordinates/coordinates.py
@@ -201,24 +201,26 @@ class Coordinates(tl.HasTraits):
         return cls(coords, coord_ref_sys=coord_ref_sys, ctype=ctype, distance_units=distance_units)
 
     @classmethod
-    def from_json(cls, d):
-        if isinstance(d, str):
-            d = json.loads(d)
-
+    def from_definition(cls, d):
         coords = []
         for elem in d:
             if isinstance(elem, list):
-                c = StackedCoordinates.from_json(elem)
+                c = StackedCoordinates.from_definition(elem)
             elif 'start' in elem and 'stop' in elem and 'step' in elem:
-                c = UniformCoordinates1d.from_json(elem)
+                c = UniformCoordinates1d.from_definition(elem)
             elif 'values' in elem:
-                c = ArrayCoordinates1d.from_json(elem)
+                c = ArrayCoordinates1d.from_definition(elem)
             else:
                 raise ValueError("Could not parse coordinates definition with keys %s" % elem.keys())
             
             coords.append(c)
 
         return cls(coords)
+
+    @classmethod
+    def from_json(cls, s):
+        d = json.loads(s)
+        return cls.from_definition(d)
     
     # ------------------------------------------------------------------------------------------------------------------
     # standard dict-like methods
@@ -348,12 +350,16 @@ class Coordinates(tl.HasTraits):
             return 'NA'
 
     @property
+    def definition(self):
+        return [c.definition for c in self._coords.values()]
+
+    @property
     def json(self):
-        return json.dumps([c.json for c in self._coords.values()])
+        return json.dumps(self.definition)
 
     @property
     def hash(self):
-        return hash(json.dumps(self.json))
+        return hash(self.json)
     
     # ------------------------------------------------------------------------------------------------------------------
     # Methods

--- a/podpac/core/coordinates/stacked_coordinates.py
+++ b/podpac/core/coordinates/stacked_coordinates.py
@@ -102,7 +102,7 @@ class StackedCoordinates(BaseCoordinates):
         return cls([ArrayCoordinates1d.from_xarray(xcoord[dims]) for dims in dims], **kwargs)
 
     @classmethod
-    def from_json(cls, d):
+    def from_definition(cls, d):
         coords = []
         for elem in d:
             if 'start' in elem and 'stop' in elem and 'step' in elem:
@@ -183,8 +183,8 @@ class StackedCoordinates(BaseCoordinates):
         return x[self.name].coords
 
     @property
-    def json(self):
-        return [c.json for c in self._coords]
+    def definition(self):
+        return [c.definition for c in self._coords]
 
     # -----------------------------------------------------------------------------------------------------------------
     # Methods

--- a/podpac/core/coordinates/uniform_coordinates1d.py
+++ b/podpac/core/coordinates/uniform_coordinates1d.py
@@ -128,7 +128,7 @@ class UniformCoordinates1d(Coordinates1d):
             return cls(items[0], items[1], step, **kwargs)
 
     @classmethod
-    def from_json(cls, d):
+    def from_definition(cls, d):
         start = d.pop('start')
         stop = d.pop('stop')
         step = d.pop('step')
@@ -265,7 +265,7 @@ class UniformCoordinates1d(Coordinates1d):
         return area_bounds
 
     @property
-    def json(self):
+    def definition(self):
         d = OrderedDict()
         if self.dtype == float:
             d['start'] = self.start

--- a/podpac/core/data/test/test_types.py
+++ b/podpac/core/data/test/test_types.py
@@ -575,11 +575,13 @@ class TestReprojectedSource(object):
         datanode = Array(source=self.data, native_coordinates=self.coordinates_source)
         node = ReprojectedSource(source=datanode, coordinates_source=datanode)
         d = node.base_definition
+        assert d['lookup_attrs']['coordinates_source'] is datanode
 
         # no coordinates source
         node = ReprojectedSource(source=self.source, reprojected_coordinates=self.reprojected_coordinates)
-        with pytest.raises(NotImplementedError):
-            d = node.base_definition
+        d = node.base_definition
+        c = Coordinates.from_definition(d['attrs']['reprojected_coordinates'])
+        assert c == self.reprojected_coordinates
 
 class TestS3(object):
     """test S3 data source"""

--- a/podpac/core/data/types.py
+++ b/podpac/core/data/types.py
@@ -777,6 +777,18 @@ class ReprojectedSource(DataSource):
     coordinates_source = tl.Instance(Node, allow_none=True).tag(attr=True)
     reprojected_coordinates = tl.Instance(Coordinates)
 
+    def _first_init(self, **kwargs):
+        if 'coordinates_source' in kwargs and 'reprojected_coordinates' in kwargs:
+            raise TypeError("reprojected_coordinates and coordinates_source cannot both be specified")
+
+        if 'reprojected_coordinates' in kwargs:
+            if isinstance(kwargs['reprojected_coordinates'], list):
+                kwargs['reprojected_coordinates'] = Coordinates.from_definition(kwargs)
+            elif isinstance(kwargs['reprojected_coordinates'], str):
+                kwargs['reprojected_coordinates'] = Coordinates.from_json(kwargs)
+                
+        return kwargs
+
     @tl.default('reprojected_coordinates')
     def get_reprojected_coordinates(self):
         """Retrieves the reprojected coordinates in case coordinates_source is specified

--- a/podpac/core/data/types.py
+++ b/podpac/core/data/types.py
@@ -86,6 +86,15 @@ class Array(DataSource):
     """
     
     source = tl.Instance(np.ndarray)
+
+    @tl.validate('source')
+    def _validate_source(self, d):
+        a = d['value']
+        try:
+            a.astype(float)
+        except:
+            raise ValueError("Array source must be numerical")
+        return a
     
     @common_doc(COMMON_DATA_DOC)
     def get_data(self, coordinates, coordinates_index):

--- a/podpac/core/data/types.py
+++ b/podpac/core/data/types.py
@@ -774,7 +774,7 @@ class ReprojectedSource(DataSource):
     source = tl.Instance(Node)
     source_interpolation = tl.Unicode('nearest_preview').tag(attr=True)
     # Specify either one of the next two
-    coordinates_source = tl.Instance(Node, allow_none=True)
+    coordinates_source = tl.Instance(Node, allow_none=True).tag(attr=True)
     reprojected_coordinates = tl.Instance(Coordinates)
 
     @tl.default('reprojected_coordinates')
@@ -846,10 +846,9 @@ class ReprojectedSource(DataSource):
         """
         
         d = super(ReprojectedSource, self).base_definition
-
-        if self.coordinates_source is None:
-            # TODO serialize reprojected_coordinates
-            raise NotImplementedError
+        
+        if not self.coordinates_source:
+            d['attrs']['reprojected_coordinates'] = self.reprojected_coordinates.definition
         
         return d
 

--- a/podpac/core/node.py
+++ b/podpac/core/node.py
@@ -268,7 +268,7 @@ class Node(tl.HasTraits):
             d['node'] = self.__class__.__name__
         
         attrs = {}
-        node_attrs = {}
+        lookup_attrs = {}
 
         for key, value in self.traits().items():
             if not value.metadata.get('attr', False):
@@ -277,11 +277,11 @@ class Node(tl.HasTraits):
             attr = getattr(self, key)
 
             if isinstance(attr, Node):
-                node_attrs[key] = attr
+                lookup_attrs[key] = attr
             elif isinstance(attr, np.ndarray):
                 attrs[key] = attr.tolist()
             elif isinstance(attr, Coordinates):
-                attrs[key] = attr.json
+                attrs[key] = attr.definition
             else:
                 try:
                     json.dumps(attr)
@@ -293,8 +293,8 @@ class Node(tl.HasTraits):
         if attrs:
             d['attrs'] = OrderedDict([(key, attrs[key]) for key in sorted(attrs.keys())])
 
-        if node_attrs:
-            d['node_attrs'] = OrderedDict([(key, node_attrs[key]) for key in sorted(node_attrs.keys())])
+        if lookup_attrs:
+            d['lookup_attrs'] = OrderedDict([(key, lookup_attrs[key]) for key in sorted(lookup_attrs.keys())])
 
         return d
 

--- a/podpac/core/node.py
+++ b/podpac/core/node.py
@@ -266,27 +266,35 @@ class Node(tl.HasTraits):
         else:
             d['plugin'] = self.__module__
             d['node'] = self.__class__.__name__
+        
         attrs = {}
+        node_attrs = {}
+
         for key, value in self.traits().items():
             if not value.metadata.get('attr', False):
                 continue
 
             attr = getattr(self, key)
 
-            if isinstance(attr, np.ndarray):
-                attr = attr.tolist()
+            if isinstance(attr, Node):
+                node_attrs[key] = attr
+            elif isinstance(attr, np.ndarray):
+                attrs[key] = attr.tolist()
             elif isinstance(attr, Coordinates):
-                attr = attr.json
-            
-            try:
-                json.dumps(attr)
-            except:
-                raise NodeException("Cannot serialize attr '%s' with type '%s'" % (key, type(attr)))
-            
-            attrs[key] = attr
+                attrs[key] = attr.json
+            else:
+                try:
+                    json.dumps(attr)
+                except:
+                    raise NodeException("Cannot serialize attr '%s' with type '%s'" % (key, type(attr)))
+                else:
+                    attrs[key] = attr
 
         if attrs:
             d['attrs'] = OrderedDict([(key, attrs[key]) for key in sorted(attrs.keys())])
+
+        if node_attrs:
+            d['node_attrs'] = OrderedDict([(key, node_attrs[key]) for key in sorted(node_attrs.keys())])
 
         return d
 

--- a/podpac/core/test/test_node.py
+++ b/podpac/core/test/test_node.py
@@ -28,7 +28,10 @@ class TestNodeProperties(object):
     def test_base_definition(self):
         class N(Node):
             my_attr = tl.Int().tag(attr=True)
-        n = N(my_attr=7)
+            my_node_attr = tl.Instance(Node).tag(attr=True)
+        
+        a = Node()
+        n = N(my_attr=7, my_node_attr=a)
 
         d = n.base_definition
         assert isinstance(d, OrderedDict)
@@ -38,6 +41,9 @@ class TestNodeProperties(object):
         assert isinstance(d['attrs'], OrderedDict)
         assert 'my_attr' in d['attrs']
         assert d['attrs']['my_attr'] == 7
+        assert isinstance(d['lookup_attrs'], OrderedDict)
+        assert 'my_node_attr' in d['lookup_attrs']
+        assert d['lookup_attrs']['my_node_attr'] is a
 
     def test_base_definition_array_attr(self):
         class N(Node):
@@ -54,7 +60,7 @@ class TestNodeProperties(object):
 
         node = N(my_attr=podpac.Coordinates([[0, 1], [1, 2, 3]], dims=['lat', 'lon']))
         d = node.base_definition
-        my_attr = podpac.Coordinates.from_json(d['attrs']['my_attr'])
+        my_attr = podpac.Coordinates.from_definition(d['attrs']['my_attr'])
         assert my_attr == node.my_attr
 
     def test_base_definition_unserializable(self):


### PR DESCRIPTION
Closes #10 and #43 

## Usage

The tests in core/pipeline/test/test_pipeline_util.py provide a good summary of usage.

You can reference other nodes in the pipeline or attributes of other nodes in the pipeline in
 - Compositor `sources`
 - Algorithm 'inputs'
 - DataSource `lookup_source`
 - any `lookup_attrs`
 - output `node`

Normal values (strings, integers, etc) are used in
 - DataSource `source`
 - DataSource and Compositor `interpolation`
 - `attrs`

## ReprojectedSource

You can now make and use pipelines using `reprojected_coordinates`.

The ReprojectedSource `coordinates_source` can still be used:  `"lookup_attrs": {"coordinates_source": "other_node"}`

But you can also use `reprojected_source` and provide another node's attribute: * `"lookup_attrs": {"reprojected_coordinates": "other_node.some_coord_attr"}`

The ReprojectedSource `definition` property will output `"attrs": {"reprojected_coordinates": <serialized coordinates>`, and ReprojectedSource deserialize the coordinates. Note that this uses `attrs` because there is no lookup.