### PR TITLE
HOTFIX: The ImageOutput image trait type is reverted to Bytes.

### DIFF
--- a/podpac/core/pipeline/output.py
+++ b/podpac/core/pipeline/output.py
@@ -154,16 +154,12 @@ class ImageOutput(Output):
         Description
     """
 
-    format = tl.CaselessStrEnum(
-        values=['png'], default_value='png').tag(attr=True)
+    format = tl.CaselessStrEnum(values=['png'], default_value='png').tag(attr=True)
     mode = tl.Unicode(default_value="image").tag(attr=True)
     vmax = tl.CFloat(allow_none=True, default_value=np.nan).tag(attr=True)
     vmin = tl.CFloat(allow_none=True, default_value=np.nan).tag(attr=True)
-    image = tl.Instance(BytesIO, allow_none=True, default_value=None)
+    image = tl.Bytes(allow_none=True, default_value=None)
 
     # TODO: docstring?
     def write(self, output, coordinates):
-        try:
-            self.image = get_image(output, format=self.format, vmin=self.vmin, vmax=self.vmax)
-        except Exception as e:
-            warnings.warn("Error getting image from output: %s" % e)
+        self.image = get_image(output, format=self.format, vmin=self.vmin, vmax=self.vmax)


### PR DESCRIPTION
The try-except that hid the actual error is also removed. I think that user code that needs to catch that exception should have it's own try-except. Is that okay?