### PR TITLE
FEATURE: second attempt at the log - see contributing.md "## Logging"

### DIFF
--- a/doc/source/developer/contributing.md
+++ b/doc/source/developer/contributing.md
@@ -105,6 +105,51 @@ $ pylint podpac/settings.py     # lint single file
 
 Configuration options are specified in `.pylintrc`.
 
+## Logging
+
+We use the python `logging` library to support library logging.
+To include logging in your module, use:
+
+```python
+import logging
+log = logging.getLogger(__name__)  # creates a logger with the current module name
+
+# log a message
+log.debug('Debug message')
+log.info('Info message')
+log.warning('Warning message')
+log.error('Error message')
+```
+
+Do not set levels, handlers, or formatters in your modules.
+See the [python logging documentation](https://docs.python.org/3/library/logging.html#logging.Logger.debug) for details on how to construct log messages.
+
+To handling logging in your application, you can use a simple config:
+
+```python
+import logging
+logging.basicConfig(level=logging.INFO)  # log to console
+logging.basicConfig(level=logging.INFO, filename='podpac.log')  # log to a file podpac.log
+```
+
+or a more complicated configuration which handles only podpac logs:
+
+```python
+# log only podpac logs
+log = logging.getLogger('podpac')
+log.setLevel(logging.DEBUG)
+
+# log only podpac logs in a file
+import logging
+from logging import FileHandler
+log = logging.getLogger('podpac')
+log.setLevel(logging.DEBUG)
+log.addHandler(FileHandler('podpac.log', 'w'))
+```
+
+We have created a convience method `create_logfile()` in the `podpac.utils` module to
+automatically create a log file for only podpac logs.
+
 ## Import Conventions / API Conventions
 
 ### Public API

--- a/podpac/core/data/datasource.py
+++ b/podpac/core/data/datasource.py
@@ -8,6 +8,7 @@ including user defined data sources.
 from __future__ import division, unicode_literals, print_function, absolute_import
 from collections import OrderedDict
 import warnings
+import logging
 
 import numpy as np
 import xarray as xr
@@ -20,6 +21,8 @@ from podpac.core.node import Node, NodeException
 from podpac.core.utils import common_doc, trait_is_defined
 from podpac.core.node import COMMON_NODE_DOC
 from podpac.core.data.interpolate import Interpolation, interpolation_trait
+
+log = logging.getLogger(__name__)
 
 DATA_DOC = {
     'native_coordinates': 'The coordinates of the data source.',
@@ -268,6 +271,8 @@ class DataSource(Node):
         ValueError
             Cannot evaluate these coordinates
         """
+
+        log.debug('Evaluating {} data source'.format(self.__class__.__name__))
 
         if self.coordinate_index_type != 'numpy':
             warnings.warn('Coordinates index type {} is not yet supported.'.format(self.coordinate_index_type) +

--- a/podpac/core/test/test_utils.py
+++ b/podpac/core/test/test_utils.py
@@ -126,3 +126,9 @@ class TestCommonDocs(object):
         f2 = ut.common_doc({"key": "value"})(f)
         assert f(42) == f2(42)
         assert f.__doc__ is None
+
+
+# TODO: add log testing
+class TestLog(object):
+    def test_create_log(self):
+        pass

--- a/podpac/core/utils.py
+++ b/podpac/core/utils.py
@@ -9,9 +9,13 @@ import sys
 import json
 import importlib
 from collections import OrderedDict
+import logging
 
 import traitlets as tl
 import numpy as np
+
+# create log for module
+_log = logging.getLogger(__name__)
 
 def common_doc(doc_dict):
     """ Decorator: replaces commond fields in a function docstring
@@ -211,6 +215,50 @@ def optional_import(module_name, package=None, return_root=False):
         except ImportError:
             module = None
     return module
+
+def create_logfile(filename='podpac.log',
+                   level=logging.INFO,
+                   format='[%(asctime)s] %(name)s - %(levelname)s - %(message)s'):
+    """Convience method to create a log file that only logs
+    podpac related messages
+    
+    Parameters
+    ----------
+    filename : str, optional
+        Filename of the log file. Defaults to ``podpac.log``
+    level : int, optional
+        Log level to use (0 - 50). Defaults to ``logging.INFO`` (20)
+        See https://docs.python.org/3/library/logging.html#levels
+    format : str, optional
+        String format for log messages.
+        See https://docs.python.org/3/library/logging.html#logrecord-attributes
+        for creating format
+    
+    Returns
+    -------
+    logging.Logger, logging.Handler, logging.Formatter
+        Returns the constructed logger, handler, and formatter for the log file
+    """
+    # get logger for podpac module only
+    log = logging.getLogger('podpac')
+    log.setLevel(level)
+
+    # create a file handler
+    handler = logging.FileHandler(filename, 'a')
+
+    # create a logging format
+    # see https://docs.python.org/3/library/logging.html#logrecord-attributes
+    formatter = logging.Formatter(format)
+    handler.setFormatter(formatter)
+
+    # add the handlers to the logger
+    log.addHandler(handler)
+
+    # insert log from utils into logfile
+    _log.info('created logfile')
+
+    return log, handler, formatter
+
 
 if sys.version < '3.6':
     # for Python 2 and Python < 3.6 compatibility


### PR DESCRIPTION
This includes one util method for creating podpac only log handler - i'm open to removing this, but this seems like a good middle road.

BasicConfig will work for most people, but unfortuantely there is no way to configure this to be a podpac only logger (i.e. you get all other module logging as well). This util method will create a log file with a specific format that has podpac ONLY logs.