### PR TITLE
Feature/import faster

### DIFF
--- a/dist/aws/aws_requirements.txt
+++ b/dist/aws/aws_requirements.txt
@@ -12,3 +12,4 @@ pydap>=3.2
 rasterio>=0.36
 requests>=2.18
 numexpr>=2.6
+lazy-import>=0.2.2

--- a/podpac/__init__.py
+++ b/podpac/__init__.py
@@ -12,7 +12,7 @@ version_info : OrderedDict
 """
 
 
-# Monkey match os.makedirs for Python 2 compatibility
+# Monkey patch os.makedirs for Python 2 compatibility
 import sys
 import os
 _osmakedirs = os.makedirs

--- a/podpac/core/__init__.py
+++ b/podpac/core/__init__.py
@@ -1,5 +1,20 @@
+import sys
+
 # Lazy-import the core dependencies for faster import of PODPAC
 import lazy_import
+
+# Monkey-patch lazy_import for Python2 compatibility
+if sys.version_info.major == 2:
+    # Need to save a reference to the real function
+    lazy_import._old_lazy_module = lazy_import.lazy_module
+    
+    def lazy_module(modname, *args, **kwargs):
+        # Python 2 complains about unicode strings, so we turn the modname into a str
+        return lazy_import._old_lazy_module(str(modname), *args, **kwargs)
+    # Patch
+    lazy_import.lazy_module = lazy_module
+del sys
+
 requests = lazy_import.lazy_module('requests')
 pint = lazy_import.lazy_module('pint')
 plt = lazy_import.lazy_module('matplotlib.pyplot')

--- a/podpac/core/__init__.py
+++ b/podpac/core/__init__.py
@@ -1,1 +1,12 @@
+# Lazy-import the core dependencies for faster import of PODPAC
+import lazy_import
+requests = lazy_import.lazy_module('requests')
+pint = lazy_import.lazy_module('pint')
+plt = lazy_import.lazy_module('matplotlib.pyplot')
+np = lazy_import.lazy_module('numpy')
+sp = lazy_import.lazy_module('scipy')
+tl = lazy_import.lazy_module('traitlets')
+xr = lazy_import.lazy_module('xarray')
+
 from .managers import aws_lambda 
+

--- a/podpac/core/algorithm/algorithm.py
+++ b/podpac/core/algorithm/algorithm.py
@@ -290,7 +290,7 @@ class Arithmetic(Algorithm):
 
         try:
             result = ne.evaluate(eqn, f_locals)
-        except:
+        except ImportError:
             result = eval(eqn, f_locals)
         res = res[0].copy()  # Make an xarray object with correct dimensions
         res[:] = result

--- a/podpac/core/algorithm/algorithm.py
+++ b/podpac/core/algorithm/algorithm.py
@@ -9,12 +9,10 @@ import inspect
 import numpy as np
 import xarray as xr
 import traitlets as tl
-
-# Helper utility for optional imports
-from podpac.core.utils import optional_import
+from lazy_import import lazy_module
 
 # Optional dependencies
-ne = optional_import('numexpr')
+ne = lazy_module('numexpr')
 
 # Internal dependencies
 from podpac.core.coordinates import Coordinates, union
@@ -290,10 +288,10 @@ class Arithmetic(Algorithm):
         res = xr.broadcast(*[inputs[f] for f in fields])
         f_locals = dict(zip(fields, res))
 
-        if ne is None:
-            result = eval(eqn, f_locals)
-        else:
+        try:
             result = ne.evaluate(eqn, f_locals)
+        except:
+            result = eval(eqn, f_locals)
         res = res[0].copy()  # Make an xarray object with correct dimensions
         res[:] = result
         return res

--- a/podpac/core/data/test/test_types.py
+++ b/podpac/core/data/test/test_types.py
@@ -14,6 +14,7 @@ import pytest
 import numpy as np
 from traitlets import TraitError
 from xarray.core.coordinates import DataArrayCoordinates
+import pydap
 import pydap.client
 import rasterio
 import boto3
@@ -28,6 +29,9 @@ from podpac.core.data.datasource import COMMON_DATA_DOC, DataSource
 from podpac.core.data.types import WCS_DEFAULT_VERSION, WCS_DEFAULT_CRS
 from podpac.core.data.types import Array, PyDAP, Rasterio, WCS, ReprojectedSource, S3, CSV, H5PY
 from podpac.core.settings import settings
+
+# Trying to fix test
+pydap.client.open_url
 
 def test_allow_missing_modules():
     """TODO: Allow user to be missing rasterio and scipy"""

--- a/podpac/core/data/test/test_types.py
+++ b/podpac/core/data/test/test_types.py
@@ -30,6 +30,9 @@ from podpac.core.data.types import WCS_DEFAULT_VERSION, WCS_DEFAULT_CRS
 from podpac.core.data.types import Array, PyDAP, Rasterio, WCS, ReprojectedSource, S3, CSV, H5PY
 from podpac.core.settings import settings
 
+# Trying to fix test
+pydap.client.open_url
+
 def test_allow_missing_modules():
     """TODO: Allow user to be missing rasterio and scipy"""
     pass

--- a/podpac/core/data/test/test_types.py
+++ b/podpac/core/data/test/test_types.py
@@ -30,9 +30,6 @@ from podpac.core.data.types import WCS_DEFAULT_VERSION, WCS_DEFAULT_CRS
 from podpac.core.data.types import Array, PyDAP, Rasterio, WCS, ReprojectedSource, S3, CSV, H5PY
 from podpac.core.settings import settings
 
-# Trying to fix test
-pydap.client.open_url
-
 def test_allow_missing_modules():
     """TODO: Allow user to be missing rasterio and scipy"""
     pass

--- a/podpac/core/data/test/test_types.py
+++ b/podpac/core/data/test/test_types.py
@@ -14,7 +14,7 @@ import pytest
 import numpy as np
 from traitlets import TraitError
 from xarray.core.coordinates import DataArrayCoordinates
-import pydap
+import pydap.client
 import rasterio
 import boto3
 import botocore

--- a/podpac/core/data/types.py
+++ b/podpac/core/data/types.py
@@ -24,21 +24,21 @@ import traitlets as tl
 import pandas as pd  # Core dependency of xarray
 
 # Helper utility for optional imports
-from podpac.core.utils import optional_import
+from lazy_import import lazy_module
 
 # Optional dependencies
-bs4 = optional_import('bs4')
+bs4 = lazy_module('bs4')
 # Not used directly, but used indirectly by bs4 so want to check if it's available
-lxml = optional_import('lxml')
-pydap = optional_import('pydap.client', return_root=True)
-rasterio = optional_import('rasterio')
-h5py = optional_import('h5py')
-RasterToNumPyArray = optional_import('arcpy.RasterToNumPyArray')
-boto3 = optional_import('boto3')
-requests = optional_import('requests')
+lxml = lazy_module('lxml')
+pydap = lazy_module('pydap.client', level='base')
+rasterio = lazy_module('rasterio')
+h5py = lazy_module('h5py')
+boto3 = lazy_module('boto3')
+requests = lazy_module('requests')
 # esri
-urllib3 = optional_import('urllib3')
-certifi = optional_import('certifi')
+RasterToNumPyArray = lazy_module('arcpy.RasterToNumPyArray')
+urllib3 = lazy_module('urllib3')
+certifi = lazy_module('certifi')
 
 # Internal dependencies
 from podpac.core import authentication
@@ -902,7 +902,7 @@ class WCS(DataSource):
                 else:
                     raise Exception("Do not have a URL request library to get WCS data.")
                 
-                if rasterio is not None:
+                try:
                     try: # This works with rasterio v1.0a8 or greater, but not on python 2
                         with rasterio.open(io) as dataset:
                             output.data[i, ...] = dataset.read()
@@ -921,7 +921,7 @@ class WCS(DataSource):
 
                         os.remove(tmppath) # Clean up
 
-                elif RasterToNumPyArray is not None:
+                except ImportError:
                     # Writing the data to a temporary tiff and reading it from there is hacky
                     # However reading directly from r.data or io doesn't work
                     # Should improve in the future
@@ -964,7 +964,7 @@ class WCS(DataSource):
             else:
                 raise Exception("Do not have a URL request library to get WCS data.")
             
-            if rasterio is not None:
+            try:
                 try: # This works with rasterio v1.0a8 or greater, but not on python 2
                     with rasterio.open(io) as dataset:
                         if dotime:
@@ -981,14 +981,15 @@ class WCS(DataSource):
                     with rasterio.open(tmppath) as dataset:
                         output.data[:] = dataset.read()
                     os.remove(tmppath) # Clean up
-            elif RasterToNumPyArray is not None:
+            except ImportError:
                 # Writing the data to a temporary tiff and reading it from there is hacky
                 # However reading directly from r.data or io doesn't work
                 # Should improve in the future
                 open('temp.tiff', 'wb').write(r.data)
-                output.data[:] = RasterToNumPyArray('temp.tiff')
-            else:
-                raise Exception('Rasterio or Arcpy not available to read WCS feed.')
+                try:
+                    output.data[:] = RasterToNumPyArray('temp.tiff')
+                except:
+                    raise Exception('Rasterio or Arcpy not available to read WCS feed.')
         if not coordinates['lat'].is_descending:
             if dotime:
                 output.data[:] = output.data[:, ::-1, :]

--- a/podpac/core/utils.py
+++ b/podpac/core/utils.py
@@ -11,7 +11,6 @@ import functools
 import importlib
 from collections import OrderedDict
 import logging
-import lazy_import
 
 import traitlets as tl
 import numpy as np

--- a/podpac/core/utils.py
+++ b/podpac/core/utils.py
@@ -11,6 +11,7 @@ import functools
 import importlib
 from collections import OrderedDict
 import logging
+import lazy_import
 
 import traitlets as tl
 import numpy as np
@@ -133,22 +134,14 @@ def optional_import(module_name, package=None, module_attr=None, return_root=Fal
         The imported module if available. None otherwise.
     '''
 
-    try:
-        if return_root:
-            module = importlib.__import__(module_name)
-            if module_attr:
-                raise Exception("Cannot defined 'module_attr' if 'return_root == True'")
-        else:
-            module = importlib.import_module(module_name)
-            if module_attr:
-                module = getattr(module, module_attr)
-    except ImportError:
-        module = None
-    except AttributeError:
-        try: # Python 2.7
-            module = __import__(module_name)
-        except ImportError:
-            module = None
+    if return_root:
+        module = lazy_import.lazy_module(module_name, level='base')
+        if module_attr:
+            raise Exception("Cannot defined 'module_attr' if 'return_root == True'")
+    else:
+        module = lazy_import.lazy_module(module_name)
+        if module_attr:
+            module = getattr(module, module_attr)
     return module
 
 def create_logfile(filename='podpac.log',

--- a/podpac/core/utils.py
+++ b/podpac/core/utils.py
@@ -107,42 +107,6 @@ def trait_is_defined(obj, trait):
     """
     return obj.has_trait(trait) and trait in obj._trait_values
 
-def optional_import(module_name, package=None, module_attr=None, return_root=False):
-    '''
-    Import optional packages if present.
-
-    Parameters
-    -----------
-    module_name: str
-        The name of the module to import
-    package: str, optional
-        Default is None. The root package, in case module_name is relative
-    module_attr: str
-        Class or function to be returned from package. Only available if return_root is False
-    return_root: bool
-        Default if False. If True, will return the root package instead of the module
-
-    Examples
-    ----------
-    >>> bar = optional_import('foo.bar')  # Returns bar
-    >>> foo = optional_import('foo.bar', return_root=True)  # Returns foo
-    >>> bar = optional_import('foo', module_attr='bar')  # Returns function bar
-
-    Returns
-    --------
-    module
-        The imported module if available. None otherwise.
-    '''
-
-    if return_root:
-        module = lazy_import.lazy_module(module_name, level='base')
-        if module_attr:
-            raise Exception("Cannot defined 'module_attr' if 'return_root == True'")
-    else:
-        module = lazy_import.lazy_module(module_name)
-        if module_attr:
-            module = getattr(module, module_attr)
-    return module
 
 def create_logfile(filename='podpac.log',
                    level=logging.INFO,

--- a/podpac/datalib/gfs.py
+++ b/podpac/datalib/gfs.py
@@ -8,12 +8,14 @@ import traitlets as tl
 import numpy as np
 
 # Helper utility for optional imports
-from podpac.core.utils import optional_import
+from lazy_import import lazy_module
 
-rasterio = optional_import('rasterio')
-boto3 = optional_import('boto3')
-botocore = optional_import('botocore')
+# Optional Imports
+rasterio = lazy_module('rasterio')
+boto3 = lazy_module('boto3')
+botocore = lazy_module('botocore')
 
+# Internal imports
 from podpac.data import DataSource, Rasterio
 from podpac.coordinates import Coordinates, merge_dims
 

--- a/podpac/datalib/smap.py
+++ b/podpac/datalib/smap.py
@@ -27,10 +27,10 @@ import xarray as xr
 import traitlets as tl
 
 # Helper utility for optional imports
-from podpac.core.utils import optional_import
+from lazy_import import lazy_module
 
 # Optional dependencies
-bs4 = optional_import('bs4')
+bs4 = lazy_module('bs4')
 
 # fixing problem with older versions of numpy
 if not hasattr(np, 'isnat'):

--- a/podpac/datalib/terraintiles.py
+++ b/podpac/datalib/terraintiles.py
@@ -45,13 +45,13 @@ from podpac.data import Rasterio
 from podpac.compositor import OrderedCompositor
 from podpac.interpolators import Rasterio as RasterioInterpolator, ScipyGrid, ScipyPoint
 from podpac.data import interpolation_trait
-from podpac.core.utils import optional_import
+from lazy_import import lazy_module
 
 
 # optional imports
-boto3 = optional_import('boto3')
-botocore = optional_import('botocore')
-rasterio = optional_import('rasterio')
+boto3 = lazy_module('boto3')
+botocore = lazy_module('botocore')
+rasterio = lazy_module('rasterio')
 
 ####
 # module attributes

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ install_requires = ['matplotlib>=2.1',
                     'scipy>=1.0',
                     'traitlets>=4.3',
                     'xarray>=0.10',
-                    'requests>=2.18']
+                    'requests>=2.18',
+                    'lazy-import>=0.2.2']
 if sys.version_info.major == 2:
     install_requires += ['future>=0.16']
 


### PR DESCRIPTION
Faster imports. Testing on my machine: 
2.2 seconds before lazy import
1.6 seconds after lazy import. 

Probably still a few places where it could be improved, but this seems to work pretty well for now. 

@jmilloy @mlshapiro @dsully1992 @drc-creare  
Please use the `optional_import` utility function for optional imports -- as it uses the lazy_import module. 