### PR TITLE
Automatically copies node traits when debug is on.

### DIFF
--- a/podpac/core/algorithm/algorithm.py
+++ b/podpac/core/algorithm/algorithm.py
@@ -22,6 +22,7 @@ from podpac.core.node import NodeException
 from podpac.core.node import COMMON_NODE_DOC
 from podpac.core.node import node_eval
 from podpac.core.utils import common_doc
+from podpac.core.utils import NodeTrait
 
 COMMON_DOC = COMMON_NODE_DOC.copy()
 
@@ -254,13 +255,13 @@ class Arithmetic(Algorithm):
     arith = Arithmetic(A=a, B=b, eqn = 'A * B + {offset}', params={'offset': 1})
     """
     
-    A = tl.Instance(Node)
-    B = tl.Instance(Node, allow_none=True)
-    C = tl.Instance(Node, allow_none=True)
-    D = tl.Instance(Node, allow_none=True)
-    E = tl.Instance(Node, allow_none=True)
-    F = tl.Instance(Node, allow_none=True)
-    G = tl.Instance(Node, allow_none=True)
+    A = NodeTrait()
+    B = NodeTrait(allow_none=True)
+    C = NodeTrait(allow_none=True)
+    D = NodeTrait(allow_none=True)
+    E = NodeTrait(allow_none=True)
+    F = NodeTrait(allow_none=True)
+    G = NodeTrait(allow_none=True)
     eqn = tl.Unicode().tag(attr=True)
     params = tl.Dict().tag(attr=True)
 

--- a/podpac/core/algorithm/coord_select.py
+++ b/podpac/core/algorithm/coord_select.py
@@ -13,7 +13,7 @@ from podpac.core.coordinates import UniformCoordinates1d, ArrayCoordinates1d
 from podpac.core.coordinates import make_coord_value, make_coord_delta, add_coord
 from podpac.core.node import Node, COMMON_NODE_DOC
 from podpac.core.algorithm.algorithm import Algorithm
-from podpac.core.utils import common_doc
+from podpac.core.utils import common_doc, NodeTrait
 
 COMMON_DOC = COMMON_NODE_DOC.copy()
 
@@ -31,8 +31,8 @@ class ModifyCoordinates(Algorithm):
         Modification parameters for given dimension. Varies by node.
     """
     
-    source = tl.Instance(Node)
-    coordinates_source = tl.Instance(Node)
+    source = NodeTrait()
+    coordinates_source = NodeTrait()
     lat = tl.List().tag(attr=True)
     lon = tl.List().tag(attr=True)
     time = tl.List().tag(attr=True)

--- a/podpac/core/algorithm/signal.py
+++ b/podpac/core/algorithm/signal.py
@@ -21,7 +21,7 @@ from podpac.core.coordinates import Coordinates, UniformCoordinates1d
 from podpac.core.coordinates import add_coord
 from podpac.core.node import Node
 from podpac.core.algorithm.algorithm import Algorithm
-from podpac.core.utils import common_doc, ArrayTrait
+from podpac.core.utils import common_doc, ArrayTrait, NodeTrait
 from podpac.core.node import COMMON_NODE_DOC, node_eval
 
 COMMON_DOC = COMMON_NODE_DOC.copy()
@@ -69,7 +69,7 @@ class Convolution(Algorithm):
         Note: These kernels are automatically normalized such that kernel.sum() == 1
     """
     
-    source = tl.Instance(Node)
+    source = NodeTrait
     kernel = ArrayTrait(dtype=float).tag(attr=True)
 
     def _first_init(self, kernel=None, kernel_type=None, kernel_ndim=None, **kwargs):

--- a/podpac/core/algorithm/stats.py
+++ b/podpac/core/algorithm/stats.py
@@ -18,7 +18,7 @@ import podpac
 from podpac.core.coordinates import Coordinates
 from podpac.core.node import Node
 from podpac.core.algorithm.algorithm import Algorithm
-from podpac.core.utils import common_doc
+from podpac.core.utils import common_doc, NodeTrait
 from podpac.core.node import COMMON_NODE_DOC, node_eval
 
 COMMON_DOC = COMMON_NODE_DOC.copy()
@@ -38,7 +38,7 @@ class Reduce(Algorithm):
         The source node that will be reduced. 
     """
     
-    source = tl.Instance(Node)
+    source = NodeTrait()
     dims = tl.List().tag(attr=True)
 
     _reduced_coordinates = tl.Instance(Coordinates, allow_none=True)
@@ -864,8 +864,8 @@ class GroupReduce(Algorithm):
         Source node
     """
 
-    source = tl.Instance(Node)
-    coordinates_source = tl.Instance(Node, allow_none=True)
+    source = NodeTrait()
+    coordinates_source = NodeTrait(allow_none=True)
     
     # see https://github.com/pydata/xarray/blob/eeb109d9181c84dfb93356c5f14045d839ee64cb/xarray/core/accessors.py#L61
     groupby = tl.CaselessStrEnum(['dayofyear']) # could add season, month, etc

--- a/podpac/core/algorithm/test/test_signal.py
+++ b/podpac/core/algorithm/test/test_signal.py
@@ -6,6 +6,7 @@ import numpy as np
 from numpy.testing import assert_equal, assert_array_equal
 import traitlets as tl
 
+from podpac.core.settings import settings
 from podpac import Coordinates, clinspace, crange
 from podpac.algorithm import Arange
 from podpac.data import Array
@@ -62,23 +63,52 @@ class TestConvolution(object):
     def test_eval_nan(self):
         lat = clinspace(45, 66, 30, name='lat')
         lon = clinspace(-80, 70, 40, name='lon')
-
         coords = Coordinates([lat, lon])
+
         data = np.ones(coords.shape)
         data[10, 10] = np.nan
         source = Array(source=data, native_coordinates=coords)
         node = Convolution(source=source, kernel=[[1, 2, 1]])
+
         o = node.eval(coords[8:12, 7:13])
 
     def test_eval_with_output_argument(self):
         lat = clinspace(45, 66, 30, name='lat')
         lon = clinspace(-80, 70, 40, name='lon')
-
         coords = Coordinates([lat, lon])
-        node = Convolution(source=Arange(), kernel_type='mean,3', kernel_ndim=2)
+
+        node = Convolution(source=Arange(), kernel=[[1, 2, 1]], kernel_ndim=2)
+        
         a = node.create_output_array(coords)
         o = node.eval(coords, output=a)
         assert_array_equal(a, o)
+
+    def test_debuggable_source(self):
+        lat = clinspace(45, 66, 30, name='lat')
+        lon = clinspace(-80, 70, 40, name='lon')
+        coords = Coordinates([lat, lon])
+
+        # normal version
+        a = Arange()
+        node = Convolution(source=a, kernel=[[1, 2, 1]], kernel_ndim=2)
+        node.eval(coords)
+
+        assert node.source is a
+
+        # debuggable
+        settings['DEBUG'] = True
+
+        a = Arange()
+        node = Convolution(source=a, kernel=[[1, 2, 1]], kernel_ndim=2)
+        node.eval(coords)
+
+        assert node.source is not a
+        assert node._requested_coordinates == coords
+        assert node.source._requested_coordinates is not None
+        assert node.source._requested_coordinates != coords
+        assert a._requested_coordinates is None
+
+        settings['DEBUG'] = False
 
 class TestSpatialConvolution(object):
     def test_init_kernel(self):

--- a/podpac/core/data/types.py
+++ b/podpac/core/data/types.py
@@ -31,7 +31,7 @@ from lazy_import import lazy_module
 from podpac.core import authentication
 from podpac.core.node import Node
 from podpac.core.settings import settings
-from podpac.core.utils import cached_property, clear_cache, common_doc, trait_is_defined, ArrayTrait
+from podpac.core.utils import cached_property, clear_cache, common_doc, trait_is_defined, ArrayTrait, NodeTrait
 from podpac.core.data.datasource import COMMON_DATA_DOC, DataSource
 from podpac.core.coordinates import Coordinates, UniformCoordinates1d, ArrayCoordinates1d, StackedCoordinates
 from podpac.core.algorithm.algorithm import Algorithm
@@ -1073,7 +1073,7 @@ class ReprojectedSource(DataSource):
         Coordinates where the source node should be evaluated. 
     """
     
-    source = tl.Instance(Node)
+    source = NodeTrait()
     source_interpolation = interpolation_trait().tag(attr=True)
     reprojected_coordinates = tl.Instance(Coordinates).tag(attr=True)
 
@@ -1157,7 +1157,7 @@ class S3(DataSource):
     """
     
     source = tl.Unicode()
-    node = tl.Instance(Node)
+    node = NodeTrait()
     node_class = tl.Type(DataSource)  # A class
     node_kwargs = tl.Dict(default_value={})
     s3_bucket = tl.Unicode(allow_none=True)

--- a/podpac/core/utils.py
+++ b/podpac/core/utils.py
@@ -234,6 +234,16 @@ class TupleTrait(tl.List):
         value = super(TupleTrait, self).validate(obj, value)
         return tuple(value)
 
+class NodeTrait(tl.ForwardDeclaredInstance):
+    def __init__(self, *args, **kwargs):
+        super(NodeTrait, self).__init__('Node', *args, **kwargs)
+
+    def validate(self, obj, value):
+        super(NodeTrait, self).validate(obj, value)
+        if podpac.core.settings.settings['DEBUG']:
+            value = deepcopy(value)
+        return value
+
 class JSONEncoder(json.JSONEncoder):
     def default(self, obj):
         # podpac Coordinates objects


### PR DESCRIPTION
This is a proposed additional fix for #110.

Instead of only copying nodes in pipelines, this copies nodes in all cases when debugging is on.

This example is from `test_debuggable_source` in the `test_signal.py`:

Normal usage:

```
        a = Arange()
        node = Convolution(source=a, kernel=[[1, 2, 1]], kernel_ndim=2)
        node.eval(coords)

        # doesn't copy
        assert node.source is a
```

Debugging:

```
        settings['DEBUG'] = True

        a = Arange()
        node = Convolution(source=a, kernel=[[1, 2, 1]], kernel_ndim=2)
        node.eval(coords)

        # copies
        assert node.source is not a

        # a._requested coordinates are not effected
        assert node._requested_coordinates is not None
        assert node.source._requested_coordinates is not None
        assert a._requested_coordinates is None
```