### PR TITLE
Sets attribute __doc__ strings directly so that they will be inherited

### DIFF
--- a/doc/source/developer/contributing.md
+++ b/doc/source/developer/contributing.md
@@ -50,9 +50,9 @@ Examples:
 - https://docs.scipy.org/doc/numpy/docs/howto_document.html#example-source
 
 Note that class attributes can be documented multiple ways.
- - Public attributes (traits) should be documented in the preceding line with `#: <type> : <description>.`
- - Public properties created with the `@property` decorator should be documented in the getter method.
- - Additionaly, document key public attributes and properties again in the main class docs under `Parameters`.
+ - Key public attributes and properties should be documented in the main class docstring under `Parameters`.
+ - All public attributes (traits) should be documented in the subsequent line by setting its `__doc__` property.
+ - All public properties created with the `@property` decorator should be documented in the getter method.
 
 ```python
 class ExampleClass(tl.HasTraits):
@@ -68,45 +68,20 @@ class ExampleClass(tl.HasTraits):
         Description of attr2.
     """
 
-    #: str : Description of attr1
     attr1 = tl.Str()
+    attr.__doc__ = ":str: Description of attr1"
 
-    #: dict : Description of attr2
     attr2 = tl.Dict(allow_none=True)
+    attr2.__doc__ = ":dict: Description of attr2"
 
-    #: int : Description of secondary attr3
     attr3 : tl.Int()
+    attr2.__doc__ = ":int: Description of secondary attr3"
 
     @property
     def attr4(self):
         """:bool: Description of attr4."""
 
         return True
-```
-
-The docstrings for inherited traits are not inherited. You must define inherited traits again in child classes:
-
-```python
-class ExampleChild(ExampleClass):
-    """Summary.
-
-    ...
-    """
-
-    #: str : Description of my_attr (not inherited)
-    my_attr = tl.Str()
-
-    # inherited traits, duplicated here for the docstrings:
-
-    #: str : Description of attr1
-    attr1 = tl.Str()
-
-    #: dict : Description of attr2
-    attr2 = tl.Dict(allow_none=True)
-
-    #: int : Description of secondary attr3
-    attr3 : tl.Int()
-
 ```
 
 #### References

--- a/podpac/core/coordinates/array_coordinates1d.py
+++ b/podpac/core/coordinates/array_coordinates1d.py
@@ -47,32 +47,8 @@ class ArrayCoordinates1d(Coordinates1d):
     :class:`Coordinates1d`, :class:`UniformCoordinates1d`
     """
 
-    #: array : User-defined coordinate values
     coords = tl.Instance(np.ndarray)
-
-    #:str: Dimension name, one of 'lat', 'lon', 'time', or 'alt'.
-    name = tl.Enum(['lat', 'lon', 'time', 'alt'], allow_none=True)
-
-    #: Units : Coordinate units.
-    units = tl.Instance(Units, allow_none=True)
-
-    #: str : Coordinate reference system.
-    coord_ref_sys = tl.Enum(['WGS84', 'SPHER_MERC'], allow_none=True)
-
-    #: str : Coordinates type, on of 'point', 'left', 'right', or 'midpoint'.
-    ctype = tl.Enum(['point', 'left', 'right', 'midpoint'])
-
-    #: : *To be replaced.*
-    extents = tl.Instance(np.ndarray, allow_none=True, default_value=None)
-
-    #: bool : Are the coordinate values unique and sorted.
-    is_monotonic = tl.CBool(allow_none=True, readonly=True)
-    
-    #: bool : Are the coordinate values sorted in descending order.
-    is_descending = tl.CBool(allow_none=True, readonly=True)
-
-    #: bool : Are the coordinate values uniformly-spaced.
-    is_uniform = tl.CBool(allow_none=True, readonly=True)
+    coords.__doc__ = ":array: User-defined coordinate values"
 
     def __init__(self, coords, name=None, ctype=None, units=None, extents=None, coord_ref_sys=None):
         """

--- a/podpac/core/coordinates/coordinates1d.py
+++ b/podpac/core/coordinates/coordinates1d.py
@@ -56,29 +56,29 @@ class Coordinates1d(BaseCoordinates):
     :class:`ArrayCoordinates1d`, :class:`UniformCoordinates1d`
     """
 
-    #:str: Dimension name, one of 'lat', 'lon', 'time', or 'alt'.
     name = tl.Enum(['lat', 'lon', 'time', 'alt'], allow_none=True)
+    name.__doc__ = ":str: Dimension name, one of 'lat', 'lon', 'time', or 'alt'"
 
-    #: Units : Coordinate units.
     units = tl.Instance(Units, allow_none=True)
+    units.__doc__ = ":Units: Coordinate units."
 
-    #: str : Coordinate reference system.
     coord_ref_sys = tl.Enum(['WGS84', 'SPHER_MERC'], allow_none=True)
+    coord_ref_sys.__doc__ = ":str: Coordinate reference system."
 
-    #: str : Coordinates type, one of 'point', 'left', 'right', or 'midpoint'.
     ctype = tl.Enum(['point', 'left', 'right', 'midpoint'])
+    ctype.__doc__ = ":str: Coordinates type, one of 'point', 'left', 'right', or 'midpoint'."
 
-    #: : *To be replaced.*
     extents = tl.Instance(np.ndarray, allow_none=True, default_value=None)
+    extents.__doc__ = ":: *To be replaced.*"
 
-    #: bool : Are the coordinate values unique and sorted.
     is_monotonic = tl.CBool(allow_none=True, readonly=True)
+    is_monotonic.__doc__ = ":bool: Are the coordinate values unique and sorted."
     
-    #: bool : Are the coordinate values sorted in descending order.
     is_descending = tl.CBool(allow_none=True, readonly=True)
+    is_descending.__doc__ = ":bool: Are the coordinate values sorted in descending order."
 
-    #: bool : Are the coordinate values uniformly-spaced.
     is_uniform = tl.CBool(allow_none=True, readonly=True)
+    is_uniform.__doc__ = ":bool: Are the coordinate values uniformly-spaced."
 
     def __init__(self, name=None, ctype=None, units=None, extents=None, coord_ref_sys=None, **kwargs):
         """*Do not use.*"""

--- a/podpac/core/coordinates/uniform_coordinates1d.py
+++ b/podpac/core/coordinates/uniform_coordinates1d.py
@@ -53,38 +53,20 @@ class UniformCoordinates1d(Coordinates1d):
     :class:`Coordinates1d`, :class:`ArrayCoordinates1d`, :class:`crange`, :class:`clinspace`
     """
 
-    #:float, datetime64: Start coordinate.
     start = tl.Union([tl.Float(), tl.Instance(np.datetime64)])
+    start.__doc__ = ":float, datetime64: Start coordinate."
     
-    #:float, datetime64: Stop coordinate.
     stop = tl.Union([tl.Float(), tl.Instance(np.datetime64)])
+    stop.__doc__ = ":float, datetime64: Stop coordinate."
 
-    #:float, timedelta64: Signed, non-zero step between coordinates.
     step = tl.Union([tl.Float(), tl.Instance(np.timedelta64)])
+    step.__doc__ = ":float, timedelta64: Signed, non-zero step between coordinates."
 
-    #:str: Dimension name, one of 'lat', 'lon', 'time', or 'alt'.
-    name = tl.Enum(['lat', 'lon', 'time', 'alt'], allow_none=True)
-
-    #: Units : Coordinate units.
-    units = tl.Instance(Units, allow_none=True)
-
-    #: str : Coordinate reference system.
-    coord_ref_sys = tl.Enum(['WGS84', 'SPHER_MERC'], allow_none=True)
-
-    #: str : Coordinates type, one of 'point', 'left', 'right', or 'midpoint'.
-    ctype = tl.Enum(['point', 'left', 'right', 'midpoint'])
-
-    #: : *To be replaced.*
-    extents = tl.Instance(np.ndarray, allow_none=True, default_value=None)
-
-    #: bool : Are the coordinate values unique and sorted (always True).
     is_monotonic = tl.CBool(True, readonly=True)
-
-    #: bool : Are the coordinate values sorted in descending order.
-    is_descending = tl.CBool(allow_none=True, readonly=True)
+    is_monotonic.__doc__ = ":bool: Are the coordinate values unique and sorted (always True)."
     
-    #: bool : Are the coordinate values uniformly-spaced (always True).
     is_uniform = tl.CBool(True, readonly=True)
+    is_uniform.__doc__ = ":bool: Are the coordinate values uniformly-spaced (always True)."
 
     def __init__(self, start, stop, step=None, size=None, name=None, ctype=None, units=None, coord_ref_sys=None, extents=None):
         """


### PR DESCRIPTION
A wrote a class decorator to set the `__doc__` strings for `class_traits`, but that didn't work for a few reasons. What do you think of this? It is the basically the same as writing  `#:` or `""" """` docstrings that Sphinx picks up (and Sphinx displays them exactly the same), but they are inherited properly.