### PR TITLE
ENH: allow stacked dimensions to be set from Coordinates or StackedCoordinates

### DIFF
--- a/podpac/core/coordinates/coordinates.py
+++ b/podpac/core/coordinates/coordinates.py
@@ -461,9 +461,16 @@ class Coordinates(tl.HasTraits):
 
     def __setitem__(self, dim, c):
 
-        # try to cast to ArrayCoordinates1d
-        if not isinstance(c, BaseCoordinates):
+        # cast input coordinates
+        if isinstance(c, BaseCoordinates):
+            pass
+        elif isinstance(c, (list, tuple, np.ndarray, xr.DataArray)):
             c = ArrayCoordinates1d(c)
+        elif isinstance(c, Coordinates):
+            c = c[dim]
+        else:
+            raise TypeError("Invalid coords, expected list, array, " +
+                            "or class implementing BaseCoordinates, not '%s'" % type(c))
 
         if c.name is None:
             c.name = dim

--- a/podpac/core/coordinates/coordinates.py
+++ b/podpac/core/coordinates/coordinates.py
@@ -462,12 +462,17 @@ class Coordinates(tl.HasTraits):
     def __setitem__(self, dim, c):
 
         # cast input coordinates
+        #             if isinstance(coords[i], BaseCoordinates):
         if isinstance(c, BaseCoordinates):
             pass
-        elif isinstance(c, (list, tuple, np.ndarray, xr.DataArray)):
-            c = ArrayCoordinates1d(c)
         elif isinstance(c, Coordinates):
             c = c[dim]
+        elif isinstance(c, (list, tuple, np.ndarray)):
+            if '_' in dim:
+                cs = [val if isinstance(val, Coordinates1d) else ArrayCoordinates1d(val) for val in c]
+                c = StackedCoordinates(cs)
+            else:
+                c = ArrayCoordinates1d(c)
         else:
             raise TypeError("Invalid coords, expected list, array, " +
                             "or class implementing BaseCoordinates, not '%s'" % type(c))

--- a/podpac/core/coordinates/coordinates.py
+++ b/podpac/core/coordinates/coordinates.py
@@ -460,8 +460,6 @@ class Coordinates(tl.HasTraits):
         raise KeyError("Dimension '%s' not found in Coordinates %s" % (dim, self.dims))
 
     def __setitem__(self, dim, c):
-        if not dim in self.dims:
-            raise KeyError("Cannot set dimension '%s' in Coordinates %s" % (dim, self.dims))
 
         # try to cast to ArrayCoordinates1d
         if not isinstance(c, BaseCoordinates):
@@ -470,9 +468,17 @@ class Coordinates(tl.HasTraits):
         if c.name is None:
             c.name = dim
 
-        d = self._coords.copy()
-        d[dim] = c
-        self._coords = d
+        if dim in self.dims:
+            d = self._coords.copy()
+            d[dim] = c
+            self._coords = d
+        
+        elif dim in self.udims:
+            stacked_dim = [sd for sd in self.dims if dim in sd][0]
+            self._coords[stacked_dim][dim] = c
+        else:
+            raise KeyError("Cannot set dimension '%s' in Coordinates %s" % (dim, self.dims))
+
 
     def __delitem__(self, dim):
         if not dim in self.dims:

--- a/podpac/core/coordinates/stacked_coordinates.py
+++ b/podpac/core/coordinates/stacked_coordinates.py
@@ -261,11 +261,15 @@ class StackedCoordinates(BaseCoordinates):
             c.name = dim
 
         if dim in self.dims:
-            print('setting dim')
             idx = self.dims.index(dim)
-            d = list(self._coords)
-            d[idx] = c
-            self._coords = tuple(d)
+            coords = list(self._coords)
+            coords[idx] = c
+
+            self._check_sizes([c.size for c in coords])
+            self._check_names([c.name for c in coords])
+            self._check_coord_ref_sys(coords)
+
+            self._coords = tuple(coords)
 
     # ------------------------------------------------------------------------------------------------------------------
     # Properties

--- a/podpac/core/coordinates/stacked_coordinates.py
+++ b/podpac/core/coordinates/stacked_coordinates.py
@@ -58,7 +58,7 @@ class StackedCoordinates(BaseCoordinates):
         
     """
 
-    _coords = tl.Tuple(trait=tl.Instance(Coordinates1d), read_only=True)
+    _coords = tl.Tuple(trait=tl.Instance(Coordinates1d))
 
     def __init__(self, coords, coord_ref_sys=None, ctype=None, distance_units=None):
         """
@@ -248,6 +248,24 @@ class StackedCoordinates(BaseCoordinates):
 
         else:
             return StackedCoordinates([c[index] for c in self._coords])
+
+    def __setitem__(self, dim, c):
+        if not dim in self.dims:
+            raise KeyError("Cannot set dimension '%s' in StackedCoordinates %s" % (dim, self.dims))
+
+        # try to cast to ArrayCoordinates1d
+        if not isinstance(c, BaseCoordinates):
+            c = ArrayCoordinates1d(c)
+
+        if c.name is None:
+            c.name = dim
+
+        if dim in self.dims:
+            print('setting dim')
+            idx = self.dims.index(dim)
+            d = list(self._coords)
+            d[idx] = c
+            self._coords = tuple(d)
 
     # ------------------------------------------------------------------------------------------------------------------
     # Properties

--- a/podpac/core/coordinates/test/test_coordinates.py
+++ b/podpac/core/coordinates/test/test_coordinates.py
@@ -466,19 +466,22 @@ class TestCoordinatesDict(object):
     def test_setitem(self):
         coords = deepcopy(self.coords)
         
+        coords['time'] = [1, 2, 3]
         coords['time'] = ArrayCoordinates1d([1, 2, 3])
         coords['time'] = ArrayCoordinates1d([1, 2, 3], name='time')
-        coords['time'] = [1, 2, 3]
+        coords['time'] = Coordinates([[1, 2, 3]], dims=['time'])
 
-        coords['lat_lon'] == clinspace((0, 1), (10, 20), 5)
+        # coords['lat_lon'] = [np.linspace(0, 10, 5), np.linspace(0, 10, 5)]
+        coords['lat_lon'] = clinspace((0, 1), (10, 20), 5)
+        coords['lat_lon'] = Coordinates([(np.linspace(0, 10, 5), np.linspace(0, 10, 5))], dims=['lat_lon'])
 
         # update a single stacked dimension
         coords['lat'] = np.linspace(5, 20, 5)
         assert coords['lat'] == ArrayCoordinates1d(np.linspace(5, 20, 5), name='lat')
         
         coords = deepcopy(self.coords)
-        coords['lat_lon']['lat'] = np.linspace(5, 20, 5)
-        assert coords['lat'] == ArrayCoordinates1d(np.linspace(5, 20, 5), name='lat')
+        coords['lat_lon']['lat'] = np.linspace(5, 20, 3)
+        assert coords['lat'] == ArrayCoordinates1d(np.linspace(5, 20, 3), name='lat')
 
         with pytest.raises(KeyError, match="Cannot set dimension"):
             coords['alt'] = ArrayCoordinates1d([1, 2, 3], name='alt')
@@ -491,6 +494,22 @@ class TestCoordinatesDict(object):
 
         with pytest.raises(ValueError, match="coord_ref_sys mismatch"):
             coords['time'] = ArrayCoordinates1d([1, 2, 3], coord_ref_sys='SPHER_MERC')
+
+        with pytest.raises(KeyError, match="not found in Coordinates"):
+            coords['lat_lon'] = Coordinates([(np.linspace(0, 10, 5), np.linspace(0, 10, 5))], dims=['lon_lat'])
+
+        with pytest.raises(ValueError, match="Dimension name mismatch"):
+            coords['lat_lon'] = clinspace((0, 1), (10, 20), 5, name='lon_lat')
+
+        with pytest.raises(ValueError, match="Size mismatch"):
+            coords['lat'] = np.linspace(5, 20, 5)
+
+        with pytest.raises(ValueError, match="Duplicate dimension"):
+            coords['lat'] = clinspace(0, 10, 3, name='lon')
+
+        with pytest.raises(ValueError, match="coord_ref_sys mismatch"):
+            coords['lat_lon'] = Coordinates([(np.linspace(0, 10, 3), np.linspace(0, 10, 3))], dims=['lat_lon'], coord_ref_sys='WGS84')
+            coords['lat'] = Coordinates([np.linspace(0, 10, 3)], dims=['lat'], coord_ref_sys='SPHER_MERC') # should work
 
     def test_delitem(self):
         # unstacked

--- a/podpac/core/coordinates/test/test_coordinates.py
+++ b/podpac/core/coordinates/test/test_coordinates.py
@@ -472,6 +472,14 @@ class TestCoordinatesDict(object):
 
         coords['lat_lon'] == clinspace((0, 1), (10, 20), 5)
 
+        # update a single stacked dimension
+        coords['lat'] = np.linspace(5, 20, 5)
+        assert coords['lat'] == ArrayCoordinates1d(np.linspace(5, 20, 5), name='lat')
+        
+        coords = deepcopy(self.coords)
+        coords['lat_lon']['lat'] = np.linspace(5, 20, 5)
+        assert coords['lat'] == ArrayCoordinates1d(np.linspace(5, 20, 5), name='lat')
+
         with pytest.raises(KeyError, match="Cannot set dimension"):
             coords['alt'] = ArrayCoordinates1d([1, 2, 3], name='alt')
 

--- a/podpac/core/coordinates/test/test_coordinates.py
+++ b/podpac/core/coordinates/test/test_coordinates.py
@@ -473,6 +473,7 @@ class TestCoordinatesDict(object):
 
         # coords['lat_lon'] = [np.linspace(0, 10, 5), np.linspace(0, 10, 5)]
         coords['lat_lon'] = clinspace((0, 1), (10, 20), 5)
+        coords['lat_lon'] = (np.linspace(0, 10, 5), np.linspace(0, 10, 5))
         coords['lat_lon'] = Coordinates([(np.linspace(0, 10, 5), np.linspace(0, 10, 5))], dims=['lat_lon'])
 
         # update a single stacked dimension

--- a/podpac/core/coordinates/test/test_stacked_coordinates.py
+++ b/podpac/core/coordinates/test/test_stacked_coordinates.py
@@ -33,7 +33,14 @@ class TestStackedCoordinatesCreation(object):
         c = StackedCoordinates([lat, lon, time])
         assert c.dims == (None, None, None)
         assert c.udims == (None, None, None)
-        assert c.name == '?_?_?'
+        assert c.name is None
+
+        lat = ArrayCoordinates1d([0, 1, 2], name='lat')
+        c = StackedCoordinates([lat, lon, time])
+        assert c.dims == ('lat', None, None)
+        assert c.udims == ('lat', None, None)
+        assert c.name == 'lat_?_?'
+
         repr(c)
 
     def test_ctype(self):


### PR DESCRIPTION
This would be helpful to me since I would not have to figure out how dimensions are stacked in order to set them. It seems like there was a good reason to keep the StackedCoordinates components read only - feel free to reject this PR if this goes against a design consideration

Example:

stack_coords = Coordinates([(np.linspace(-10, 10, 21), np.linspace(-30, -10, 21))], dims=['lat_lon'])

stack_coords['lat'] = np.linspace(-50, -10, 21)
stack_coords['lat_lon']['lat'] = np.linspace(-50, -10, 21)  # also works