### PR TITLE
WIP: convert stacked coords to OrderedDict.

### DIFF
--- a/podpac/core/coordinates/cfunctions.py
+++ b/podpac/core/coordinates/cfunctions.py
@@ -36,7 +36,7 @@ def crange(start, stop, step, name=None):
 
 def clinspace(start, stop, size, name=None):
     """
-    Create uniformly-spaced 1d or stacked coordinates with a start, stop, and size.
+    Create uniformly-spaced 1d coordinates with a start, stop, and size.
 
     For numerical coordinates, the start and stop are converted to ``float``. For time coordinates, the start and stop
     are converted to numpy ``datetime64``. For convenience, podpac automatically converts datetime strings such as
@@ -44,10 +44,10 @@ def clinspace(start, stop, size, name=None):
 
     Arguments
     ---------
-    start : float, datetime64, datetime, str, tuple
-        Start coordinate for 1d coordinates, or tuple of start coordinates for stacked coordinates.
-    stop : float, datetime64, datetime, str, tuple
-        Stop coordinate for 1d coordinates, or tuple of stop coordinates for stacked coordinates.
+    start : float, datetime64, datetime, str
+        Start coordinate for 1d coordinates
+    stop : float, datetime64, datetime, str
+        Stop coordinate for 1d coordinates
     size : int
         Number of coordinates.
     name : str, optional
@@ -67,15 +67,9 @@ def clinspace(start, stop, size, name=None):
         raise ValueError("Size mismatch, 'start' and 'stop' must have the same size (%s != %s)" % (
             np.array(start).size, np.array(stop).size))
     
-    # As of numpy 0.16, np.array([0, (0, 10)]) no longer raises a ValueError
-    # so we have to explicitly check for sizes of start and stop (see above)
-    a = np.array([start, stop])
-    if a.ndim == 2:
-        c = StackedCoordinates([UniformCoordinates1d(start[i], stop[i], size=size) for i in range(a[0].size)])
-    else:
-        c = UniformCoordinates1d(start, stop, size=size)
+    c = UniformCoordinates1d(start, stop, size=size)
 
     if name is not None:
         c.name = name
-        
+    
     return c

--- a/podpac/core/coordinates/test/test_cfunctions.py
+++ b/podpac/core/coordinates/test/test_cfunctions.py
@@ -38,38 +38,6 @@ def test_clinspace():
     c = clinspace(0, 1, 6, name='lat')
     assert c.name == 'lat'
 
-def test_clinspace_stacked():
-    c = clinspace((0, 10, '2018-01-01'), (1, 20, '2018-01-06'), 6)
-    assert isinstance(c, StackedCoordinates)
-    
-    c1, c2, c3 = c
-    assert isinstance(c1, UniformCoordinates1d)
-    assert c1.start == 0.0
-    assert c1.stop == 1.0
-    assert c1.size == 6
-    assert isinstance(c2, UniformCoordinates1d)
-    assert c2.start == 10.0
-    assert c2.stop == 20.0
-    assert c2.size == 6
-    assert isinstance(c3, UniformCoordinates1d)
-    assert c3.start == np.datetime64('2018-01-01')
-    assert c3.stop == np.datetime64('2018-01-06')
-    assert c3.size == 6
-
-    # named
-    c = clinspace((0, 10, '2018-01-01'), (1, 20, '2018-01-06'), 6, name='lat_lon_time')
-    assert c.name == 'lat_lon_time'
-
-    # size must be an integer
-    with pytest.raises(TypeError):
-        clinspace((0, 10), (1, 20), (6, 6))
-
-    with pytest.raises(TypeError):
-        clinspace((0, 10), (1, 20), 0.2)
-
-    with pytest.raises(TypeError):
-        clinspace((0, 10), (1, 20), (0.2, 1.0))
-
 def test_clinspace_shape_mismatch():
     with pytest.raises(ValueError, match="Size mismatch, 'start' and 'stop' must have the same size"):
         clinspace(0, (0, 10), 6)

--- a/podpac/core/coordinates/test/test_coordinates.py
+++ b/podpac/core/coordinates/test/test_coordinates.py
@@ -472,7 +472,7 @@ class TestCoordinatesDict(object):
         coords['time'] = Coordinates([[1, 2, 3]], dims=['time'])
 
         # coords['lat_lon'] = [np.linspace(0, 10, 5), np.linspace(0, 10, 5)]
-        coords['lat_lon'] = clinspace((0, 1), (10, 20), 5)
+        coords['lat_lon'] = (clinspace(0, 10, 5), clinspace(1, 20, 5))
         coords['lat_lon'] = (np.linspace(0, 10, 5), np.linspace(0, 10, 5))
         coords['lat_lon'] = Coordinates([(np.linspace(0, 10, 5), np.linspace(0, 10, 5))], dims=['lat_lon'])
 
@@ -553,7 +553,7 @@ class TestCoordinatesDict(object):
 
         # overwrite a stacked dimension
         coords = deepcopy(self.coords)
-        c = Coordinates([clinspace((0, 1), (10, 20), 5)], dims=['lat_lon'])
+        c = Coordinates([(clinspace(0, 10, 5), clinspace(1, 20, 5))], dims=['lat_lon'])
         coords.update(c)
         assert coords.dims == ('lat_lon', 'time')
         assert coords['lat_lon'] == c['lat_lon']
@@ -561,7 +561,7 @@ class TestCoordinatesDict(object):
 
         # mixed
         coords = deepcopy(self.coords)
-        c = Coordinates([clinspace((0, 1), (10, 20), 5), [100, 200, 300]], dims=['lat_lon', 'alt'])
+        c = Coordinates([(clinspace(0, 10, 5), clinspace(1, 20, 5)), [100, 200, 300]], dims=['lat_lon', 'alt'])
         coords.update(c)
         assert coords.dims == ('lat_lon', 'time', 'alt')
         assert coords['lat_lon'] == c['lat_lon']


### PR DESCRIPTION
This is probably 75% done, but has resulted in some unintended consequences:

- `StackedCoordinates` now requires dims/names on creation, otherwise we can't keep track. I could use some index values as names (i.e. 0, 1), but that would be strange if they were never set. I can't use None (like the other implementing BaseCoordinates) since we have multiple dimensions using the same None key overwriting each other. For now, I required name. 
- Because of the name requirements, `clinspace` is not as intuitive for stacked coordinates. I removed `clinspace` support for `StackedCoordinates`. 
- `StackedCoordinates` end up looking like a mixture between `Coordinates` and `BaseCoordinates`. I think this is intuitive, but it may not be since its really multi-indexed.

Note I removed `read_only`, but after talking with @mpu-creare I will add back in.

At the end of the day, I want the stacked coordinates to be intuitive. Before I go deeper lets decide if this is the right path.

Alternatively, I can just change the `StackedCoordinates._coords` type to be a list, which will let me implement the transform work. That will have less consequences, though I've already gone through the effort to implement this, I feel like its worth considering.