### PR TITLE
In pipelines, nodes are copied when debugging is on, to help when debugging.

### DIFF
--- a/podpac/core/pipeline/pipeline.py
+++ b/podpac/core/pipeline/pipeline.py
@@ -9,10 +9,12 @@ import warnings
 import importlib
 from collections import OrderedDict
 import json
+from copy import deepcopy
 
 import traitlets as tl
 import numpy as np
 
+from podpac.core.settings import settings
 from podpac.core.utils import OrderedDictTrait, JSONEncoder
 from podpac.core.node import Node, NodeException
 from podpac.core.data.datasource import DataSource
@@ -65,9 +67,9 @@ class Pipeline(Node):
     @tl.validate('json')
     def _json_validate(self, proposal):
         s = proposal['value']
-        definition = json.loads(s)
+        definition = json.loads(s, object_pairs_hook=OrderedDict)
         parse_pipeline_definition(definition)
-        return json.dumps(json.loads(s), cls=JSONEncoder) # standardize
+        return json.dumps(json.loads(s, object_pairs_hook=OrderedDict), cls=JSONEncoder) # standardize
 
     @tl.validate('definition')
     def _validate_definition(self, proposal):
@@ -81,7 +83,6 @@ class Pipeline(Node):
 
     @tl.default('definition')
     def _definition_from_json(self):
-        print("definition from json")
         return json.loads(self.json, object_pairs_hook=OrderedDict)
 
     @tl.default('output')
@@ -285,4 +286,7 @@ def _get_subattr(nodes, name, ref):
     except (KeyError, AttributeError):
         raise PipelineError("'%s' references nonexistent node/attribute '%s'" % (name, ref))
     
+    if settings['DEBUG']:
+        attr = deepcopy(attr)
+
     return attr

--- a/podpac/core/pipeline/test/test.json
+++ b/podpac/core/pipeline/test/test.json
@@ -1,7 +1,7 @@
 {
     "nodes": {
         "a": {
-            "node": "core.algorithm.algorithm.Arange"
+            "node": "algorithm.Arange"
         }
     },
     "output": {

--- a/podpac/core/pipeline/test/test_pipeline.py
+++ b/podpac/core/pipeline/test/test_pipeline.py
@@ -32,7 +32,7 @@ class TestPipeline(object):
         {
             "nodes": {
                 "a": {
-                    "node": "core.algorithm.algorithm.Arange"
+                    "node": "algorithm.Arange"
                 }
             }
         }
@@ -48,7 +48,7 @@ class TestPipeline(object):
         {
             "nodes": {
                 "a": {
-                    "node": "core.algorithm.algorithm.Arange"
+                    "node": "algorithm.Arange"
                 }
             }
         }
@@ -69,7 +69,7 @@ class TestPipeline(object):
         {
             "nodes": {
                 "a": {
-                    "node": "core.algorithm.algorithm.Arange"
+                    "node": "algorithm.Arange"
                 }
             }
         }
@@ -90,7 +90,7 @@ class TestPipeline(object):
         {
             "nodes": {
                 "a": {
-                    "node": "core.algorithm.algorithm.Arange"
+                    "node": "algorithm.Arange"
                 }
             },
             "output": {
@@ -115,7 +115,7 @@ class TestPipeline(object):
         {
             "nodes": {
                 "a": {
-                    "node": "core.algorithm.algorithm.Arange"
+                    "node": "algorithm.Arange"
                 }
             },
             "output": {
@@ -132,3 +132,32 @@ class TestPipeline(object):
         if pipeline.output.path is not None and os.path.isfile(pipeline.output.path):
             os.remove(pipeline.output.path)
         assert pipeline.output.path is None
+
+    def test_debuggable(self):
+        s = '''
+        {
+            "nodes": {
+                "a": {
+                    "node": "algorithm.Arange"
+                },
+                "mean": {
+                    "node": "algorithm.SpatialConvolution",
+                    "inputs": {"source": "a"},
+                    "attrs": {"kernel_type": "mean,3"}
+                },
+                "c": {
+                    "node": "algorithm.Arithmetic",
+                    "inputs": {"A": "a", "B": "mean"},
+                    "attrs": {"eqn": "a-b"}
+                }
+            }
+        }
+        '''
+
+        pipeline = Pipeline(json=s)
+        assert pipeline.node.A is pipeline.node.B.source
+
+        podpac.core.settings.settings['DEBUG'] = True
+        pipeline = Pipeline(json=s)
+        assert pipeline.node.A is not pipeline.node.B.source
+        podpac.core.settings.settings['DEBUG'] = False


### PR DESCRIPTION
The change here is very small, and may be sufficient to close #110. See `test_debuggable` in the pipeline tests and the change in `_get_subattr`. I am only copying nodes if debugging is on, but we could also just always deepcopy if you want.

This PR also includes also bugfixes so that pipelines load json definition as OrderedDict.