### PR TITLE
Tests should run without warnings.

### DIFF
--- a/podpac/core/algorithm/stats.py
+++ b/podpac/core/algorithm/stats.py
@@ -795,7 +795,7 @@ class Reduce2(Reduce):
 
         y = xr.full_like(output, np.nan)
         for x, xslices in xs:
-            yslc = [xslices[x.dims.index(dim)] for dim in self._reduced_coordinates.dims]
+            yslc = tuple(xslices[x.dims.index(dim)] for dim in self._reduced_coordinates.dims)
             y.data[yslc] = self.reduce(x)
         return y
 

--- a/podpac/core/cache/test/test_cache_stores.py
+++ b/podpac/core/cache/test/test_cache_stores.py
@@ -15,7 +15,7 @@ from podpac.core.cache.s3_cache_store import S3CacheStore
 
 COORDS1 = podpac.Coordinates([[0, 1, 2], [10, 20, 30, 40], ["2018-01-01", "2018-01-02"]], dims=["lat", "lon", "time"])
 COORDS2 = podpac.Coordinates([[0, 1, 2], [10, 20, 30]], dims=["lat", "lon"])
-NODE1 = podpac.data.Array(source=np.ones(COORDS1.shape), source_coordinates=COORDS1)
+NODE1 = podpac.data.Array(source=np.ones(COORDS1.shape), native_coordinates=COORDS1)
 NODE2 = podpac.algorithm.Arange()
 
 

--- a/podpac/core/coordinates/test/test_coordinates.py
+++ b/podpac/core/coordinates/test/test_coordinates.py
@@ -551,7 +551,8 @@ class TestCoordinatesSerialization(object):
 
     def test_from_url(self):
         crds = Coordinates([[41, 40], [-71, -70], "2018-05-19"], dims=["lat", "lon", "time"])
-        crds2 = crds.transform("EPSG:3857")
+        with pytest.warns(UserWarning, match="transformation of coordinate segment lengths not yet implemented"):
+            crds2 = crds.transform("EPSG:3857")
 
         url = (
             r"http://testwms/?map=map&&service=WMS&request=GetMap&layers=layer&styles=&format=image%2Fpng"
@@ -1153,7 +1154,8 @@ class TestCoordinatesMethods(object):
         assert c.crs == "EPSG:4326"
 
         # transform
-        c_trans = c.transform("EPSG:2193")
+        with pytest.warns(UserWarning, match="transformation of coordinate segment lengths not yet implemented"):
+            c_trans = c.transform("EPSG:2193")
         assert c.crs == "EPSG:4326"
         assert c_trans.crs == "EPSG:2193"
         assert round(c_trans["lat"].coordinates[0, 0]) == 29995930.0
@@ -1167,7 +1169,8 @@ class TestCoordinatesMethods(object):
 
         # support proj4 strings
         proj = "+proj=merc +lat_ts=56.5 +ellps=GRS80"
-        c_trans = c.transform(proj)
+        with pytest.warns(UserWarning, match="transformation of coordinate segment lengths not yet implemented"):
+            c_trans = c.transform(proj)
         assert c.crs == "EPSG:4326"
         assert c_trans.crs == proj
         assert round(c_trans["lat"].coordinates[0, 0]) == 0.0
@@ -1181,7 +1184,8 @@ class TestCoordinatesMethods(object):
 
         # support altitude unit transformations
         proj = "+proj=merc +vunits=us-ft"
-        c_trans = c.transform(proj)
+        with pytest.warns(UserWarning, match="transformation of coordinate segment lengths not yet implemented"):
+            c_trans = c.transform(proj)
         assert round(c_trans["lat"].coordinates[0, 0]) == 0.0
         assert round(c_trans["alt"].coordinates[1]) == 3.0
         assert round(c_trans["alt"].coordinates[2]) == 7.0
@@ -1198,12 +1202,15 @@ class TestCoordinatesMethods(object):
         assert c2_trans.alt_units == "m"
 
         # alt_units parameter
-        c_trans = c.transform("EPSG:2193", alt_units="us-ft")
+        with pytest.warns(UserWarning, match="transformation of coordinate segment lengths not yet implemented"):
+            c_trans = c.transform("EPSG:2193", alt_units="us-ft")
         assert round(c_trans["alt"].coordinates[1]) == 3.0
         assert round(c_trans["alt"].coordinates[2]) == 7.0
         assert c_trans.crs == "EPSG:2193"
         assert c_trans.alt_units == "us-ft"
-        c_trans = c.transform("EPSG:2193", alt_units="km")
+
+        with pytest.warns(UserWarning, match="transformation of coordinate segment lengths not yet implemented"):
+            c_trans = c.transform("EPSG:2193", alt_units="km")
         assert c_trans["alt"].coordinates[1] == 0.001
         assert c_trans["alt"].coordinates[2] == 0.002
         assert c_trans.crs == "EPSG:2193"
@@ -1394,7 +1401,8 @@ class TestCoordinatesMethods(object):
             crs="EPSG:2193",
         )
 
-        c_int = c.intersect(o)
+        with pytest.warns(UserWarning, match="transformation of coordinate segment lengths not yet implemented"):
+            c_int = c.intersect(o)
         assert c_int.crs == c.crs
         assert o.crs == "EPSG:2193"  # didn't get changed
         assert np.all(c_int["lat"].bounds == np.array([5.0, 10.0]))

--- a/podpac/core/coordinates/test/test_uniform_coordinates1d.py
+++ b/podpac/core/coordinates/test/test_uniform_coordinates1d.py
@@ -382,14 +382,10 @@ class TestUniformCoordinatesCreation(object):
         assert c.step == np.timedelta64(1, "D")
 
         # invalid
-        with pytest.raises(
-            ValueError, match="UniformCoordinates1d.from_tuple expects a tuple of \(start, stop, step/size\)"
-        ):
+        with pytest.raises(ValueError, match="UniformCoordinates1d.from_tuple expects a tuple"):
             UniformCoordinates1d.from_tuple((0, 10))
 
-        with pytest.raises(
-            ValueError, match="UniformCoordinates1d.from_tuple expects a tuple of \(start, stop, step/size\)"
-        ):
+        with pytest.raises(ValueError, match="UniformCoordinates1d.from_tuple expects a tuple"):
             UniformCoordinates1d.from_tuple(np.array([0, 10, 0.5]))
 
     def test_copy(self):

--- a/podpac/core/coordinates/uniform_coordinates1d.py
+++ b/podpac/core/coordinates/uniform_coordinates1d.py
@@ -86,9 +86,8 @@ class UniformCoordinates1d(Coordinates1d):
         # validate and set start, stop, and step
         start = make_coord_value(start)
         stop = make_coord_value(stop)
-        if step == 0:
-            raise ValueError("step must be nonzero")
-        elif step is not None:
+
+        if step is not None:
             step = make_coord_delta(step)
         elif isinstance(size, (int, np.long, np.integer)) and not isinstance(size, np.timedelta64):
             step = divide_delta(stop - start, size - 1)
@@ -105,10 +104,10 @@ class UniformCoordinates1d(Coordinates1d):
                 % (type(start), type(stop), type(step))
             )
 
-        if fstep < 0 and start < stop:
+        if fstep <= 0 and start < stop:
             raise ValueError("UniformCoordinates1d step must be greater than zero if start < stop.")
 
-        if fstep > 0 and start > stop:
+        if fstep >= 0 and start > stop:
             raise ValueError("UniformCoordinates1d step must be less than zero if start > stop.")
 
         self.set_trait("start", start)
@@ -133,10 +132,9 @@ class UniformCoordinates1d(Coordinates1d):
         if not super(UniformCoordinates1d, self).__eq__(other):
             return False
 
-        # not necessary
-        # if isinstance(other, UniformCoordinates1d):
-        #     if self.start != other.start or self.stop != other.stop or self.step != other.step:
-        #         return False
+        if isinstance(other, UniformCoordinates1d):
+            if self.start != other.start or self.stop != other.stop or self.step != other.step:
+                return False
 
         if isinstance(other, ArrayCoordinates1d):
             if not np.array_equal(self.coordinates, other.coordinates):

--- a/podpac/core/data/interpolation.py
+++ b/podpac/core/data/interpolation.py
@@ -493,13 +493,8 @@ class Interpolation(object):
         # TODO: short circuit if source_coordinates contains eval_coordinates
         # this has to be done better...
         # short circuit if source and eval coordinates are the same
-        if not (set(source_coordinates.udims) - set(eval_coordinates.udims)):
-            eq = True
-            for udim in source_coordinates.udims:
-                if not np.all(source_coordinates[udim].coordinates == eval_coordinates[udim].coordinates):
-                    eq = False
-
-            if eq:
+        if all(udims in eval_coordinates.udims for udims in source_coordinates.udims):
+            if all(source_coordinates[udim] == eval_coordinates[udim] for udim in source_coordinates.udims):
                 output_data.data = source_data.transpose(*output_data.dims).data  # transpose and insert
                 return output_data
 

--- a/podpac/core/data/interpolator.py
+++ b/podpac/core/data/interpolator.py
@@ -167,6 +167,7 @@ class Interpolator(tl.HasTraits):
     # defined by implementing Interpolator class
     methods_supported = tl.List(tl.Unicode())
     dims_supported = tl.List(tl.Unicode())
+    spatial_tolerance = tl.Float(allow_none=True, default_value=np.inf)
 
     # defined at instantiation
     method = tl.Unicode()

--- a/podpac/core/data/interpolators.py
+++ b/podpac/core/data/interpolators.py
@@ -122,6 +122,7 @@ class NearestPreview(NearestNeighbor):
 
     methods_supported = ["nearest_preview"]
     method = tl.Unicode(default_value="nearest_preview")
+    spatial_tolerance = tl.Float(read_only=True, allow_none=True, default_value=None)
 
     @common_doc(COMMON_INTERPOLATOR_DOCS)
     def can_select(self, udims, source_coordinates, eval_coordinates):
@@ -163,7 +164,8 @@ class NearestPreview(NearestNeighbor):
                 else:
                     dst_start = dst_coords.coordinates[0]
                     dst_stop = dst_coords.coordinates[-1]
-                    dst_delta = (dst_stop - dst_start) / (dst_coords.size - 1)
+                    with np.errstate(invalid="ignore"):
+                        dst_delta = (dst_stop - dst_start) / (dst_coords.size - 1)
 
                 if isinstance(src_coords, UniformCoordinates1d):
                     src_start = src_coords.start
@@ -172,7 +174,8 @@ class NearestPreview(NearestNeighbor):
                 else:
                     src_start = src_coords.coordinates[0]
                     src_stop = src_coords.coordinates[-1]
-                    src_delta = (src_stop - src_start) / (src_coords.size - 1)
+                    with np.errstate(invalid="ignore"):
+                        src_delta = (src_stop - src_start) / (src_coords.size - 1)
 
                 ndelta = max(1, np.round(dst_delta / src_delta))
                 if src_coords.size == 1:

--- a/podpac/core/data/test/test_datasource.py
+++ b/podpac/core/data/test/test_datasource.py
@@ -219,7 +219,8 @@ class TestDataSource(object):
 
         # this will not throw an error because the requested coordinates will be transformed before request
         output = node.create_output_array(c)
-        node.eval(c_x, output=output)
+        with pytest.warns(UserWarning, match="transformation of coordinate segment lengths not yet implemented"):
+            node.eval(c_x, output=output)
 
         # this will throw an error because output is not in the same crs as node
         output = node.create_output_array(c_x)
@@ -258,10 +259,12 @@ class TestDataSource(object):
     def test_evaluate_with_crs_transform(self):
         # grid coords
         grid_coords = Coordinates([np.linspace(-10, 10, 21), np.linspace(-10, -10, 21)], dims=["lat", "lon"])
-        grid_coords = grid_coords.transform("EPSG:2193")
+        with pytest.warns(UserWarning, match="transformation of coordinate segment lengths not yet implemented"):
+            grid_coords = grid_coords.transform("EPSG:2193")
 
         node = MockDataSource()
-        out = node.eval(grid_coords)
+        with pytest.warns(UserWarning, match="transformation of coordinate segment lengths not yet implemented"):
+            out = node.eval(grid_coords)
 
         assert round(out.coords["lat"].values[0, 0]) == -8889021.0
         assert round(out.coords["lon"].values[0, 0]) == 1928929.0

--- a/podpac/core/data/test/test_interpolate.py
+++ b/podpac/core/data/test/test_interpolate.py
@@ -167,7 +167,8 @@ class TestInterpolation(object):
             Interpolation({"default": {"method": "nearest", "params": {"spatial_tolerance": "tol"}}})
 
         # should not allow undefined params
-        interp = Interpolation({"default": {"method": "nearest", "params": {"myarg": 1}}})
+        with pytest.warns(DeprecationWarning):  # eventually, Traitlets will raise an exception here
+            interp = Interpolation({"default": {"method": "nearest", "params": {"myarg": 1}}})
         with pytest.raises(AttributeError):
             assert interp.config[("default",)]["interpolators"][0].myarg == "tol"
 

--- a/podpac/core/data/test/test_types.py
+++ b/podpac/core/data/test/test_types.py
@@ -254,14 +254,14 @@ class TestCSV(object):
         node = CSV(source=self.source, lat_col=0, lon_col=1, time_col=2, alt_col=3, data_col="data")
         nc = node.native_coordinates
         assert nc.size == 5
-        assert np.all(nc["lat"].coordinates == [0, 1, 1, 1, 1])
-        assert np.all(nc["lon"].coordinates == [0, 0, 2, 2, 2])
-        assert np.all(nc["alt"].coordinates == [0, 0, 0, 0, 4])
+        np.testing.assert_array_equal(nc["lat"].coordinates, [0, 1, 1, 1, 1])
+        np.testing.assert_array_equal(nc["lon"].coordinates, [0, 0, 2, 2, 2])
+        np.testing.assert_array_equal(nc["alt"].coordinates, [0, 0, 0, 0, 4])
 
     def test_data(self):
         node = CSV(source=self.source, lat_col=0, lon_col=1, time_col=2, alt_col=3, data_col="data")
         d = node.eval(node.native_coordinates)
-        assert np.all(d == [0, 1, 2, 3, 4])
+        np.testing.assert_array_equal(d, [0, 1, 2, 3, 4])
 
 
 class TestRasterio(object):
@@ -379,8 +379,8 @@ class TestH5PY(object):
 
         nc = node.native_coordinates
         assert node.native_coordinates.shape == (3, 4)
-        assert np.all(node.native_coordinates["lat"].coordinates == [45.1, 45.2, 45.3])
-        assert np.all(node.native_coordinates["lon"].coordinates == [-100.1, -100.2, -100.3, -100.4])
+        np.testing.assert_array_equal(node.native_coordinates["lat"].coordinates, [45.1, 45.2, 45.3])
+        np.testing.assert_array_equal(node.native_coordinates["lon"].coordinates, [-100.1, -100.2, -100.3, -100.4])
 
     def test_data(self):
         node = H5PY(
@@ -388,7 +388,7 @@ class TestH5PY(object):
         )
 
         o = node.eval(node.native_coordinates)
-        assert np.all(o.data.ravel() == np.arange(12))
+        np.testing.assert_array_equal(o.data.ravel(), np.arange(12))
 
     def test_keys(self):
         node = H5PY(source=self.source, datakey="data/init", latkey="coords/lat", lonkey="coords/lon")
@@ -545,7 +545,7 @@ class TestWCS(object):
 
         assert isinstance(native_coordinates, Coordinates)
         # TODO: one returns monotonic, the other returns uniform
-        # assert native_coordinates == node._output_coordinates
+        assert native_coordinates == node._output_coordinates
         assert native_coordinates["lat"]
         assert native_coordinates["lon"]
         assert native_coordinates["time"]

--- a/podpac/core/data/test/test_types.py
+++ b/podpac/core/data/test/test_types.py
@@ -359,7 +359,8 @@ class TestRasterio(object):
         node = Rasterio(source=self.source)
         assert node.band_count == 3
 
-        node.source = self.source.replace("RGB.byte.tif", "h5raster.hdf5")
+        with pytest.warns(rasterio.errors.NotGeoreferencedWarning):
+            node.source = self.source.replace("RGB.byte.tif", "h5raster.hdf5")
         assert node.band_count == 1
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,9 +2,9 @@
 addopts = -v --color=yes -m "not integration"
 testpaths = podpac
 filterwarnings =
-  error
   ignore::FutureWarning:traitlets
   ignore:numpy.ufunc size changed:RuntimeWarning
+  ignore::DeprecationWarning:lazy_import
 
 [coverage:run]
 omit=*/test/*,podpac/datalib/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,12 @@ testpaths = podpac
 filterwarnings =
   ignore::FutureWarning:traitlets
   ignore:numpy.ufunc size changed:RuntimeWarning
-  ignore::DeprecationWarning:lazy_import
+  ignore:Using or importing the ABCs:DeprecationWarning:lazy_import
+  ignore:Using or importing the ABCs:DeprecationWarning:botocore
+  ignore:Using or importing the ABCs:DeprecationWarning:pydap
+  ignore:The truth value of an empty array is ambiguous:DeprecationWarning:traitlets
+  ignore:The truth value of an empty array is ambiguous:DeprecationWarning:xarray
+  ignore:.*init.* syntax is deprecated:DeprecationWarning:pyproj
 
 [coverage:run]
 omit=*/test/*,podpac/datalib/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,6 @@ filterwarnings =
   ignore:Using or importing the ABCs:DeprecationWarning:pydap
   ignore:The truth value of an empty array is ambiguous:DeprecationWarning:traitlets
   ignore:The truth value of an empty array is ambiguous:DeprecationWarning:xarray
-  ignore:.*init.* syntax is deprecated:DeprecationWarning:pyproj
 
 [coverage:run]
 omit=*/test/*,podpac/datalib/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,9 @@
 addopts = -v --color=yes -m "not integration"
 testpaths = podpac
 filterwarnings =
+  error
   ignore::FutureWarning:traitlets
+  ignore:numpy.ufunc size changed:RuntimeWarning
 
 [coverage:run]
 omit=*/test/*,podpac/datalib/*


### PR DESCRIPTION
On my machine, our tests pass with 700+ warnings.

In this PR, warnings are treated as errors by pytest. All warnings are fixed by globally filtering certain warnings, catching expected warnings, or fixing bugs in podpac.

Bugfixes:
 - (core/algorithm/stats.py) multi-indexes should be tuples, not lists
 - (core/coordinates/uniform_coordinates1d.py) `np.timedelta64` cannot be compared directly with 0
 - (core/coordinates/uniform_coordinates1d.py) uniform coordinates *do* need to check `start`, `stop`, and `step`
 - (core/data/interpolation.py) numpy arrays cannot be compared with `==`
 - (core/data/interpolator.py) `spatial_tolerance` should be defined as a trait for the base interpolator