### PR TITLE
Feature/pipeline traits usage

### DIFF
--- a/dist/aws/handler.py
+++ b/dist/aws/handler.py
@@ -41,7 +41,7 @@ def handler(event, context, ret_pipeline=False):
     from podpac import settings
     from podpac.core.pipeline import Pipeline
     from podpac.core.coordinates import Coordinates
-    pipeline = Pipeline(json=json.dumps(pipeline_json), do_write_output=False)
+    pipeline = Pipeline(definition=pipeline_json, do_write_output=False)
     coords = Coordinates.from_json(
         json.dumps(_json['coordinates'], indent=4))
     pipeline.eval(coords)

--- a/dist/aws/handler.py
+++ b/dist/aws/handler.py
@@ -48,7 +48,7 @@ def handler(event, context, ret_pipeline=False):
     if ret_pipeline:
         return pipeline
 
-    filename = file_key.replace('.json', '.' + pipeline.pipeline_output.format)
+    filename = file_key.replace('.json', '.' + pipeline.output.format)
     filename = filename.replace(settings.S3_JSON_FOLDER, settings.S3_OUTPUT_FOLDER)
 
     body = cPickle.dumps(pipeline._output)

--- a/doc/notebooks/pipeline-from-JSON.ipynb
+++ b/doc/notebooks/pipeline-from-JSON.ipynb
@@ -162,8 +162,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sm.nodes['SMAP_SPL4SMAU'].username = username\n",
-    "sm.nodes['SMAP_SPL4SMAU'].password = password"
+    "sm.node.username = username\n",
+    "sm.node.password = password"
    ]
   },
   {

--- a/podpac/core/coordinates/coordinates.py
+++ b/podpac/core/coordinates/coordinates.py
@@ -17,22 +17,13 @@ import xarray as xr
 import xarray.core.coordinates
 from six import string_types
 
+from podpac.core.utils import OrderedDictTrait
 from podpac.core.coordinates.utils import GDAL_CRS
 from podpac.core.coordinates.base_coordinates import BaseCoordinates
 from podpac.core.coordinates.coordinates1d import Coordinates1d
 from podpac.core.coordinates.array_coordinates1d import ArrayCoordinates1d
 from podpac.core.coordinates.uniform_coordinates1d import UniformCoordinates1d
 from podpac.core.coordinates.stacked_coordinates import StackedCoordinates
-
-class OrderedDictTrait(tl.Dict):
-    """ OrderedDict trait for Python < 3.6 (including Python 2) compatibility """
-
-    default_value = OrderedDict()
-    def validate(self, obj, value):
-        if not isinstance(value, OrderedDict):
-            raise tl.TraitError('...')
-        super(OrderedDictTrait, self).validate(obj, value)
-        return value
 
 class Coordinates(tl.HasTraits):
     """
@@ -47,10 +38,7 @@ class Coordinates(tl.HasTraits):
     coordinates
     """
 
-    if sys.version < '3.6':
-        _coords = OrderedDictTrait(trait=tl.Instance(BaseCoordinates))
-    else:
-        _coords = tl.Dict(trait=tl.Instance(BaseCoordinates))
+    _coords = OrderedDictTrait(trait=tl.Instance(BaseCoordinates))
 
     def __init__(self, coords=[], dims=None, coord_ref_sys=None, ctype=None, distance_units=None):
         """

--- a/podpac/core/data/test/test_types.py
+++ b/podpac/core/data/test/test_types.py
@@ -83,7 +83,7 @@ class TestArray(object):
     def test_definition(self):
         node = Array(source=self.data)
         pipeline = podpac.pipeline.Pipeline(definition=node.definition)
-        np.testing.assert_array_equal(pipeline.nodes['Array'].source, self.data)
+        np.testing.assert_array_equal(pipeline.node.source, self.data)
 
 class TestPyDAP(object):
     """test pydap datasource"""

--- a/podpac/core/pipeline/test/test_pipeline.py
+++ b/podpac/core/pipeline/test/test_pipeline.py
@@ -20,6 +20,51 @@ node = Arange()
 node.eval(coords)
 
 class TestPipeline(object):
+    def test_init_path(self):
+        path = os.path.join(os.path.abspath(podpac.__path__[0]), 'core', 'pipeline', 'test', 'test.json')
+        pipeline = Pipeline(path=path)
+        
+        assert pipeline.json
+        assert pipeline.definition
+        assert pipeline.output
+
+    def test_init_json(self):
+        s = '''
+        {
+            "nodes": {
+                "a": {
+                    "node": "core.algorithm.algorithm.Arange"
+                }
+            }
+        }
+        '''
+
+        pipeline = Pipeline(json=s)
+        assert pipeline.json
+        assert pipeline.definition
+        assert pipeline.output
+
+    def test_init_definition(self):
+        s = '''
+        {
+            "nodes": {
+                "a": {
+                    "node": "core.algorithm.algorithm.Arange"
+                }
+            }
+        }
+        '''
+        
+        d = json.loads(s, object_pairs_hook=OrderedDict)
+
+        pipeline = Pipeline(definition=d)
+        assert pipeline.json
+        assert pipeline.definition
+        assert pipeline.output
+
+    def test_init_error(self):
+        pass
+
     def test_eval(self):
         s = '''
         {
@@ -31,8 +76,7 @@ class TestPipeline(object):
         }
         '''
 
-        d = json.loads(s, object_pairs_hook=OrderedDict)
-        pipeline = Pipeline(definition=d)
+        pipeline = Pipeline(json=s)
         pipeline.eval(coords)
         
         pipeline.units
@@ -59,36 +103,33 @@ class TestPipeline(object):
         }
         '''
 
-        d = json.loads(s, object_pairs_hook=OrderedDict)
-        pipeline = Pipeline(definition=d)
+        pipeline = Pipeline(json=s)
         pipeline.eval(coords)
-        assert pipeline.pipeline_output.path is not None
-        assert os.path.isfile(pipeline.pipeline_output.path)
-        os.remove(pipeline.pipeline_output.path)
+        assert pipeline.output.path is not None
+        assert os.path.isfile(pipeline.output.path)
+        os.remove(pipeline.output.path)
 
-    def test_eval_from_file(self):
-        path = os.path.join(os.path.abspath(podpac.__path__[0]), 'core', 'pipeline', 'test', 'test.json')
-        pipeline = Pipeline(path=path)
-        pipeline.eval(coords)
+    def test_eval_no_output(self):
+        path = os.path.join(os.path.abspath(podpac.__path__[0]), 'core', 'pipeline', 'test')
 
-        assert pipeline.definition['nodes']
-        assert pipeline.definition['output']
-        assert isinstance(pipeline.nodes['a'], podpac.core.algorithm.algorithm.Arange)
-        assert isinstance(pipeline.pipeline_output, FileOutput)
-        assert pipeline.pipeline_output.path is not None
-        assert os.path.isfile(pipeline.pipeline_output.path)
-        os.remove(pipeline.pipeline_output.path)
-
-    def test_eval_from_json(self):
         s = '''
         {
             "nodes": {
                 "a": {
                     "node": "core.algorithm.algorithm.Arange"
                 }
+            },
+            "output": {
+                "node": "a",
+                "mode": "file",
+                "format": "pickle",
+                "outdir": "."
             }
         }
         '''
 
-        pipeline = Pipeline(json=s)
+        pipeline = Pipeline(json=s, do_write_output=False)
         pipeline.eval(coords)
+        if pipeline.output.path is not None and os.path.isfile(pipeline.output.path):
+            os.remove(pipeline.output.path)
+        assert pipeline.output.path is None

--- a/podpac/core/pipeline/test/test_pipeline_util.py
+++ b/podpac/core/pipeline/test/test_pipeline_util.py
@@ -53,8 +53,8 @@ class TestParsePipelineDefinition(object):
         '''
 
         d = json.loads(s, object_pairs_hook=OrderedDict)
-        nodes, output = parse_pipeline_definition(d)
-        assert nodes['mydata'].source == "my_data_string"
+        output = parse_pipeline_definition(d)
+        assert output.node.source == "my_data_string"
 
         # not required
         s = '''
@@ -68,7 +68,7 @@ class TestParsePipelineDefinition(object):
         '''
 
         d = json.loads(s, object_pairs_hook=OrderedDict)
-        nodes, output = parse_pipeline_definition(d)
+        output = parse_pipeline_definition(d)
 
         # incorrect
         s = '''
@@ -111,9 +111,8 @@ class TestParsePipelineDefinition(object):
         '''
 
         d = json.loads(s, object_pairs_hook=OrderedDict)
-        nodes, output = parse_pipeline_definition(d)
-        assert nodes['mydata'].source == 'my_data_string'
-        assert nodes['mydata2'].source == 'my_data_string'
+        output = parse_pipeline_definition(d)
+        assert output.node.source == 'my_data_string'
 
         # nonexistent node
         s = '''
@@ -246,8 +245,9 @@ class TestParsePipelineDefinition(object):
         '''
 
         d = json.loads(s, object_pairs_hook=OrderedDict)
-        nodes, output = parse_pipeline_definition(d)
-        assert nodes['reprojected'].source is nodes['mysource']
+        output = parse_pipeline_definition(d)
+        assert output.node.source
+        assert output.node.source.source == 'my_data_string'
         
         # lookup_source subattr
         s = '''
@@ -271,9 +271,9 @@ class TestParsePipelineDefinition(object):
         '''
 
         d = json.loads(s, object_pairs_hook=OrderedDict)
-        nodes, output = parse_pipeline_definition(d)
-        assert nodes['double'].A is nodes['mysource']
-        assert nodes['reprojected'].source is nodes['mysource']
+        output = parse_pipeline_definition(d)
+        assert output.node.source
+        assert output.node.source.source == "my_data_string"
 
         # nonexistent node/attribute references are tested in test_datasource_lookup_source
 
@@ -290,8 +290,8 @@ class TestParsePipelineDefinition(object):
         '''
 
         d = json.loads(s, object_pairs_hook=OrderedDict)
-        nodes, output = parse_pipeline_definition(d)
-        np.testing.assert_array_equal(nodes['mysource'].source, [0, 1, 2])
+        output = parse_pipeline_definition(d)
+        np.testing.assert_array_equal(output.node.source, [0, 1, 2])
 
     def test_array_lookup_source(self):
         # source doesn't work
@@ -331,9 +331,8 @@ class TestParsePipelineDefinition(object):
         '''
 
         d = json.loads(s, object_pairs_hook=OrderedDict)
-        nodes, output = parse_pipeline_definition(d)
-        np.testing.assert_array_equal(nodes['a'].source, [0, 1, 2])
-        np.testing.assert_array_equal(nodes['b'].source, [0, 1, 2])
+        output = parse_pipeline_definition(d)
+        np.testing.assert_array_equal(output.node.source, [0, 1, 2])
 
     def test_algorithm_inputs(self):
         # basic
@@ -341,7 +340,7 @@ class TestParsePipelineDefinition(object):
         {
             "nodes": {
                 "source1": {"node": "algorithm.Arange"},
-                "source2": {"node": "algorithm.Arange"},
+                "source2": {"node": "algorithm.CoordData"},
                 "result": {        
                     "node": "algorithm.Arithmetic",
                     "inputs": {
@@ -357,10 +356,10 @@ class TestParsePipelineDefinition(object):
         '''
 
         d = json.loads(s, object_pairs_hook=OrderedDict)
-        nodes, output = parse_pipeline_definition(d)
+        output = parse_pipeline_definition(d)
 
-        assert nodes['result'].A is nodes['source1']
-        assert nodes['result'].B is nodes['source2']
+        assert isinstance(output.node.A, podpac.algorithm.Arange)
+        assert isinstance(output.node.B, podpac.algorithm.CoordData)
 
         # sub-node
         s = '''
@@ -382,10 +381,9 @@ class TestParsePipelineDefinition(object):
         '''
 
         d = json.loads(s, object_pairs_hook=OrderedDict)
-        nodes, output = parse_pipeline_definition(d)
+        output = parse_pipeline_definition(d)
 
-        assert nodes['double'].A is nodes['mysource']
-        assert nodes['quadruple'].A is nodes['mysource']
+        assert isinstance(output.node.A, podpac.algorithm.Arange)
 
         # nonexistent node/attribute references are tested in test_datasource_lookup_source
 
@@ -395,7 +393,7 @@ class TestParsePipelineDefinition(object):
         {
             "nodes": {
                 "a": {"node": "algorithm.Arange"},
-                "b": {"node": "algorithm.Arange"},
+                "b": {"node": "algorithm.CoordData"},
                 "c": {
                     "node": "compositor.OrderedCompositor",
                     "sources": ["a", "b"]
@@ -405,16 +403,16 @@ class TestParsePipelineDefinition(object):
         '''
 
         d = json.loads(s, object_pairs_hook=OrderedDict)
-        nodes, output = parse_pipeline_definition(d)
-        assert nodes['c'].sources[0] is nodes['a']
-        assert nodes['c'].sources[1] is nodes['b']
+        output = parse_pipeline_definition(d)
+        assert isinstance(output.node.sources[0], podpac.algorithm.Arange)
+        assert isinstance(output.node.sources[1], podpac.algorithm.CoordData)
 
         # sub-node
         s = '''
         {
             "nodes": {
                 "source1": {"node": "algorithm.Arange"},
-                "source2": {"node": "algorithm.Arange"},
+                "source2": {"node": "algorithm.CoordData"},
                 "double": {
                     "node": "algorithm.Arithmetic",
                     "inputs": { "A": "source1" },
@@ -429,9 +427,9 @@ class TestParsePipelineDefinition(object):
         '''
 
         d = json.loads(s, object_pairs_hook=OrderedDict)
-        nodes, output = parse_pipeline_definition(d)
-        assert nodes['c'].sources[0] is nodes['source1']
-        assert nodes['c'].sources[1] is nodes['source2']
+        output = parse_pipeline_definition(d)
+        assert isinstance(output.node.sources[0], podpac.algorithm.Arange)
+        assert isinstance(output.node.sources[1], podpac.algorithm.CoordData)
 
         # nonexistent node/attribute references are tested in test_datasource_lookup_source
 
@@ -449,8 +447,8 @@ class TestParsePipelineDefinition(object):
         '''
 
         d = json.loads(s, object_pairs_hook=OrderedDict)
-        nodes, output = parse_pipeline_definition(d)
-        assert nodes['mydata'].interpolation == "nearest"
+        output = parse_pipeline_definition(d)
+        assert output.node.interpolation == "nearest"
 
         # not required
         s = '''
@@ -464,7 +462,7 @@ class TestParsePipelineDefinition(object):
         '''
 
         d = json.loads(s, object_pairs_hook=OrderedDict)
-        nodes, output = parse_pipeline_definition(d)
+        output = parse_pipeline_definition(d)
 
         # incorrect
         s = '''
@@ -504,8 +502,8 @@ class TestParsePipelineDefinition(object):
         '''
 
         d = json.loads(s, object_pairs_hook=OrderedDict)
-        nodes, output = parse_pipeline_definition(d)
-        assert nodes['c'].interpolation == "nearest"
+        output = parse_pipeline_definition(d)
+        assert output.node.interpolation == "nearest"
 
 
     def test_attrs(self):
@@ -523,8 +521,8 @@ class TestParsePipelineDefinition(object):
         '''
 
         d = json.loads(s, object_pairs_hook=OrderedDict)
-        nodes, output = parse_pipeline_definition(d)
-        assert nodes['sm'].product == "SPL4SMGP"
+        output = parse_pipeline_definition(d)
+        assert output.node.product == "SPL4SMGP"
 
     def test_lookup_attrs(self):
         # attrs doesn't work
@@ -544,10 +542,9 @@ class TestParsePipelineDefinition(object):
         '''
 
         d = json.loads(s, object_pairs_hook=OrderedDict)
-        nodes, output = parse_pipeline_definition(d)
-        assert nodes['a'].coord_name == 'lat'
+        output = parse_pipeline_definition(d)
         with pytest.raises(AssertionError):
-            assert nodes['b'].coord_name == 'lat'
+            assert output.node.coord_name == 'lat'
 
         # but lookup_attrs does
         s = '''
@@ -566,9 +563,8 @@ class TestParsePipelineDefinition(object):
         '''
 
         d = json.loads(s, object_pairs_hook=OrderedDict)
-        nodes, output = parse_pipeline_definition(d)
-        assert nodes['a'].coord_name == 'lat'
-        assert nodes['b'].coord_name == 'lat'
+        output = parse_pipeline_definition(d)
+        assert output.node.coord_name == 'lat'
 
         # NOTE: no nodes currently have a Node as an attr
         # # lookup node directly (instead of a sub-attr)
@@ -589,8 +585,8 @@ class TestParsePipelineDefinition(object):
         # '''
 
         # d = json.loads(s, object_pairs_hook=OrderedDict)
-        # nodes, output = parse_pipeline_definition(d)
-        # assert nodes['mynode'].my_node_attr is nodes['mysource']
+        # output = parse_pipeline_definition(d)
+        # assert isinstance(output.node.my_node_attr, DataSource)
 
         # nonexistent node/attribute references are tested in test_datasource_lookup_source
 
@@ -621,9 +617,9 @@ class TestParsePipelineDefinition(object):
         }
         '''
         d = json.loads(s, object_pairs_hook=OrderedDict)
-        nodes, output = parse_pipeline_definition(d)
+        output = parse_pipeline_definition(d)
         assert isinstance(output, NoOutput)
-        assert output.node is nodes['a']
+        assert isinstance(output.node, podpac.algorithm.Arange)
         assert output.name == 'a'
 
     def test_parse_output_file(self):
@@ -639,9 +635,9 @@ class TestParsePipelineDefinition(object):
         }
         '''
         d = json.loads(s, object_pairs_hook=OrderedDict)
-        nodes, output = parse_pipeline_definition(d)
+        output = parse_pipeline_definition(d)
         assert isinstance(output, FileOutput)
-        assert output.node is nodes['a']
+        assert isinstance(output.node, podpac.algorithm.Arange)
         assert output.name == 'a'
         assert output.format == 'pickle'
         assert output.outdir == 'my_directory'
@@ -659,9 +655,9 @@ class TestParsePipelineDefinition(object):
         }
         '''
         d = json.loads(s, object_pairs_hook=OrderedDict)
-        nodes, output = parse_pipeline_definition(d)
+        output = parse_pipeline_definition(d)
         assert isinstance(output, S3Output)
-        assert output.node is nodes['a']
+        assert isinstance(output.node, podpac.algorithm.Arange)
         assert output.name == 'a'
         assert output.user == 'my_user'
         assert output.bucket == 'my_bucket'
@@ -679,9 +675,9 @@ class TestParsePipelineDefinition(object):
         }
         '''
         d = json.loads(s, object_pairs_hook=OrderedDict)
-        nodes, output = parse_pipeline_definition(d)
+        output = parse_pipeline_definition(d)
         assert isinstance(output, FTPOutput)
-        assert output.node is nodes['a']
+        assert isinstance(output.node, podpac.algorithm.Arange)
         assert output.name == 'a'
         assert output.user == 'my_user'
         assert output.url == 'my_url'
@@ -698,9 +694,9 @@ class TestParsePipelineDefinition(object):
         }
         '''
         d = json.loads(s, object_pairs_hook=OrderedDict)
-        nodes, output = parse_pipeline_definition(d)
+        output = parse_pipeline_definition(d)
         assert isinstance(output, ImageOutput)
-        assert output.node is nodes['a']
+        assert isinstance(output.node, podpac.algorithm.Arange)
         assert output.name == 'a'
 
     def test_parse_output_invalid_mode(self):
@@ -723,9 +719,9 @@ class TestParsePipelineDefinition(object):
         }
         '''
         d = json.loads(s, object_pairs_hook=OrderedDict)
-        nodes, output = parse_pipeline_definition(d)
+        output = parse_pipeline_definition(d)
         assert isinstance(output, NoOutput)
-        assert output.node is nodes['a']
+        assert isinstance(output.node, podpac.algorithm.Arange)
         assert output.name == 'a'
 
     def test_parse_output_nonexistent_node(self):
@@ -767,8 +763,8 @@ class TestParsePipelineDefinition(object):
         }
         '''
         d = json.loads(s, object_pairs_hook=OrderedDict)
-        nodes, output = parse_pipeline_definition(d)
-        assert output.node is nodes['result']
+        output = parse_pipeline_definition(d)
+        assert isinstance(output.node, podpac.algorithm.Arithmetic)
 
     def test_parse_output_implicit(self):
         s = '''
@@ -777,9 +773,9 @@ class TestParsePipelineDefinition(object):
         }
         '''
         d = json.loads(s, object_pairs_hook=OrderedDict)
-        nodes, output = parse_pipeline_definition(d)
+        output = parse_pipeline_definition(d)
         assert isinstance(output, NoOutput)
-        assert output.node is nodes['a']
+        assert isinstance(output.node, podpac.algorithm.Arange)
         assert output.name == 'a'
 
     def test_parse_custom_output(self):
@@ -793,7 +789,7 @@ class TestParsePipelineDefinition(object):
         '''
 
         d = json.loads(s, object_pairs_hook=OrderedDict)
-        nodes, output = parse_pipeline_definition(d)
+        output = parse_pipeline_definition(d)
         assert isinstance(output, ImageOutput)
 
         s = ''' {
@@ -806,7 +802,7 @@ class TestParsePipelineDefinition(object):
         '''
 
         d = json.loads(s, object_pairs_hook=OrderedDict)
-        nodes, output = parse_pipeline_definition(d)
+        output = parse_pipeline_definition(d)
         assert isinstance(output, ImageOutput)
 
     def test_parse_custom_output_invalid(self):

--- a/podpac/core/pipeline/util.py
+++ b/podpac/core/pipeline/util.py
@@ -38,7 +38,7 @@ def parse_pipeline_definition(definition):
     # parse output definition
     output = _parse_output_definition(nodes, definition.get('output', {}))
 
-    return nodes, output
+    return output
 
 def _parse_node_definition(nodes, name, d):
     # get node class

--- a/podpac/core/test/test_node.py
+++ b/podpac/core/test/test_node.py
@@ -88,14 +88,13 @@ class TestNode(object):
         # make sure it is a valid pipeline
         pipeline = podpac.pipeline.Pipeline(definition=definition)
 
-        assert isinstance(pipeline.nodes[a.base_ref], podpac.algorithm.Arange)
-        assert isinstance(pipeline.nodes[b.base_ref], podpac.algorithm.CoordData)
-        assert isinstance(pipeline.nodes[c.base_ref], podpac.compositor.OrderedCompositor)
-        assert isinstance(pipeline.nodes[node.base_ref], podpac.algorithm.Arithmetic)
-        assert isinstance(pipeline.pipeline_output, podpac.pipeline.NoOutput)
+        assert isinstance(pipeline.node.A, podpac.algorithm.Arange)
+        assert isinstance(pipeline.node.B, podpac.algorithm.CoordData)
+        assert isinstance(pipeline.node.C, podpac.compositor.OrderedCompositor)
+        assert isinstance(pipeline.node, podpac.algorithm.Arithmetic)
 
-        assert pipeline.pipeline_output.node is pipeline.nodes[node.base_ref]
-        assert pipeline.pipeline_output.name == node.base_ref
+        assert isinstance(pipeline.output, podpac.pipeline.NoOutput)
+        assert pipeline.output.name == node.base_ref
 
     def test_make_pipeline_definition_duplicate_ref(self):
         a = podpac.algorithm.Arange()
@@ -109,7 +108,7 @@ class TestNode(object):
         pipeline = podpac.pipeline.Pipeline(definition=definition)
 
         # check that the arange refs are unique
-        assert len(pipeline.nodes) == 4
+        assert len(pipeline.definition['nodes']) == 4
         
     def test_pipeline(self):
         n = Node()

--- a/podpac/core/utils.py
+++ b/podpac/core/utils.py
@@ -5,8 +5,10 @@ Utils Summary
 from __future__ import division, unicode_literals, print_function, absolute_import
 
 import os
+import sys
 import json
 import importlib
+from collections import OrderedDict
 
 import traitlets as tl
 import numpy as np
@@ -209,3 +211,19 @@ def optional_import(module_name, package=None, return_root=False):
         except ImportError:
             module = None
     return module
+
+if sys.version < '3.6':
+    # for Python 2 and Python < 3.6 compatibility
+    class OrderedDictTrait(tl.Dict):
+        """ OrderedDict trait """
+
+        default_value = OrderedDict()
+        
+        def validate(self, obj, value):
+            if not isinstance(value, OrderedDict):
+                raise tl.TraitError('...')
+            super(OrderedDictTrait, self).validate(obj, value)
+            return value
+
+else:
+    OrderedDictTrait = tl.Dict

--- a/podpac/datalib/nsidc_smap_opendap_url.txt
+++ b/podpac/datalib/nsidc_smap_opendap_url.txt
@@ -1,1 +1,1 @@
-https://n5eil01u.ecs.nsidc.org/opendap/SMAP
+https://n5eil02u.ecs.nsidc.org/opendap/SMAP


### PR DESCRIPTION
 - Removes assignments in Pipeline validators
 - The Pipeline json attribute is defined when the Pipeline is initialized using a `path` or `definition` argument
 - Units tests are added to cover these cases
 - The AWS workaround is removed

Closes #141 