### PR TITLE
Fix datasource eval when output is provided

### DIFF
--- a/podpac/core/data/datasource.py
+++ b/podpac/core/data/datasource.py
@@ -328,13 +328,14 @@ class DataSource(Node):
         # get data from data source
         self._requested_source_data = self._get_data(coordinates)
 
-        # if output is not input to evaluate, create it using the evaluated coordinates
+        # if not provided, create output using the evaluated coordinates, or
+        # if provided, set the order of coordinates to match the output dims
         if output is None:
+            requested_dims = None
             output = self.create_output_array(coordinates)
-
-        # set the order of dims to be the same as that of evaluated coordinates
-        # this is required in case the user supplied an output object with a different dims order
-        output = output.transpose(*coordinates.dims)
+        else:
+            requested_dims = coordinates.dims
+            coordinates = coordinates.transpose(*output.dims)
 
         # interpolate data into output
         output = self._interpolation.interpolate(self._requested_source_coordinates,
@@ -342,6 +343,9 @@ class DataSource(Node):
                                                  coordinates,
                                                  output)
 
+        # return the output to the originally requested output dims
+        if requested_dims is not None and requested_dims != output.dims:
+            output = output.transpose(*requested_dims)
         
         # save output to private for debugging
         self._output = output

--- a/podpac/core/data/test/test_datasource.py
+++ b/podpac/core/data/test/test_datasource.py
@@ -222,10 +222,16 @@ class TestDataSource(object):
         # evaluate with dims=[lat, lon], passing in the output
         node = MockDataSource()
         output = node.create_output_array(coords.transpose('lon', 'lat'))
-        node.eval(coords, output=output)
+        returned_output = node.eval(coords, output=output)
         
+        # returned output sohuld match the requested coordinates
+        assert returned_output.dims == ('lat', 'lon')
+
         # dims should stay in the order of the output, rather than the order of the requested coordinates
         assert output.dims == ('lon', 'lat')
+
+        # output data and returned output data should match
+        np.testing.assert_equal(output.transpose('lat', 'lon').data, returned_output.data)
 
     def test_evaluate_extra_dims(self):
         # drop extra dimension
@@ -358,4 +364,3 @@ class TestInterpolateData(object):
 
         assert isinstance(output, UnitsDataArray)
         assert np.all(output.alt.values == coords_dst.coords['alt'])
-


### PR DESCRIPTION
I think this is a pretty simple/solid PR, but I just wanted to run it by you. I thought I would need to transpose the coordinates *earlier* so that `self._requested_source_coordinates` would also be transposed, but tests seem to be working so maybe this is just fine.