### PR TITLE
Readonly source, native_coordinates (and dataset) traits

### DIFF
--- a/podpac/core/data/datasource.py
+++ b/podpac/core/data/datasource.py
@@ -152,8 +152,8 @@ class DataSource(Node):
     Custom DataSource Nodes must implement the :meth:`get_data` and :meth:`get_native_coordinates` methods.
     """
 
-    source = tl.Any()
-    native_coordinates = tl.Instance(Coordinates)
+    source = tl.Any(read_only=True)
+    native_coordinates = tl.Instance(Coordinates, read_only=True)
     interpolation = interpolation_trait()
     coordinate_index_type = tl.Enum(["list", "numpy", "xarray", "pandas"], default_value="numpy")
     nan_vals = tl.List(allow_none=True)
@@ -170,14 +170,21 @@ class DataSource(Node):
     # when native_coordinates is not defined, default calls get_native_coordinates
     @tl.default("native_coordinates")
     def _default_native_coordinates(self):
-        self.native_coordinates = self.get_native_coordinates()
-        return self.native_coordinates
+        return self.get_native_coordinates()
 
     # this adds a more helpful error message if user happens to try an inspect _interpolation before evaluate
     @tl.default("_interpolation")
     def _default_interpolation(self):
         self._set_interpolation()
         return self._interpolation
+
+    def _first_init(self, **kwargs):
+        if "source" in kwargs:
+            self.set_trait("source", kwargs.pop("source"))
+        if "native_coordinates" in kwargs:
+            self.set_trait("native_coordinates", kwargs.pop("native_coordinates"))
+
+        return super(DataSource, self)._first_init(**kwargs)
 
     # ------------------------------------------------------------------------------------------------------------------
     # Properties

--- a/podpac/core/data/test/test_types.py
+++ b/podpac/core/data/test/test_types.py
@@ -172,29 +172,10 @@ class TestPyDAP(object):
         assert node.auth_session is None
 
     def test_dataset(self):
-        """test dataset attribute and traitlet default """
+        """test dataset trait """
         self.mock_pydap()
 
         node = PyDAP(source=self.source, datakey=self.datakey)
-
-        # override/reset source on dataset opening
-        node._open_dataset(source="newsource")
-        assert node.source == "newsource"
-        assert isinstance(node.dataset, pydap.model.DatasetType)
-
-    def test_source(self):
-        """test source attribute and trailet observer """
-        self.mock_pydap()
-
-        node = PyDAP(source=self.source, datakey=self.datakey, native_coordinates=self.coordinates)
-
-        # observe source
-        node._update_dataset(change={"old": None})
-        assert node.source == self.source
-
-        output = node._update_dataset(change={"new": "newsource", "old": "oldsource"})
-        assert node.source == "newsource"
-        assert node.native_coordinates == self.coordinates
         assert isinstance(node.dataset, pydap.model.DatasetType)
 
     def test_get_data(self):
@@ -298,13 +279,6 @@ class TestRasterio(object):
             RasterReader = rasterio.io.DatasetReader  # Rasterio >= v1.0
         assert isinstance(node.dataset, RasterReader)
 
-        # update source when asked
-        with pytest.raises(rasterio.errors.RasterioIOError):
-            node.source = "assets/not-tiff"
-            node._open_dataset()
-
-        assert node.source == "assets/not-tiff"
-
         node.close_dataset()
 
     def test_default_native_coordinates(self):
@@ -348,19 +322,6 @@ class TestRasterio(object):
         numbers = node.get_band_numbers("STATISTICS_MINIMUM", "0")
         assert isinstance(numbers, np.ndarray)
         np.testing.assert_array_equal(numbers, np.arange(3) + 1)
-
-    def test_source(self):
-        """test source attribute and trailets observe"""
-
-        node = Rasterio(source=self.source)
-        assert node.source == self.source
-
-    def test_change_source(self):
-        node = Rasterio(source=self.source)
-        assert node.band_count == 3
-
-        node.source = self.source.replace("RGB.byte.tif", "h5raster.hdf5")
-        assert node.band_count == 1
 
 
 class TestH5PY(object):

--- a/podpac/core/data/types.py
+++ b/podpac/core/data/types.py
@@ -639,7 +639,7 @@ For example,
 
     source = tl.Unicode(read_only=True)
     dataset = tl.Any(read_only=True)
-    file_mode = tl.Unicode(default_value="r", read_only=True)
+    file_mode = tl.Unicode(default_value="r")
 
     # node attrs
     datakey = tl.Unicode().tag(attr=True)

--- a/podpac/datalib/intake.py
+++ b/podpac/datalib/intake.py
@@ -58,7 +58,7 @@ class IntakeCatalog(podpac.data.DataSource):
 
     # input parameters
     uri = tl.Unicode()
-    source = tl.Unicode()
+    source = tl.Unicode(read_only=True)
 
     # optional input parameters
     field = tl.Unicode(default_value=None, allow_none=True)

--- a/podpac/datalib/smap.py
+++ b/podpac/datalib/smap.py
@@ -445,7 +445,7 @@ class SMAPProperties(SMAPSource):
 
     file_url_re = re.compile(r"SMAP.*_[0-9]{8}T[0-9]{6}_.*\.h5")
 
-    source = tl.Unicode()
+    source = tl.Unicode(read_only=True)
 
     @tl.default("source")
     def _property_source_default(self):

--- a/podpac/datalib/terraintiles.py
+++ b/podpac/datalib/terraintiles.py
@@ -76,7 +76,7 @@ class TerrainTilesSource(Rasterio):
     """
 
     # parameters
-    source = tl.Unicode()
+    source = tl.Unicode(read_only=True)
 
     # attributes
     interpolation = interpolation_trait(


### PR DESCRIPTION
 * I set `source`, `native_coordinates` and `dataset` traits as read_only.
 * Traitlets does not allow read_only traits to be set at initialization, so I added a simple workaround in the DataSource `_first_init`.
 * I removed code handling source changes.
 * Note: `set_trait` still works for read_only traits in a pinch.
 * A general solution to making tagged node attrs read-only coming soon.

This is an issue we've been punting on for a while. I am unifying some of the "dataset" based datasources for the multiple outputs feature, and it is a good time to do this.