### PR TITLE
Removes deprecated NumpyArray, etc

### DIFF
--- a/podpac/core/data/types.py
+++ b/podpac/core/data/types.py
@@ -83,17 +83,6 @@ class Array(DataSource):
         d = self.create_output_array(coordinates, data=self.source[s])
         return d
 
-class NumpyArray(Array):
-    """Create a DataSource from a numpy array.
-
-    .. deprecated:: 0.2.0
-          `NumpyArray` will be removed in podpac 0.2.0, it is replaced by `Array`.
-    """
-
-    def init(self):
-        warnings.warn('NumpyArray been renamed Array. ' +
-                      'Backwards compatibility will be removed in future releases', DeprecationWarning)
-
 
 @common_doc(COMMON_DATA_DOC)
 class PyDAP(DataSource):


### PR DESCRIPTION
NumpyArray was marked for deprecation in 0.2.0 and I guess we missed that. I think we should remove it for 1.0.0.

The `Node.style` attribute is also marked for deprecation also, but I didn't remove it. Should we (can we) remove it?

I didn't find anything else.