### PR TITLE
Feature/crs2

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -55,6 +55,7 @@ disable=
         C0103,      # snake case enforcement
         W0703,      # too broad except error
         R0201,      # no self-use
+        W0212,      # access to a protected member
         print-statement,
         parameter-unpacking,
         unpacking-in-except,

--- a/podpac/core/coordinates/coordinates.py
+++ b/podpac/core/coordinates/coordinates.py
@@ -971,20 +971,6 @@ class Coordinates(tl.HasTraits):
 
         t_coords = deepcopy(self)
 
-        # update crs in all coords first
-        # read-only implementation
-        # coords = t_coords._coords.copy()
-        # for dim in coords:
-        #     if isinstance(coords[dim], StackedCoordinates):
-        #         s_coords = coords[dim]._coords.copy()
-        #         for idx, c in enumerate(t_coords[dim]):
-        #             s_coords[idx].coord_ref_sys = crs
-        #         coords[dim].set_trait('_coords', s_coords)
-        #     else:
-        #         coords[dim].coord_ref_sys = crs
-
-        # t_coords.set_trait('_coords', coords)
-
         for dim in t_coords.udims:
             t_coords[dim].coord_ref_sys = crs
 

--- a/podpac/core/coordinates/coordinates.py
+++ b/podpac/core/coordinates/coordinates.py
@@ -931,26 +931,25 @@ class Coordinates(tl.HasTraits):
         else:
             return Coordinates([self._coords[dim] for dim in dims])
 
-    def transform(self, dst_crs):
+    def transform(self, crs):
         """
         Transform coordinates into a different coordinate reference system.
         Uses PROJ4 syntax for coordinate reference systems
         
         Parameters
         ----------
-        dst_crs : str
+        crs : str
             PROJ4 compatible coordinate reference system string
         """
 
         # coordinates MUST have lat and lon, even if stacked
-        if len(set(['lat', 'lon']) - set(self.udims)):
+        if set(['lat', 'lon']) - set(self.udims):
             raise ValueError('Coordinates must have lat and lon dimensions to transform coordinate reference systems')
 
-        # TODO: update for stacked/unstacked and other dimensions
-        transformer = pyproj.Transformer.from_crs(pyproj.CRS(self.crs), pyproj.CRS(dst_crs))
-        dst_values = transformer.transform(self.coords['lat'].values, self.coords['lon'].values)
+        transformer = pyproj.Transformer.from_crs(pyproj.CRS(self.crs), pyproj.CRS(crs))
+        (lat, lon) = transformer.transform(self.coords['lat'].values, self.coords['lon'].values)
 
-        return Coordinates([dst_values[0], dst_values[1]], dims = ['lat', 'lon'], coord_ref_sys=dst_crs)
+        return Coordinates([lat, lon], dims=['lat', 'lon'], coord_ref_sys=crs)
 
 
     # ------------------------------------------------------------------------------------------------------------------

--- a/podpac/core/coordinates/coordinates.py
+++ b/podpac/core/coordinates/coordinates.py
@@ -971,7 +971,7 @@ class Coordinates(tl.HasTraits):
         trans_coords['lat'] = lat
         trans_coords['lon'] = lon
 
-        for dim in trans_coords:
+        for dim in trans_coords.udims:
             trans_coords[dim].coord_ref_sys = crs
 
         return trans_coords

--- a/podpac/core/coordinates/coordinates.py
+++ b/podpac/core/coordinates/coordinates.py
@@ -5,7 +5,7 @@ Multidimensional Coordinates
 from __future__ import division, unicode_literals, print_function, absolute_import
 
 import warnings
-import copy
+from copy import deepcopy
 import sys
 import itertools
 import json
@@ -957,12 +957,20 @@ class Coordinates(tl.HasTraits):
 
         # coordinates MUST have lat and lon, even if stacked
         if set(['lat', 'lon']) - set(self.udims):
-            raise ValueError('Coordinates must have lat and lon dimensions to transform coordinate reference systems')
+            raise ValueError('Coordinates must have both lat and lon dimensions to transform coordinate reference systems')
 
         transformer = pyproj.Transformer.from_crs(pyproj.CRS(self.crs), pyproj.CRS(crs))
         (lat, lon) = transformer.transform(self.coords['lat'].values, self.coords['lon'].values)
 
-        return Coordinates([lat, lon], dims=['lat', 'lon'], coord_ref_sys=crs)
+        transformed_coordinates = deepcopy(self)
+        transformed_coordinates['lat'] = lat
+        transformed_coordinates['lat'].coord_ref_sys = crs
+        
+        transformed_coordinates['lon'] = lon
+        transformed_coordinates['lon'].coord_ref_sys = crs
+
+        return transformed_coordinates
+        # return Coordinates([lat, lon], dims=['lat', 'lon'], coord_ref_sys=crs)
 
 
     # ------------------------------------------------------------------------------------------------------------------

--- a/podpac/core/coordinates/coordinates.py
+++ b/podpac/core/coordinates/coordinates.py
@@ -4,6 +4,7 @@ Multidimensional Coordinates
 
 from __future__ import division, unicode_literals, print_function, absolute_import
 
+import warnings
 import copy
 import sys
 import itertools
@@ -20,7 +21,6 @@ from six import string_types
 
 import podpac
 from podpac.core.utils import OrderedDictTrait
-from podpac.core.coordinates.utils import GDAL_CRS
 from podpac.core.coordinates.base_coordinates import BaseCoordinates
 from podpac.core.coordinates.coordinates1d import Coordinates1d
 from podpac.core.coordinates.array_coordinates1d import ArrayCoordinates1d
@@ -637,34 +637,33 @@ class Coordinates(tl.HasTraits):
 
         return hash_alg(self.json.encode('utf-8')).hexdigest()
 
-    # #@property
-    # #def gdal_transform(self):
-    #     if self['lon'].regularity == 'regular' and self['lat'].regularity == 'regular':
-    #         lon_bounds = self['lon'].area_bounds
-    #         lat_bounds = self['lat'].area_bounds
-    #         transform = [lon_bounds[0], self['lon'].delta, 0, lat_bounds[0], 0, -self['lat'].delta]
-    #     else:
-    #         raise NotImplementedError
-    #     return transform
-
     @property
     def coord_ref_sys(self):
-        """:str: coordinate reference system."""
+        """
+        :str: coordinate reference system.
 
+        .. deprecated:: 1.0.0
+              `coord_ref_sys` will be removed in podpac 1.0.0, it is replaced by
+              `crs` for consistency
+        """
+
+        warnings.warn('`coord_ref_sys` has been replaced with `crs` and will be deprecated in future releases', DeprecationWarning)
+        return self.crs
+    
+    @property
+    def crs(self):
+        """:str: coordinate reference system."""
         if not self._coords:
             return None
         
         # the coord_ref_sys is the same for all coords
         return list(self._coords.values())[0].coord_ref_sys
-    
-    @property
-    def gdal_crs(self):
-        """:str: GDAL coordinate reference system."""
 
-        if not self._coords:
-            return None
+        # key = 'lat' if 'lat' in self.udims else 'lon'
+        # if key == 'lon' and 'lon' not in self.udims:
+        #     return None
 
-        return GDAL_CRS[self.coord_ref_sys]
+        # return GDAL_CRS.get(self[key].coord_ref_sys, self[key].coord_ref_sys)
 
     # ------------------------------------------------------------------------------------------------------------------
     # Methods

--- a/podpac/core/coordinates/coordinates.py
+++ b/podpac/core/coordinates/coordinates.py
@@ -972,12 +972,25 @@ class Coordinates(tl.HasTraits):
         t_coords = deepcopy(self)
 
         # update crs in all coords first
+        # read-only implementation
+        # coords = t_coords._coords.copy()
+        # for dim in coords:
+        #     if isinstance(coords[dim], StackedCoordinates):
+        #         s_coords = coords[dim]._coords.copy()
+        #         for idx, c in enumerate(t_coords[dim]):
+        #             s_coords[idx].coord_ref_sys = crs
+        #         coords[dim].set_trait('_coords', s_coords)
+        #     else:
+        #         coords[dim].coord_ref_sys = crs
+
+        # t_coords.set_trait('_coords', coords)
+
         for dim in t_coords.udims:
             t_coords[dim].coord_ref_sys = crs
 
         # update values
-        t_coords['lat'] = lat
-        t_coords['lon'] = lon
+        t_coords['lat'] = ArrayCoordinates1d(lat, coord_ref_sys=crs)
+        t_coords['lon'] = ArrayCoordinates1d(lon, coord_ref_sys=crs)
 
         return t_coords
 

--- a/podpac/core/coordinates/coordinates.py
+++ b/podpac/core/coordinates/coordinates.py
@@ -847,6 +847,8 @@ class Coordinates(tl.HasTraits):
         idx : list
             List of indices for each dimension that produces the intersection, only if ``return_indices`` is True.
         """
+        if other.crs != self.crs:
+            other = other.transform(self.crs)
 
         intersections = [c.intersect(other, outer=outer, return_indices=return_indices) for c in self.values()]
         if return_indices:
@@ -967,14 +969,17 @@ class Coordinates(tl.HasTraits):
         transformer = pyproj.Transformer.from_crs(pyproj.CRS(self.crs), pyproj.CRS(crs))
         (lat, lon) = transformer.transform(self.coords['lat'].values, self.coords['lon'].values)
 
-        trans_coords = deepcopy(self)
-        trans_coords['lat'] = lat
-        trans_coords['lon'] = lon
+        t_coords = deepcopy(self)
 
-        for dim in trans_coords.udims:
-            trans_coords[dim].coord_ref_sys = crs
+        # update crs in all coords first
+        for dim in t_coords.udims:
+            t_coords[dim].coord_ref_sys = crs
 
-        return trans_coords
+        # update values
+        t_coords['lat'] = lat
+        t_coords['lon'] = lon
+
+        return t_coords
 
 
     # ------------------------------------------------------------------------------------------------------------------

--- a/podpac/core/coordinates/coordinates.py
+++ b/podpac/core/coordinates/coordinates.py
@@ -967,15 +967,14 @@ class Coordinates(tl.HasTraits):
         transformer = pyproj.Transformer.from_crs(pyproj.CRS(self.crs), pyproj.CRS(crs))
         (lat, lon) = transformer.transform(self.coords['lat'].values, self.coords['lon'].values)
 
-        transformed_coordinates = deepcopy(self)
-        transformed_coordinates['lat'] = lat
-        transformed_coordinates['lat'].coord_ref_sys = crs
-        
-        transformed_coordinates['lon'] = lon
-        transformed_coordinates['lon'].coord_ref_sys = crs
+        trans_coords = deepcopy(self)
+        trans_coords['lat'] = lat
+        trans_coords['lon'] = lon
 
-        return transformed_coordinates
-        # return Coordinates([lat, lon], dims=['lat', 'lon'], coord_ref_sys=crs)
+        for dim in trans_coords:
+            trans_coords[dim].coord_ref_sys = crs
+
+        return trans_coords
 
 
     # ------------------------------------------------------------------------------------------------------------------

--- a/podpac/core/coordinates/coordinates1d.py
+++ b/podpac/core/coordinates/coordinates1d.py
@@ -15,7 +15,7 @@ from podpac.core.utils import ArrayTrait
 from podpac.core.coordinates.utils import make_coord_delta, make_coord_delta_array, add_coord, divide_delta
 from podpac.core.coordinates.base_coordinates import BaseCoordinates
 
-DEFAULT_COORD_REF_SYS = 'WGS84'
+DEFAULT_COORD_REF_SYS = 'EPSG:4326'
 
 class Coordinates1d(BaseCoordinates):
     """
@@ -58,7 +58,7 @@ class Coordinates1d(BaseCoordinates):
 
     name = tl.Enum(['lat', 'lon', 'time', 'alt'], allow_none=True)
     units = tl.Instance(Units, allow_none=True, read_only=True)
-    coord_ref_sys = tl.Enum(['WGS84', 'SPHER_MERC'], allow_none=True, read_only=True)
+    coord_ref_sys = tl.Unicode(default_value=None, allow_none=True)
     ctype = tl.Enum(['point', 'left', 'right', 'midpoint'], read_only=True)
     segment_lengths = tl.Any(read_only=True)
 

--- a/podpac/core/coordinates/coordinates1d.py
+++ b/podpac/core/coordinates/coordinates1d.py
@@ -14,9 +14,7 @@ from podpac.core.units import Units
 from podpac.core.utils import ArrayTrait
 from podpac.core.coordinates.utils import make_coord_delta, make_coord_delta_array, add_coord, divide_delta
 from podpac.core.coordinates.base_coordinates import BaseCoordinates
-
-DEFAULT_CRS = 'EPSG:4326'
-""":str: Default coordinate reference system """
+from podpac.core.settings import settings
 
 class Coordinates1d(BaseCoordinates):
     """
@@ -46,7 +44,7 @@ class Coordinates1d(BaseCoordinates):
         Coordinate units.
     coord_ref_sys : str
         Coordinate reference system. Supports any PROJ4 compliant string (https://proj4.org/index.html).
-        If not defined, set to :str:`DEFAULT_CRS`
+        If not defined, set to settings entry: `DEFAULT_CRS`
     ctype : str
         Coordinates type: 'point', 'left', 'right', or 'midpoint'.
     segment_lengths : array, float, timedelta
@@ -127,7 +125,7 @@ class Coordinates1d(BaseCoordinates):
 
     @tl.default('coord_ref_sys')
     def _default_coord_ref_sys(self):
-        return DEFAULT_CRS
+        return settings['DEFAULT_CRS']
 
     def __repr__(self):
         return "%s(%s): Bounds[%s, %s], N[%d], ctype['%s']" % (

--- a/podpac/core/coordinates/coordinates1d.py
+++ b/podpac/core/coordinates/coordinates1d.py
@@ -16,6 +16,7 @@ from podpac.core.coordinates.utils import make_coord_delta, make_coord_delta_arr
 from podpac.core.coordinates.base_coordinates import BaseCoordinates
 
 DEFAULT_COORD_REF_SYS = 'EPSG:4326'
+""":str: Default coordinate reference system """
 
 class Coordinates1d(BaseCoordinates):
     """
@@ -44,7 +45,8 @@ class Coordinates1d(BaseCoordinates):
     units : podpac.Units
         Coordinate units.
     coord_ref_sys : str
-        Coordinate reference system.
+        Coordinate reference system. Supports any PROJ4 compliant string (https://proj4.org/index.html).
+        If not defined, set to :str:`DEFAULT_COORD_REF_SYS`
     ctype : str
         Coordinates type: 'point', 'left', 'right', or 'midpoint'.
     segment_lengths : array, float, timedelta

--- a/podpac/core/coordinates/coordinates1d.py
+++ b/podpac/core/coordinates/coordinates1d.py
@@ -15,7 +15,7 @@ from podpac.core.utils import ArrayTrait
 from podpac.core.coordinates.utils import make_coord_delta, make_coord_delta_array, add_coord, divide_delta
 from podpac.core.coordinates.base_coordinates import BaseCoordinates
 
-DEFAULT_COORD_REF_SYS = 'EPSG:4326'
+DEFAULT_CRS = 'EPSG:4326'
 """:str: Default coordinate reference system """
 
 class Coordinates1d(BaseCoordinates):
@@ -46,7 +46,7 @@ class Coordinates1d(BaseCoordinates):
         Coordinate units.
     coord_ref_sys : str
         Coordinate reference system. Supports any PROJ4 compliant string (https://proj4.org/index.html).
-        If not defined, set to :str:`DEFAULT_COORD_REF_SYS`
+        If not defined, set to :str:`DEFAULT_CRS`
     ctype : str
         Coordinates type: 'point', 'left', 'right', or 'midpoint'.
     segment_lengths : array, float, timedelta
@@ -127,7 +127,7 @@ class Coordinates1d(BaseCoordinates):
 
     @tl.default('coord_ref_sys')
     def _default_coord_ref_sys(self):
-        return DEFAULT_COORD_REF_SYS
+        return DEFAULT_CRS
 
     def __repr__(self):
         return "%s(%s): Bounds[%s, %s], N[%d], ctype['%s']" % (
@@ -177,6 +177,12 @@ class Coordinates1d(BaseCoordinates):
 
         raise NotImplementedError
 
+    @property
+    def values(self):
+        """:array, read-only: Full array of coordinates values."""
+
+        return self.coordinates
+        
     @property
     def dtype(self):
         """:type: Coordinates dtype.

--- a/podpac/core/coordinates/stacked_coordinates.py
+++ b/podpac/core/coordinates/stacked_coordinates.py
@@ -262,7 +262,7 @@ class StackedCoordinates(BaseCoordinates):
             c.name = dim
 
         idx = self.dims.index(dim)    # find the index of the dimension being set
-        coords = self._coords.copy()
+        coords = list(self._coords)
         coords[idx] = c               # set the element of the coords list to new coordinates
 
         # check consistency

--- a/podpac/core/coordinates/stacked_coordinates.py
+++ b/podpac/core/coordinates/stacked_coordinates.py
@@ -58,7 +58,7 @@ class StackedCoordinates(BaseCoordinates):
         
     """
 
-    _coords = tl.Tuple(trait=tl.Instance(Coordinates1d), read_only=True)
+    _coords = tl.List(trait=tl.Instance(Coordinates1d), read_only=True)
 
     def __init__(self, coords, coord_ref_sys=None, ctype=None, distance_units=None):
         """
@@ -225,7 +225,7 @@ class StackedCoordinates(BaseCoordinates):
         return StackedCoordinates(self._coords)
 
     # ------------------------------------------------------------------------------------------------------------------
-    # standard methods, tuple-like
+    # standard methods, list-like
     # ------------------------------------------------------------------------------------------------------------------
 
     def __repr__(self):
@@ -244,6 +244,7 @@ class StackedCoordinates(BaseCoordinates):
         if isinstance(index, string_types):
             if index not in self.dims:
                 raise KeyError("Dimension '%s' not found in dims %s" % (index, self.dims))
+            
             return self._coords[self.dims.index(index)]
 
         else:
@@ -260,8 +261,8 @@ class StackedCoordinates(BaseCoordinates):
         if c.name is None:
             c.name = dim
 
-        idx = self.dims.index(dim)    # find the tuple index of the dimension you are interested in
-        coords = list(self._coords)   # make list from _coords tuple
+        idx = self.dims.index(dim)    # find the index of the dimension being set
+        coords = self._coords.copy()
         coords[idx] = c               # set the element of the coords list to new coordinates
 
         # check consistency

--- a/podpac/core/coordinates/stacked_coordinates.py
+++ b/podpac/core/coordinates/stacked_coordinates.py
@@ -317,6 +317,12 @@ class StackedCoordinates(BaseCoordinates):
         return pd.MultiIndex.from_arrays([np.array(c.coordinates) for c in self._coords], names=self.dims)
 
     @property
+    def values(self):
+        """:pandas.MultiIndex: MultiIndex of stacked coordinates values."""
+
+        return self.coordinates
+
+    @property
     def coords(self):
         """:dict-like: xarray coordinates (container of coordinate arrays)"""
 

--- a/podpac/core/coordinates/test/test_array_coordinates1d.py
+++ b/podpac/core/coordinates/test/test_array_coordinates1d.py
@@ -10,10 +10,10 @@ from numpy.testing import assert_equal
 import podpac
 from podpac.core.units import Units
 from podpac.core.coordinates.array_coordinates1d import ArrayCoordinates1d
-from podpac.core.coordinates.coordinates1d import DEFAULT_CRS
 from podpac.core.coordinates.uniform_coordinates1d import UniformCoordinates1d
 from podpac.core.coordinates.stacked_coordinates import StackedCoordinates
 from podpac.core.coordinates.coordinates import Coordinates
+from podpac.core.settings import settings
 
 class TestArrayCoordinatesInit(object):
     def test_empty(self):
@@ -372,7 +372,7 @@ class TestArrayCoordinatesInit(object):
 
     def test_coord_ref_sys(self):
         c = ArrayCoordinates1d([])
-        assert c.coord_ref_sys == DEFAULT_CRS
+        assert c.coord_ref_sys == settings['DEFAULT_CRS']
 
         c = ArrayCoordinates1d([], coord_ref_sys='SPHER_MERC')
         assert c.coord_ref_sys == 'SPHER_MERC'

--- a/podpac/core/coordinates/test/test_array_coordinates1d.py
+++ b/podpac/core/coordinates/test/test_array_coordinates1d.py
@@ -1,4 +1,3 @@
-
 from datetime import datetime
 import json
 
@@ -11,6 +10,7 @@ from numpy.testing import assert_equal
 import podpac
 from podpac.core.units import Units
 from podpac.core.coordinates.array_coordinates1d import ArrayCoordinates1d
+from podpac.core.coordinates.coordinates1d import DEFAULT_CRS
 from podpac.core.coordinates.uniform_coordinates1d import UniformCoordinates1d
 from podpac.core.coordinates.stacked_coordinates import StackedCoordinates
 from podpac.core.coordinates.coordinates import Coordinates
@@ -372,13 +372,13 @@ class TestArrayCoordinatesInit(object):
 
     def test_coord_ref_sys(self):
         c = ArrayCoordinates1d([])
-        assert c.coord_ref_sys == 'WGS84'
+        assert c.coord_ref_sys == DEFAULT_CRS
 
         c = ArrayCoordinates1d([], coord_ref_sys='SPHER_MERC')
         assert c.coord_ref_sys == 'SPHER_MERC'
         
         with pytest.raises(tl.TraitError):
-            ArrayCoordinates1d([], coord_ref_sys='ABCD')
+            ArrayCoordinates1d([], coord_ref_sys=1)
 
 class TestArrayCoordinatesEq(object):
     def test_eq_type(self):

--- a/podpac/core/coordinates/test/test_coordinates.py
+++ b/podpac/core/coordinates/test/test_coordinates.py
@@ -10,12 +10,13 @@ import pandas as pd
 from numpy.testing import assert_equal
 
 import podpac
-from podpac.core.coordinates.coordinates1d import Coordinates1d, DEFAULT_CRS
+from podpac.core.coordinates.coordinates1d import Coordinates1d
 from podpac.core.coordinates.array_coordinates1d import ArrayCoordinates1d
 from podpac.core.coordinates.stacked_coordinates import StackedCoordinates
 from podpac.core.coordinates.cfunctions import crange, clinspace
 from podpac.core.coordinates.coordinates import Coordinates
 from podpac.core.coordinates.coordinates import concat, union, merge_dims
+from podpac.core.settings import settings
 
 class TestCoordinateCreation(object):
     def test_empty(self):
@@ -418,8 +419,8 @@ class TestCoordinatesProperties(object):
 
         # default
         c = Coordinates([[0, 1, 2]], dims=['lat'])
-        assert c.coord_ref_sys == DEFAULT_CRS
-        assert c.crs == DEFAULT_CRS
+        assert c.coord_ref_sys == settings['DEFAULT_CRS']
+        assert c.crs == settings['DEFAULT_CRS']
 
         # set
         c = Coordinates([[0, 1, 2]], dims=['lat'], coord_ref_sys='EPSG:2193')
@@ -741,25 +742,25 @@ class TestCoordinatesMethods(object):
         c1 = Coordinates([[[0, 1], [10, 20]], [100, 200, 300]], dims=['lat_lon', 'alt'])
 
         # default crs
-        assert c.crs == DEFAULT_CRS
+        assert c.crs == settings['DEFAULT_CRS']
 
         # transform
         c_trans = c.transform('EPSG:2193')
-        assert c.crs == DEFAULT_CRS
+        assert c.crs == settings['DEFAULT_CRS']
         assert c_trans.crs == 'EPSG:2193'
         assert round(c_trans['lat'].values[0]) == 29995930.0
 
         # support proj4 strings
         proj = '+proj=merc +lat_ts=56.5 +ellps=GRS80'
         c_trans = c.transform(proj)
-        assert c.crs == DEFAULT_CRS
+        assert c.crs == settings['DEFAULT_CRS']
         assert c_trans.crs == proj
         assert round(c_trans['lat'].values[0]) == 615849.0
 
         # support stacked coordinates
         proj = '+proj=merc +lat_ts=56.5 +ellps=GRS80'
         c1_trans = c1.transform(proj)
-        assert c1.crs == DEFAULT_CRS
+        assert c1.crs == settings['DEFAULT_CRS']
         assert c1_trans.crs == proj
         assert round(c1_trans['lat'].values[0]) == 615849.0
 
@@ -773,7 +774,7 @@ class TestCoordinatesMethods(object):
                 dims=['lat', 'lon', 'time'], coord_ref_sys='EPSG:2193')
 
         c_int = c.intersect(o)
-        assert c_int.crs == DEFAULT_CRS
+        assert c_int.crs == settings['DEFAULT_CRS']
         assert np.all(c_int['lat'].bounds == np.array([5., 10.]))
         assert np.all(c_int['lon'].bounds == np.array([4., 10.]))
         assert np.all(c_int['time'].values == c['time'].values)

--- a/podpac/core/coordinates/test/test_coordinates.py
+++ b/podpac/core/coordinates/test/test_coordinates.py
@@ -779,6 +779,11 @@ class TestCoordinatesMethods(object):
         assert round(c1_trans['alt'].values[1]) == 656.0
         assert '+vunits=us-ft' in c1_trans.crs
 
+        # make sure vunits can be overwritten appropriately
+        c2_trans = c1_trans.transform(alt_units='m')
+        assert round(c2_trans['alt'].values[0]) == 100.0
+        assert '+vunits=m' in c2_trans.crs and '+vunits=us-ft' not in c2_trans.crs
+
         # alt_units parameter
         c_trans = c.transform('EPSG:2193', alt_units='us-ft')
         assert round(c_trans['alt'].values[1]) == 3.0

--- a/podpac/core/coordinates/test/test_coordinates.py
+++ b/podpac/core/coordinates/test/test_coordinates.py
@@ -738,6 +738,7 @@ class TestCoordinatesMethods(object):
 
     def test_transform(self):
         c = Coordinates([[0, 1], [10, 20], ['2018-01-01', '2018-01-02']], dims=['lat', 'lon', 'time'])
+        c1 = Coordinates([[[0, 1], [10, 20]], [100, 200, 300]], dims=['lat_lon', 'alt'])
 
         # default crs
         assert c.crs == DEFAULT_CRS
@@ -747,6 +748,20 @@ class TestCoordinatesMethods(object):
         assert c.crs == DEFAULT_CRS
         assert c_trans.crs == 'EPSG:2193'
         assert round(c_trans['lat'].values[0]) == 29995930.0
+
+        # support proj4 strings
+        proj = '+proj=merc +lat_ts=56.5 +ellps=GRS80'
+        c_trans = c.transform(proj)
+        assert c.crs == DEFAULT_CRS
+        assert c_trans.crs == proj
+        assert round(c_trans['lat'].values[0]) == 615849.0
+
+        # support stacked coordinates
+        proj = '+proj=merc +lat_ts=56.5 +ellps=GRS80'
+        c1_trans = c1.transform(proj)
+        assert c1.crs == DEFAULT_CRS
+        assert c1_trans.crs == proj
+        assert round(c1_trans['lat'].values[0]) == 615849.0
 
     def test_intersect(self):
         pass

--- a/podpac/core/coordinates/test/test_coordinates.py
+++ b/podpac/core/coordinates/test/test_coordinates.py
@@ -10,7 +10,7 @@ import pandas as pd
 from numpy.testing import assert_equal
 
 import podpac
-from podpac.core.coordinates.coordinates1d import Coordinates1d
+from podpac.core.coordinates.coordinates1d import Coordinates1d, DEFAULT_CRS
 from podpac.core.coordinates.array_coordinates1d import ArrayCoordinates1d
 from podpac.core.coordinates.stacked_coordinates import StackedCoordinates
 from podpac.core.coordinates.cfunctions import crange, clinspace
@@ -735,6 +735,18 @@ class TestCoordinatesMethods(object):
 
         with pytest.raises(ValueError, match="Invalid transpose dimensions"):
             c.transpose('lon', 'lat')
+
+    def test_transform(self):
+        c = Coordinates([[0, 1], [10, 20], ['2018-01-01', '2018-01-02']], dims=['lat', 'lon', 'time'])
+
+        # default crs
+        assert c.crs == DEFAULT_CRS
+
+        # transform
+        c_trans = c.transform('EPSG:2193')
+        assert c.crs == DEFAULT_CRS
+        assert c_trans.crs == 'EPSG:2193'
+        assert round(c_trans['lat'].values[0]) == 29995930.0
 
     def test_intersect(self):
         pass

--- a/podpac/core/coordinates/test/test_coordinates.py
+++ b/podpac/core/coordinates/test/test_coordinates.py
@@ -764,8 +764,19 @@ class TestCoordinatesMethods(object):
         assert round(c1_trans['lat'].values[0]) == 615849.0
 
     def test_intersect(self):
-        pass
-        # TODO
+        # TODO: add additional testing
+        
+        # should change the other coordinates crs into the native coordinates crs for intersect
+        c = Coordinates([np.linspace(0, 10, 11), np.linspace(0, 10, 11), ['2018-01-01', '2018-01-02']], \
+                        dims=['lat', 'lon', 'time'])
+        o = Coordinates([np.linspace(28000000, 29500000, 20), np.linspace(-280000, 400000, 20), ['2018-01-01', '2018-01-02']], \
+                dims=['lat', 'lon', 'time'], coord_ref_sys='EPSG:2193')
+
+        c_int = c.intersect(o)
+        assert c_int.crs == DEFAULT_CRS
+        assert np.all(c_int['lat'].bounds == np.array([5., 10.]))
+        assert np.all(c_int['lon'].bounds == np.array([4., 10.]))
+        assert np.all(c_int['time'].values == c['time'].values)
 
 class TestCoordinatesSpecial(object):
     def test_repr(self):

--- a/podpac/core/coordinates/test/test_coordinates.py
+++ b/podpac/core/coordinates/test/test_coordinates.py
@@ -414,17 +414,17 @@ class TestCoordinatesProperties(object):
         # empty
         c = Coordinates([])
         assert c.coord_ref_sys == None
-        assert c.gdal_crs == None
+        assert c.crs == None
 
         # default
         c = Coordinates([[0, 1, 2]], dims=['lat'])
-        assert c.coord_ref_sys == 'WGS84'
-        assert c.gdal_crs == 'EPSG:4326'
+        assert c.coord_ref_sys == DEFAULT_CRS
+        assert c.crs == DEFAULT_CRS
 
         # set
-        c = Coordinates([[0, 1, 2]], dims=['lat'], coord_ref_sys='SPHER_MERC')
-        assert c.coord_ref_sys == 'SPHER_MERC'
-        assert c.gdal_crs == 'EPSG:3857'
+        c = Coordinates([[0, 1, 2]], dims=['lat'], coord_ref_sys='EPSG:2193')
+        assert c.coord_ref_sys == 'EPSG:2193'
+        assert c.crs == 'EPSG:2193'
 
 class TestCoordinatesDict(object):
     coords = Coordinates([[[0, 1, 2], [10, 20, 30]], ['2018-01-01', '2018-01-02']], dims=['lat_lon', 'time'])

--- a/podpac/core/coordinates/utils.py
+++ b/podpac/core/coordinates/utils.py
@@ -15,11 +15,6 @@ import numbers
 import numpy as np
 from six import string_types
 
-GDAL_CRS = {
-    'WGS84': 'EPSG:4326',
-    'SPHER_MERC': 'EPSG:3857'
-}
-
 def get_timedelta(s):
     """
     Make a numpy timedelta from a podpac timedelta string.

--- a/podpac/core/data/datasource.py
+++ b/podpac/core/data/datasource.py
@@ -381,6 +381,8 @@ class DataSource(Node):
         else:
             requested_dims = coordinates.dims
             coordinates = coordinates.transpose(*output.dims)
+            # TODO: there is no real way to know the crs of an input output UnitsDataArray
+
 
         # interpolate data into output
         output = self._interpolation.interpolate(self._requested_source_coordinates,
@@ -392,9 +394,12 @@ class DataSource(Node):
         if requested_dims is not None and requested_dims != output.dims:
             output = output.transpose(*requested_dims)
         
-        # transform the output crs to the requested coordinates crs
+        # transform the output crs to the r]equested coordinates crs
+        # TODO: this could be made into method in/for UnitsDataArray 
         if self._evaluated_coordinates.crs != coordinates.crs:
-            output.coords = self._evaluated_coordinates.coords
+            coords = Coordinates.from_xarray(output.coords)
+            t_coords = coords.transform(self._evaluated_coordinates.crs)
+            output = output.assign_coords(**t_coords.coords)
 
         # save output to private for debugging
         if settings['DEBUG']:

--- a/podpac/core/data/datasource.py
+++ b/podpac/core/data/datasource.py
@@ -166,6 +166,7 @@ class DataSource(Node):
     _requested_source_coordinates = tl.Instance(Coordinates)
     _requested_source_coordinates_index = tl.Tuple()
     _requested_source_data = tl.Instance(UnitsDataArray)
+    _evaluated_coordinates = tl.Instance(Coordinates)
 
     # when native_coordinates is not defined, default calls get_native_coordinates
     @tl.default('native_coordinates')

--- a/podpac/core/data/datasource.py
+++ b/podpac/core/data/datasource.py
@@ -353,7 +353,7 @@ class DataSource(Node):
             self.native_coordinates.intersect(coordinates, outer=True, return_indices=True)
 
         # if requested coordinates and native coordinates do not intersect, shortcut with nan UnitsDataArary
-        if np.prod(self._requested_source_coordinates.shape) == 0:
+        if self._requested_source_coordinates.size == 0:
             if output is None:
                 output = self.create_output_array(self._evaluated_coordinates)
             else:

--- a/podpac/core/data/interpolation.py
+++ b/podpac/core/data/interpolation.py
@@ -22,9 +22,9 @@ INTERPOLATORS = [NearestNeighbor, NearestPreview, Rasterio, ScipyPoint, ScipyGri
 INTERPOLATORS_DICT = {}
 """dict : Dictionary of a string interpolator name and associated interpolator class"""
 
-INTERPOLATION_METHODS = ['nearest_preview','nearest','bilinear','cubic','cubic_spline',
-           'lanczos','average','mode','gauss','max','min','med','q1','q3',
-           'spline_2','spline_3' ,'spline_4']
+INTERPOLATION_METHODS = ['nearest_preview', 'nearest', 'bilinear', 'cubic', 'cubic_spline',
+                         'lanczos', 'average', 'mode', 'gauss', 'max', 'min', 'med', 'q1', 'q3',
+                         'spline_2', 'spline_3', 'spline_4']
 
 INTERPOLATION_METHODS_DICT = {}
 """dict: Dictionary of string interpolation methods and associated interpolator classes
@@ -82,15 +82,11 @@ class Interpolation(object):
     definition : str, tuple (str, list of podpac.core.data.interpolator.Interpolator), dict
         Interpolation definition used to define interpolation methods for each definiton.
         See :attr:`podpac.data.DataSource.interpolation` for more details.
-    coordinates : :class:`podpac.Coordinates`
-        source coordinates to be interpolated
-    **kwargs :
-        Keyword arguments passed on to each :class:`podpac.interpolators.Interpolator`
     
     Raises
     ------
     InterpolationException
-    TypeError
+        Raised when definition parameter is improperly formatted
     
     """
  

--- a/podpac/core/data/interpolators.py
+++ b/podpac/core/data/interpolators.py
@@ -265,7 +265,7 @@ class Rasterio(Interpolator):
         
         with rasterio.Env():
             src_transform = get_rasterio_transform(source_coordinates)
-            src_crs = {'init': source_coordinates.gdal_crs}
+            src_crs = {'init': source_coordinates.crs}
             # Need to make sure array is c-contiguous
             if source_coordinates['lat'].is_descending:
                 source = np.ascontiguousarray(source_data.data)
@@ -273,7 +273,7 @@ class Rasterio(Interpolator):
                 source = np.ascontiguousarray(source_data.data[::-1, :])
         
             dst_transform = get_rasterio_transform(eval_coordinates)
-            dst_crs = {'init': eval_coordinates.gdal_crs}
+            dst_crs = {'init': eval_coordinates.crs}
             # Need to make sure array is c-contiguous
             if not output_data.data.flags['C_CONTIGUOUS']:
                 destination = np.ascontiguousarray(output_data.data)

--- a/podpac/core/data/test/test_datasource.py
+++ b/podpac/core/data/test/test_datasource.py
@@ -233,6 +233,37 @@ class TestDataSource(object):
 
         # output data and returned output data should match
         np.testing.assert_equal(output.transpose('lat', 'lon').data, returned_output.data)
+        np.testing.assert_equal(output.transpose('lat', 'lon').data, returned_output.data)
+
+
+    def test_evaluate_with_crs_transform(self):
+        # initialize coords with dims=[lon, lat]
+        grid_coords = Coordinates([np.linspace(-10, 10, 21), np.linspace(-10, -10, 21)], dims=['lat', 'lon'])
+        stack_coords = Coordinates([(np.linspace(-10, 10, 21), np.linspace(-10, -10, 21)), np.linspace(0, 10, 10)], dims=['lat_lon', 'time'])
+        
+        # transform coords so we know they will intersect with MockDataSource
+        grid_coords = grid_coords.transform('EPSG:2193')
+        stack_coords = stack_coords.transform('EPSG:2193')
+
+        # grid coords
+        node = MockDataSource()
+        out = node.eval(grid_coords)
+
+        assert round(out.coords['lat'].values[0]) == -8889021.0
+        assert round(out.coords['lon'].values[0]) == 1928929.0
+
+        # stacked coords
+        node = MockDataSource()
+        out = node.eval(stack_coords)
+
+        assert 'lat_lon' in out.coords
+        assert round(out.coords['lat'].values[0]) == -8889021.0
+        assert round(out.coords['lon'].values[0]) == 1928929.0
+
+
+
+
+    
 
     def test_evaluate_extra_dims(self):
         # drop extra dimension
@@ -323,7 +354,6 @@ class TestDataSource(object):
 
         assert isinstance(output, UnitsDataArray)
         assert node.native_coordinates['lat'].coordinates[4] == output.coords['lat'].values[4]
-
 
 
 

--- a/podpac/core/data/types.py
+++ b/podpac/core/data/types.py
@@ -26,6 +26,16 @@ import pandas as pd  # Core dependency of xarray
 # Helper utility for optional imports
 from lazy_import import lazy_module
 
+# Internal dependencies
+from podpac.core import authentication
+from podpac.core.node import Node
+from podpac.core.settings import settings
+from podpac.core.utils import cached_property, clear_cache, common_doc, trait_is_defined, ArrayTrait
+from podpac.core.data.datasource import COMMON_DATA_DOC, DataSource
+from podpac.core.coordinates import Coordinates, UniformCoordinates1d, ArrayCoordinates1d, StackedCoordinates
+from podpac.core.algorithm.algorithm import Algorithm
+from podpac.core.data.interpolation import interpolation_trait
+
 # Optional dependencies
 bs4 = lazy_module('bs4')
 # Not used directly, but used indirectly by bs4 so want to check if it's available
@@ -41,17 +51,6 @@ requests = lazy_module('requests')
 RasterToNumPyArray = lazy_module('arcpy.RasterToNumPyArray')
 urllib3 = lazy_module('urllib3')
 certifi = lazy_module('certifi')
-
-# Internal dependencies
-from podpac.core import authentication
-from podpac.core.node import Node
-from podpac.core.settings import settings
-from podpac.core.utils import cached_property, clear_cache, common_doc, trait_is_defined, ArrayTrait
-from podpac.core.data.datasource import COMMON_DATA_DOC, DataSource
-from podpac.core.coordinates import Coordinates, UniformCoordinates1d, ArrayCoordinates1d, StackedCoordinates
-from podpac.core.algorithm.algorithm import Algorithm
-from podpac.core.data.interpolation import interpolation_trait
-
 
 # Set up logging
 _logger = logging.getLogger(__name__)

--- a/podpac/core/data/types.py
+++ b/podpac/core/data/types.py
@@ -499,7 +499,10 @@ class Rasterio(DataSource):
         #         crs = None
         # except:
         #     crs = None
-        crs = None
+        try:
+            crs = self.dataset.crs['init'].upper()
+        except:
+            crs = None
 
         # get bounds
         left, bottom, right, top = self.dataset.bounds

--- a/podpac/core/settings.py
+++ b/podpac/core/settings.py
@@ -38,7 +38,8 @@ DEFAULT_SETTINGS = {
     'LOG_FILE_PATH': os.path.join(os.path.expanduser('~'), '.podpac', 'logs', 'podpac.log'),
     'MULTITHREADING': False,
     'N_THREADS': 8,
-    'CHUNK_SIZE': None
+    'CHUNK_SIZE': None,
+    'DEFAULT_CRS': 'EPSG:4326'
 }
 
 

--- a/podpac/datalib/terraintiles.py
+++ b/podpac/datalib/terraintiles.py
@@ -114,9 +114,8 @@ class TerrainTilesSource(Rasterio):
             f.seek(0)
             
             dataset = f.open()
-            reprojected_dataset = self._reproject(dataset, {'init': 'epsg:4326'})  # reproject dataset into WGS84
 
-        return reprojected_dataset
+        return dataset
 
     def get_data(self, coordinates, coordinates_index):
         data = super(TerrainTilesSource, self).get_data(coordinates, coordinates_index)

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-""" 
+"""
 podpac module
 """
 
@@ -20,7 +20,9 @@ install_requires = ['matplotlib>=2.1',
                     'traitlets>=4.3',
                     'xarray>=0.10',
                     'requests>=2.18',
+                    'pyproj>=2.1',
                     'lazy-import>=0.2.2']
+
 if sys.version_info.major == 2:
     install_requires += ['future>=0.16']
 


### PR DESCRIPTION
Enables coordinate transformations using the PROJ4 syntax.

Automatically handles coordinate transformations in DataSource nodes. The data source eval process entails:

- first convert evaluated `coordinates` in the same crs as the `native_coordinates` in the data source node.
- Run the DataSource eval process, including coordinate intersection, interpolation coordinate down-selection, interpolation of data, and output data creation all the in the CRS of the native coordinates
- Just before returning the output, transform the coords of the output UnitsDataArray into the CRS of the original evaluated `coordinates`
- Return UnitsDataArray

There is ONE potential caveat that I haven't probed deeply. If an output UnitsDataArray is included in the `DataSource.eval(coordinates, output=output)`, it will work correctly assuming the output array is in the crs of the evaluated coordinates.  There is no way to verify what crs since we don't track the crs on the UnitsDataArray.  

## Example Usage:

```python
c = Coordinates([[0, 1], [10, 20], ['2018-01-01', '2018-01-02']], dims=['lat', 'lon', 'time'])  # uses default crs
tc = c.transform('EPSG:2193')   # use a gdal string
tc = c.transform('+proj=merc +lat_ts=56.5 +ellps=GRS80')  # use a proj4 string
```

works for stacked coordinates:

```python
stack_coords = Coordinates([(np.linspace(-10, 10, 21), np.linspace(-30, -10, 21))], dims=['lat_lon'])
tc = c.transform('EPSG:2193')   # use a gdal string
tc = c.transform('+proj=merc +lat_ts=56.5 +ellps=GRS80')  # use a proj4 string
```

use in DataSource node:

```python
c = Coordinates([[0, 1], [10, 20], ['2018-01-01', '2018-01-02']], dims=['lat', 'lon', 'time'])
node = Array(source=np.ones((2,2,2)), native_coordinates=c)
ct = c.transform('EPSG:2193')
node.eval(ct)

>> <xarray.UnitsDataArray (lat: 2, lon: 2, time: 2)>
array([[[1., 1.],
        [1., 1.]],

       [[1., 1.],
        [1., 1.]]])
Coordinates:
  * lat      (lat) float64 3e+07 2.987e+07
  * lon      (lon) float64 -3.203e+05 -1.523e+06
  * time     (time) datetime64[ns] 2018-01-01 2018-01-02
Attributes:
    layer_style:  <podpac.core.style.Style object at 0x1c29f5dfd0>
    units:        None
```

## More Transform Examples (from docstring)

Transform gridded coordinates::

    c = Coordinates([np.linspace(-10, 10, 21), np.linspace(-30, -10, 21)], dims=['lat', 'lon'])
    c.crs

    >> 'EPSG:4326'

    c.transform('EPSG:2193')

    >> Coordinates
        lat: ArrayCoordinates1d(lat): Bounds[-9881992.849134896, 29995929.885877542], N[21], ctype['point']
        lon: ArrayCoordinates1d(lon): Bounds[1928928.7360588573, 4187156.434405213], N[21], ctype['midpoint']

Transform stacked coordinates::

    c = Coordinates([(np.linspace(-10, 10, 21), np.linspace(-30, -10, 21))], dims=['lat_lon'])
    c.transform('EPSG:2193')

    >> Coordinates
        lat_lon[lat]: ArrayCoordinates1d(lat): Bounds[-9881992.849134896, 29995929.885877542], N[21], ctype['point']
        lat_lon[lon]: ArrayCoordinates1d(lon): Bounds[1928928.7360588573, 4187156.434405213], N[21], ctype['midpoint']

Transform coordinates using a PROJ4 string::

    c = Coordinates([np.linspace(-10, 10, 21), np.linspace(-30, -10, 21)], dims=['lat', 'lon'])
    c.transform('+proj=merc +lat_ts=56.5 +ellps=GRS80')

    >> Coordinates
        lat: ArrayCoordinates1d(lat): Bounds[-1847545.541169525, -615848.513723175], N[21], ctype['midpoint']
        lon: ArrayCoordinates1d(lon): Bounds[-614897.0725896168, 614897.0725896184], N[21], ctype['midpoint']

Transform coordinates with altitude::

    # include alt units in proj4 string
    c = Coordinates([[0, 1, 2], [0, 1, 2], [1, 2, 3]], dims=['lat', 'lon', 'alt'])
    c.transform('+init=epsg:2193 +vunits=ft')

    >> Coordinates
        lat: ArrayCoordinates1d(lat): Bounds[594971.8894642257, 819117.0608407748], N[3], ctype['midpoint']
        lon: ArrayCoordinates1d(lon): Bounds[29772096.71234478, 29995929.885877542], N[3], ctype['midpoint']
        alt: ArrayCoordinates1d(alt): Bounds[3.280839895013123, 9.842519685039369], N[3], ctype['midpoint']


    # specify alt units seperately
    c.transform('EPSG:2193', alt_units='ft')

    >> Coordinates
        lat: ArrayCoordinates1d(lat): Bounds[594971.8894642257, 819117.0608407748], N[3], ctype['midpoint']
        lon: ArrayCoordinates1d(lon): Bounds[29772096.71234478, 29995929.885877542], N[3], ctype['midpoint']
        alt: ArrayCoordinates1d(alt): Bounds[3.280839895013123, 9.842519685039369], N[3], ctype['midpoint']

    # using alt_units will save the property `crs` as a proj4 string:
    ct = c.transform('EPSG:2193', alt_units='ft')
    ct.crs

    >> '+proj=tmerc +lat_0=0 +lon_0=173 +k=0.9996 +x_0=1600000 +y_0=10000000 +ellps=GRS80 +units=m +no_defs +type=crs +vunits=ft'
