### PR TITLE
Feature/basic cache limits

### DIFF
--- a/doc/source/user/settings.md
+++ b/doc/source/user/settings.md
@@ -83,3 +83,100 @@ from podpac import settings
 
 print(settings.defaults)
 ```
+
+## Details on Specific Settings 
+
+For information on specific settings for your version of podpac see the settings module doc.
+
+```python
+>>> from podpac import settings
+>>> print(settings.__doc__)
+"""
+    Persistently stored podpac settings
+
+    Podpac settings are persistently stored in a ``settings.json`` file created at runtime.
+    By default, podpac will create a settings json file in the users
+    home directory (``~/.podpac/settings.json``) when first run.
+
+    Default settings can be overridden or extended by:
+      * editing the ``settings.json`` file in the home directory (i.e. ``~/.podpac/settings.json``)
+      * creating a ``settings.json`` in the current working directory (i.e. ``./settings.json``)
+
+    If ``settings.json`` files exist in multiple places, podpac will load settings in the following order,
+    overwriting previously loaded settings in the process:
+      * podpac settings defaults
+      * home directory settings (``~/.podpac/settings.json``)
+      * current working directory settings (``./settings.json``)
+
+    :attr:`settings.settings_path` shows the path of the last loaded settings file (e.g. the active settings file).
+    To persistenyl update the active settings file as changes are made at runtime,
+    set the ``settings['AUTOSAVE_SETTINGS']`` field to ``True``. The active setting file can be persistently
+    saved at any time using :meth:`settings.save`.
+
+    The default settings are shown below:
+
+    Attributes
+    ----------
+    DEFAULT_CRS : str
+        Default coordinate reference system for spatial coordinates. Defaults to 'EPSG:4326'.
+    AWS_ACCESS_KEY_ID : str
+        The access key for your AWS account.
+        See the `boto3 documentation
+        <https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#environment-variable-configuration>`_
+        for more details.
+    AWS_SECRET_ACCESS_KEY : str
+        The secret key for your AWS account.
+        See the `boto3 documentation
+        <https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#environment-variable-configuration>`_
+        for more details.
+    AWS_REGION_NAME : str
+        Name of the AWS region, e.g. us-west-1, us-west-2, etc.
+    DEFAULT_CACHE : list
+        Defines a default list of cache stores in priority order. Defaults to `['ram']`.
+    CACHE_OUTPUT_DEFAULT : bool
+        Default value for node ``cache_output`` trait.
+    RAM_CACHE_MAX_BYTES : int
+        Maximum RAM cache size in bytes.
+        Note, for RAM cache only, the limit is applied to the total amount of RAM used by the python process;
+        not just the contents of the RAM cache. The python process will not be restrited by this limit,
+        but once the limit is reached, additions to the cache will be subject to it.
+        Defaults to ``1e9`` (~1G).
+        Set to `None` explicitly for no limit.
+    DISK_CACHE_MAX_BYTES : int
+        Maximum disk space for use by the disk cache in bytes.
+        Defaults to ``10e9`` (~10G).
+        Set to `None` explicitly for no limit.
+    S3_CACHE_MAX_BYTES : int
+        Maximum storage space for use by the s3 cache in bytes.
+        Defaults to ``10e9`` (~10G).
+        Set to `None` explicitly for no limit.
+    DISK_CACHE_DIR : str
+        Subdirectory to use for the disk cache. Defaults to ``'cache'`` in the podpac root directory.
+    S3_CACHE_DIR : str
+        Subdirectory to use for S3 cache (within the specified S3 bucket). Defaults to ``'cache'``.
+    RAM_CACHE_ENABLED: bool
+        Enable caching to RAM. Note that if disabled, some nodes may fail. Defaults to ``True``.
+    DISK_CACHE_ENABLED: bool
+        Enable caching to disk. Note that if disabled, some nodes may fail. Defaults to ``True``.
+    S3_CACHE_ENABLED: bool
+        Enable caching to RAM. Note that if disabled, some nodes may fail. Defaults to ``True``.
+    ROOT_PATH : str
+        Path to primary podpac working directory. Defaults to the ``.podpac`` directory in the users home directory.
+    S3_BUCKET_NAME : str
+        The AWS S3 Bucket to use for cloud based processing.
+    S3_JSON_FOLDER : str
+        Folder within :attr:`S3_BUCKET_NAME` to use for cloud based processing.
+    S3_OUTPUT_FOLDER : str
+        Folder within :attr:`S3_BUCKET_NAME` to use for outputs.
+    AUTOSAVE_SETTINGS: bool
+        Save settings automatically as they are changed during runtime. Defaults to ``False``.
+    MULTITHREADING: bool
+        Uses multithreaded evaluation, when applicable. Defaults to ``False``.
+    N_THREADS: int
+        Number of threads to use (only if MULTITHREADING is True). Defaults to ``10``.
+    CHUNK_SIZE: int, 'auto', None
+        Chunk size for iterative evaluation, when applicable (e.g. Reduce Nodes). Use None for no iterative evaluation,
+        and 'auto' to automatically calculate a chunk size based on the system. Defaults to ``None``.
+"""
+>>>
+```

--- a/podpac/core/cache/cache.py
+++ b/podpac/core/cache/cache.py
@@ -762,8 +762,7 @@ class FileCacheStore(CacheStore):
         else:
             self.save_new_container(listings=[listing], path=path)
 
-
-        if self.max_size and self.size() >= self.max_size:
+        if self.max_size is not None and self.size() >= self.max_size:
         #     # TODO removal policy
             self.rem(node=node, key=key, coordinates=coordinates)
             raise CacheException("Cache is full. Remove some old entries and try again.")
@@ -915,7 +914,7 @@ class DiskCacheStore(FileCacheStore):
         else:
             self._root_dir_path = self._path_join([settings['ROOT_PATH'], settings['DISK_CACHE_DIR']])
 
-        if max_size:
+        if max_size is not None:
             self.max_size = max_size
         elif 'DISK_CACHE_MAX_BYTES' in settings and settings['DISK_CACHE_MAX_BYTES']:
             self.max_size = settings['DISK_CACHE_MAX_BYTES']
@@ -1068,7 +1067,7 @@ class S3CacheStore(FileCacheStore):
                                              aws_secret_access_key=aws_secret_access_key)
         self._s3_bucket = s3_bucket
 
-        if max_size:
+        if max_size is not None:
             self.max_size = max_size
         elif 'S3_CACHE_MAX_BYTES' in settings and settings['S3_CACHE_MAX_BYTES']:
             self.max_size = settings['S3_CACHE_MAX_BYTES']
@@ -1238,7 +1237,7 @@ class RamCacheStore(CacheStore):
         if not settings['RAM_CACHE_ENABLED']:
             raise CacheException("RAM cache is disabled in the podpac settings.")
 
-        if max_size:
+        if max_size is not None:
             self.max_size = max_size
         elif 'RAM_CACHE_MAX_BYTES' in settings and settings['RAM_CACHE_MAX_BYTES']:
             self.max_size = settings['RAM_CACHE_MAX_BYTES']
@@ -1281,8 +1280,7 @@ class RamCacheStore(CacheStore):
         if full_key in _thread_local.cache:
             if not update:
                 raise CacheException("Cache entry already exists. Use update=True to overwrite.")
-
-        if self.max_size and self.size() >= self.max_size:
+        if self.max_size is not None and self.size() >= self.max_size:
         #     # TODO removal policy
             raise CacheException("RAM cache full. Remove some old entries and try again.")
 

--- a/podpac/core/cache/cache.py
+++ b/podpac/core/cache/cache.py
@@ -13,6 +13,7 @@ from hashlib import md5 as hash_alg
 import six
 import fnmatch
 from lazy_import import lazy_module
+import psutil
 try:
     import cPickle  # Python 2.7
 except:
@@ -317,6 +318,12 @@ class CacheStore(object):
         if len(self.cache_modes.intersection(modes)) > 0:
             return True
         return False
+
+    def size(self):
+        """Return size of cache store in bytes
+        """
+        raise NotImplementedError
+
 
     def put(self, node, data, key, coordinates=None, update=False):
         '''Cache data for specified node.
@@ -729,6 +736,11 @@ class FileCacheStore(CacheStore):
             If True existing data in cache will be updated with `data`, If False, error will be thrown if attempting put something into the cache with the same node, key, coordinates of an existing entry.
         '''
         self.make_cache_dir(node)
+
+        if self.size() >= self.max_size:
+        #     # TODO removal policy
+            raise CacheException("RAM cache full. Remove some old entries and try again.")
+
         listing = CacheListing(node=node, key=key, coordinates=coordinates, data=data)
         if self.has(node, key, coordinates): # a little inefficient but will do for now
             if not update:
@@ -869,7 +881,7 @@ class DiskCacheStore(FileCacheStore):
 
     cache_modes = set(['disk','all'])
 
-    def __init__(self, root_cache_dir_path=None, storage_format='pickle'):
+    def __init__(self, root_cache_dir_path=None, storage_format='pickle', max_size=None):
         """Initialize a cache that uses a folder on a local disk file system.
         
         Parameters
@@ -878,9 +890,13 @@ class DiskCacheStore(FileCacheStore):
             Root directory for the files managed by this cache. `None` indicates to use the folder specified in the global podpac settings. Should be a fully specified valid path.
         storage_format : str, optional
             Indicates the file format for storage. Defaults to 'pickle' which is currently the only supported format.
+        max_size : None, optional
+            Maximum allowed size of the cache store in bytes. Defaults to podpac 'DISK_CACHE_MAX_BYTES' setting, or no limit if this setting does not exist.
         
         Raises
         ------
+        CacheException
+            Description
         NotImplementedError
             If unsupported `storage_format` is specified
         """
@@ -895,6 +911,13 @@ class DiskCacheStore(FileCacheStore):
             self._root_dir_path = settings['DISK_CACHE_DIR']
         else:
             self._root_dir_path = self._path_join([settings['ROOT_PATH'], settings['DISK_CACHE_DIR']])
+
+        if max_size:
+            self.max_size = max_size
+        elif 'DISK_CACHE_MAX_BYTES' in settings and settings['DISK_CACHE_MAX_BYTES']:
+            self.max_size = settings['DISK_CACHE_MAX_BYTES']
+        else:
+            self.max_size = None
 
         # make directory if it doesn't already exist
         os.makedirs(self._root_dir_path, exist_ok=True)
@@ -971,12 +994,20 @@ class DiskCacheStore(FileCacheStore):
     def rem_dir(self, directory):
         os.rmdir(directory)
 
+    def size(self):
+        total_size = 0
+        for dirpath, dirnames, filenames in os.walk(start_path):
+            for f in filenames:
+                fp = os.path.join(dirpath, f)
+                total_size += os.path.getsize(fp)
+        return total_size
+
 class S3CacheStore(FileCacheStore):
 
     cache_modes = set(['s3','all'])
     _delim = '/'
 
-    def __init__(self, root_cache_dir_path=None, storage_format='pickle', 
+    def __init__(self, root_cache_dir_path=None, storage_format='pickle', max_size=None,
                  s3_bucket=None, aws_region_name=None, aws_access_key_id=None, aws_secret_access_key=None):
         """Initialize a cache that uses a folder on a local disk file system.
         
@@ -986,6 +1017,8 @@ class S3CacheStore(FileCacheStore):
             Root directory for the files managed by this cache. `None` indicates to use the folder specified in the global podpac settings. Should be the common "root" s3 prefix that you want to have all cached objects stored in. Do not store any objects in the bucket that share this prefix as they may be deleted by the cache.
         storage_format : str, optional
             Indicates the file format for storage. Defaults to 'pickle' which is currently the only supported format.
+        max_size : None, optional
+            Maximum allowed size of the cache store in bytes. Defaults to podpac 'S3_CACHE_MAX_BYTES' setting, or no limit if this setting does not exist.
         s3_bucket : str, optional
             bucket name, overides settings
         aws_region_name : str, optional
@@ -1031,6 +1064,14 @@ class S3CacheStore(FileCacheStore):
                                              aws_access_key_id=aws_access_key_id,
                                              aws_secret_access_key=aws_secret_access_key)
         self._s3_bucket = s3_bucket
+
+        if max_size:
+            self.max_size = max_size
+        elif 'S3_CACHE_MAX_BYTES' in settings and settings['S3_CACHE_MAX_BYTES']:
+            self.max_size = settings['S3_CACHE_MAX_BYTES']
+        else:
+            self.max_size = None
+
         try:
             self._s3_client.head_bucket(Bucket=self._s3_bucket)
         except Exception as e:
@@ -1060,6 +1101,17 @@ class S3CacheStore(FileCacheStore):
         response = self._s3_client.list_objects_v2(Bucket=self._s3_bucket, Prefix=path)
         obj_count = response['KeyCount']
         return obj_count == 1 and response['Contents'][0]['Key'] == path
+
+    def size(self):
+        paginator = self._s3_client.get_paginator('list_objects')
+        operation_parameters = {'Bucket': self._s3_bucket,
+                                'Prefix': self._root_dir_path}
+        page_iterator = paginator.paginate(**operation_parameters)
+        total_size = 0
+        for page in page_iterator:
+            for obj in page['Contents']:
+                total_size += obj['Size']
+        return total_size
 
     def make_cache_dir(self, node):
         """Create subdirectory for caching data for `node`
@@ -1166,9 +1218,28 @@ class RamCacheStore(CacheStore):
 
     cache_modes = set(['ram', 'all'])
 
-    def __init__(self):
+    def __init__(self, max_size=None):
+        """Summary
+        
+        Raises
+        ------
+        CacheException
+            Description
+        
+        Parameters
+        ----------
+        max_size : None, optional
+            Maximum allowed size of the cache store in bytes. Defaults to podpac 'S3_CACHE_MAX_BYTES' setting, or no limit if this setting does not exist.
+        """
         if not settings['RAM_CACHE_ENABLED']:
             raise CacheException("RAM cache is disabled in the podpac settings.")
+
+        if max_size:
+            self.max_size = max_size
+        elif 'RAM_CACHE_MAX_BYTES' in settings and settings['RAM_CACHE_MAX_BYTES']:
+            self.max_size = settings['RAM_CACHE_MAX_BYTES']
+        else:
+            self.max_size = None
 
         super(CacheStore, self).__init__()
 
@@ -1179,6 +1250,10 @@ class RamCacheStore(CacheStore):
 
     def _get_full_key(self, node, coordinates, key):
         return (self._get_key(node), self._get_key(coordinates), key)
+
+    def size(self):
+        process = psutil.Process(os.getpid())
+        return process.memory_info().rss # this is actually the total size of the process
 
     def put(self, node, data, key, coordinates=None, update=False):
         '''Cache data for specified node.
@@ -1203,10 +1278,9 @@ class RamCacheStore(CacheStore):
             if not update:
                 raise CacheException("Cache entry already exists. Use update=True to overwrite.")
 
-        # TODO
-        # elif current_size + data_size > max_size:
+        if self.size() >= self.max_size:
         #     # TODO removal policy
-        #     raise CacheException("RAM cache full. Remove some old entries and try again.")
+            raise CacheException("RAM cache full. Remove some old entries and try again.")
 
         # TODO include insert date, last retrieval date, and/or # retrievals for use in a removal policy
         _thread_local.cache[full_key] = data

--- a/podpac/core/cache/cache.py
+++ b/podpac/core/cache/cache.py
@@ -737,10 +737,6 @@ class FileCacheStore(CacheStore):
         '''
         self.make_cache_dir(node)
 
-        if self.max_size and self.size() >= self.max_size:
-        #     # TODO removal policy
-            raise CacheException("Cache is full. Remove some old entries and try again.")
-
         listing = CacheListing(node=node, key=key, coordinates=coordinates, data=data)
         if self.has(node, key, coordinates): # a little inefficient but will do for now
             if not update:
@@ -765,6 +761,13 @@ class FileCacheStore(CacheStore):
         # if file for listing does not already exist, we need to create a new container, add the listing, and save to file
         else:
             self.save_new_container(listings=[listing], path=path)
+
+
+        if self.max_size and self.size() >= self.max_size:
+        #     # TODO removal policy
+            self.rem(node=node, key=key, coordinates=coordinates)
+            raise CacheException("Cache is full. Remove some old entries and try again.")
+
         return True
 
     def get(self, node, key, coordinates=None):

--- a/podpac/core/cache/test/test_disk_store.py
+++ b/podpac/core/cache/test/test_disk_store.py
@@ -16,12 +16,11 @@ from podpac.core.coordinates.coordinates import Coordinates
 
 root_disk_cache_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), 'tmp_cache'))
 
-def make_cache_ctrl():
-    store = DiskCacheStore(root_cache_dir_path=root_disk_cache_dir)
+def make_cache_ctrl(max_size=None):
+    store = DiskCacheStore(root_cache_dir_path=root_disk_cache_dir, max_size=max_size)
     ctrl = CacheCtrl(cache_stores=[store])
+    ctrl.rem(node='*', key='*', coordinates='*', mode='all')
     return ctrl
-
-cache = make_cache_ctrl()
 
 def make_array_data_source(coords_func=None, data_func=None):
     if data_func is None:
@@ -44,7 +43,42 @@ node_funcs = [lambda: make_array_data_source(coords_func=c, data_func=d) for d i
 data_funcs = [lambda: np.zeros((2,3,4)), lambda: np.ones((2,3,4))]
 coord_funcs = coord_funcs + [lambda: None]
 
+def test_put_and_get_with_cache_limits():
+    insufficient_sizes = [0, 10, 100]
+    sufficient_sizes = [1e6, 1e9]
+
+    for s in insufficient_sizes:
+        cache = make_cache_ctrl(max_size=s)
+        for coord_f in coord_funcs:
+            for node_f in node_funcs:
+                for data_f in data_funcs:
+                    c1,c2 = coord_f(),coord_f()
+                    n1,n2 = node_f(), node_f()
+                    din = data_f()
+                    k = "key"
+                    with pytest.raises(CacheException):
+                        cache.put(node=n1, data=din, key=k, coordinates=c1, mode='all', update=False)
+                    assert not cache.has(node=n1, key=k, coordinates=c1, mode='all')
+                    cache.rem(node='*', key='*', coordinates='*', mode='all')
+
+    for s in sufficient_sizes:
+        cache = make_cache_ctrl(max_size=s)
+        for coord_f in coord_funcs:
+            for node_f in node_funcs:
+                for data_f in data_funcs:
+                    c1,c2 = coord_f(),coord_f()
+                    n1,n2 = node_f(), node_f()
+                    din = data_f()
+                    k = "key"
+                    cache.put(node=n1, data=din, key=k, coordinates=c1, mode='all', update=False)
+                    dout = cache.get(node=n1, key=k, coordinates=c1, mode='all')
+                    assert (din == dout).all()
+                    dout = cache.get(node=n2, key=k, coordinates=c2, mode='all')
+                    assert (din == dout).all()
+                    cache.rem(node='*', key='*', coordinates='*', mode='all')
+
 def test_put_and_get():
+    cache = make_cache_ctrl()
     for coord_f in coord_funcs:
         for node_f in node_funcs:
             for data_f in data_funcs:
@@ -61,6 +95,7 @@ def test_put_and_get():
 
 
 def test_put_and_update():
+    cache = make_cache_ctrl()
     for coord_f in coord_funcs:
         for node_f in node_funcs:
             for data_f in data_funcs:
@@ -81,6 +116,7 @@ def test_put_and_update():
                 cache.rem(node='*', key='*', coordinates='*', mode='all')
 
 def test_put_and_remove():
+    cache = make_cache_ctrl()
     for coord_f in coord_funcs:
         for node_f in node_funcs:
             for data_f in data_funcs:
@@ -97,6 +133,7 @@ def test_put_and_remove():
                 cache.rem(node='*', key='*', coordinates='*', mode='all')
 
 def test_put_two_and_remove_one():
+    cache = make_cache_ctrl()
     for coord_f in coord_funcs:
         for node_f in node_funcs:
             for data_f in data_funcs:
@@ -118,6 +155,7 @@ def test_put_two_and_remove_one():
                 cache.rem(node='*', key='*', coordinates='*', mode='all')
 
 def test_put_two_and_remove_all():
+    cache = make_cache_ctrl()
     for coord_f in coord_funcs:
         for node_f in node_funcs:
             for data_f in data_funcs:
@@ -141,6 +179,7 @@ def test_put_two_and_remove_all():
                 cache.rem(node='*', key='*', coordinates='*', mode='all')
 
 def test_two_different_nodes_put_and_one_node_removes_all():
+    cache = make_cache_ctrl()
     lat = np.random.rand(3)
     lon = np.random.rand(4)
     coords = Coordinates([lat,lon],['lat','lon'])
@@ -172,6 +211,7 @@ def test_two_different_nodes_put_and_one_node_removes_all():
     cache.rem(node='*', key='*', coordinates='*', mode='all')
 
 def test_put_something_new_into_existing_file():
+    cache = make_cache_ctrl()
     lat = np.random.rand(3)
     lon = np.random.rand(4)
     dummy_coords = Coordinates([lat,lon],['lat','lon'])
@@ -210,6 +250,7 @@ def test_put_something_new_into_existing_file():
                 cache.rem(node='*', key='*', coordinates='*', mode='all')
 
 def test_put_and_get_array_datasource_output():
+    cache = make_cache_ctrl()
     lat = [0, 1, 2]
     lon = [10, 20, 30, 40]
     dates = ['2018-01-01', '2018-01-02']
@@ -223,6 +264,7 @@ def test_put_and_get_array_datasource_output():
     cache.rem(node='*', key='*', coordinates='*', mode='all') # clear the cache stores
 
 def test_put_and_get_with_different_instances_of_same_key_objects_array_datasource_output():
+    cache = make_cache_ctrl()
     lat = [0, 1, 2]
     lon = [10, 20, 30, 40]
     dates = ['2018-01-01', '2018-01-02']
@@ -246,6 +288,7 @@ def test_put_and_get_with_different_instances_of_same_key_objects_array_datasour
     cache.rem(node='*', key='*', coordinates='*', mode='all') # clear the cache stores
 
 def test_put_and_update_array_datasource_numpy_array():
+    cache = make_cache_ctrl()
     lat = [0, 1, 2]
     lon = [10, 20, 30, 40]
     dates = ['2018-01-01', '2018-01-02']
@@ -266,6 +309,7 @@ def test_put_and_update_array_datasource_numpy_array():
     cache.rem(node='*', key='*', coordinates='*', mode='all') # clear the cache stores
 
 def test_put_and_remove_array_datasource_numpy_array():
+    cache = make_cache_ctrl()
     lat = [0, 1, 2]
     lon = [10, 20, 30, 40]
     dates = ['2018-01-01', '2018-01-02']

--- a/podpac/core/cache/test/test_s3_store.py
+++ b/podpac/core/cache/test/test_s3_store.py
@@ -46,6 +46,7 @@ node_funcs = [lambda: make_array_data_source(coords_func=c, data_func=d) for d i
 data_funcs = [lambda: np.zeros((2,3,4)), lambda: np.ones((2,3,4))]
 coord_funcs = coord_funcs + [lambda: None]
 
+@pytest.mark.skipif(pytest.config.getoption('--ci'), reason="not a ci test")
 def test_put_and_get_with_cache_limits():
     insufficient_sizes = [0, 10, 100]
     sufficient_sizes = [1e6, 1e9]

--- a/podpac/core/settings.py
+++ b/podpac/core/settings.py
@@ -91,11 +91,20 @@ class PodpacSettings(dict):
     CACHE_OUTPUT_DEFAULT : bool
         Default value for node ``cache_output`` trait.
     RAM_CACHE_MAX_BYTES : int
-        Maximum RAM cache size in bytes. Note, for RAM cache only, the limit is applied to the total amount of RAM used by the python process; not just the contents of the RAM cache. Defaults to ``1e9`` (~1G). Set to `None` explicitly for no limit.
+        Maximum RAM cache size in bytes. 
+        Note, for RAM cache only, the limit is applied to the total amount of RAM used by the python process; 
+        not just the contents of the RAM cache. The python process will not be restrited by this limit,
+        but once the limit is reached, additions to the cache will be subject to it.
+        Defaults to ``1e9`` (~1G). 
+        Set to `None` explicitly for no limit.
     DISK_CACHE_MAX_BYTES : int
-        Maximum disk space for use by the disk cache in bytes. Defaults to ``10e9`` (~10G). Set to `None` explicitly for no limit.
+        Maximum disk space for use by the disk cache in bytes. 
+        Defaults to ``10e9`` (~10G). 
+        Set to `None` explicitly for no limit.
     S3_CACHE_MAX_BYTES : int
-        Maximum storage space for use by the s3 cache in bytes. Defaults to ``10e9`` (~10G). Set to `None` explicitly for no limit.
+        Maximum storage space for use by the s3 cache in bytes. 
+        Defaults to ``10e9`` (~10G). 
+        Set to `None` explicitly for no limit.
     DISK_CACHE_DIR : str
         Subdirectory to use for the disk cache. Defaults to ``'cache'`` in the podpac root directory.
     S3_CACHE_DIR : str

--- a/podpac/core/settings.py
+++ b/podpac/core/settings.py
@@ -91,7 +91,7 @@ class PodpacSettings(dict):
     CACHE_OUTPUT_DEFAULT : bool
         Default value for node ``cache_output`` trait.
     RAM_CACHE_MAX_BYTES : int
-        Maximum RAM cache size in bytes. Defaults to ``1e9`` (~1G). Set to `None` explicitly for no limit.
+        Maximum RAM cache size in bytes. Note, for RAM cache only, the limit is applied to the total amount of RAM used by the python process; not just the contents of the RAM cache. Defaults to ``1e9`` (~1G). Set to `None` explicitly for no limit.
     DISK_CACHE_MAX_BYTES : int
         Maximum disk space for use by the disk cache in bytes. Defaults to ``10e9`` (~10G). Set to `None` explicitly for no limit.
     S3_CACHE_MAX_BYTES : int

--- a/podpac/core/settings.py
+++ b/podpac/core/settings.py
@@ -19,9 +19,9 @@ DEFAULT_SETTINGS = {
     'DEBUG': False,  # This flag currently sets self._output on nodes
     'DEFAULT_CACHE': ['ram'],
     'CACHE_OUTPUT_DEFAULT': True,
-    'RAM_CACHE_MAX_BYTES': 1e9, # ~1GB    TODO
-    'DISK_CACHE_MAX_BYTES': 10e9, # ~10GB TODO
-    'S3_CACHE_MAX_BYTES': 10e9, # ~10GB TODO
+    'RAM_CACHE_MAX_BYTES': 1e9,   # ~1GB
+    'DISK_CACHE_MAX_BYTES': 10e9, # ~10GB
+    'S3_CACHE_MAX_BYTES': 10e9,   # ~10GB
     'DISK_CACHE_DIR': 'cache',
     'S3_CACHE_DIR': 'cache',
     'RAM_CACHE_ENABLED': True,
@@ -91,11 +91,11 @@ class PodpacSettings(dict):
     CACHE_OUTPUT_DEFAULT : bool
         Default value for node ``cache_output`` trait.
     RAM_CACHE_MAX_BYTES : int
-        Maximum RAM cache size in bytes. Defaults to ``1e9`` (~1G).
+        Maximum RAM cache size in bytes. Defaults to ``1e9`` (~1G). Set to `None` explicitly for no limit.
     DISK_CACHE_MAX_BYTES : int
-        Maximum disk space for use by the disk cache in bytes. Defaults to ``10e9`` (~10G).
+        Maximum disk space for use by the disk cache in bytes. Defaults to ``10e9`` (~10G). Set to `None` explicitly for no limit.
     S3_CACHE_MAX_BYTES : int
-        Maximum storage space for use by the s3 cache in bytes. Defaults to ``10e9`` (~10G).
+        Maximum storage space for use by the s3 cache in bytes. Defaults to ``10e9`` (~10G). Set to `None` explicitly for no limit.
     DISK_CACHE_DIR : str
         Subdirectory to use for the disk cache. Defaults to ``'cache'`` in the podpac root directory.
     S3_CACHE_DIR : str

--- a/podpac/core/settings.py
+++ b/podpac/core/settings.py
@@ -19,8 +19,9 @@ DEFAULT_SETTINGS = {
     'DEBUG': False,
     'DEFAULT_CACHE': ['ram'],
     'CACHE_OUTPUT_DEFAULT': True,
-#    'RAM_CACHE_MAX_BYTES': 1e9, # ~1GB    TODO
-#    'DISK_CACHE_MAX_BYTES': 10e9, # ~10GB TODO
+    'RAM_CACHE_MAX_BYTES': 1e9, # ~1GB    TODO
+    'DISK_CACHE_MAX_BYTES': 10e9, # ~10GB TODO
+    'S3_CACHE_MAX_BYTES': 10e9, # ~10GB TODO
     'DISK_CACHE_DIR': 'cache',
     'S3_CACHE_DIR': 'cache',
     'RAM_CACHE_ENABLED': True,
@@ -90,6 +91,8 @@ class PodpacSettings(dict):
         Maximum RAM cache size in bytes. Defaults to ``1e9`` (~1G).
     DISK_CACHE_MAX_BYTES : int
         Maximum disk space for use by the disk cache in bytes. Defaults to ``10e9`` (~10G).
+    S3_CACHE_MAX_BYTES : int
+        Maximum storage space for use by the s3 cache in bytes. Defaults to ``10e9`` (~10G).
     DISK_CACHE_DIR : str
         Subdirectory to use for the disk cache. Defaults to ``'cache'`` in the podpac root directory.
     S3_CACHE_DIR : str

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,8 @@ install_requires = ['matplotlib>=2.1',
                     'xarray>=0.10',
                     'requests>=2.18',
                     'pyproj>=2.1',
-                    'lazy-import>=0.2.2']
+                    'lazy-import>=0.2.2',
+                    'psutil']
 
 if sys.version_info.major == 2:
     install_requires += ['future>=0.16']


### PR DESCRIPTION
Basic implementation of caching limits. Throws error when limits are reached. S3 and Disk cache store sizes are determined by iterating through objects (files) and summing up their sizes. Things that are being put into cache are temporarily added to determine size and then removed if limit is exceeded. RAM cache store size is determined via the amount of memory the python process is currently using (via psutil). This is an overestimate but possibly the desired behavior anyway. 

It would be nice to have the S3 and Disk cache stores use ledger/index objects/files in order to keep track of the contents. This would improve the speed of calculating the cache size and would help with caching policies that automatically remove things based on priorities like size and timestamps. However, I may not have time to add this before the release.

@jmilloy I added you as a reviewer since you have worked with the cache system and wrote the RAM cache.

@mpu-creare I added you because you may want to push this through to free me up for other work.