### PR TITLE
general readonly tag

### DIFF
--- a/podpac/core/data/datasource.py
+++ b/podpac/core/data/datasource.py
@@ -152,8 +152,8 @@ class DataSource(Node):
     Custom DataSource Nodes must implement the :meth:`get_data` and :meth:`get_native_coordinates` methods.
     """
 
-    source = tl.Any()
-    native_coordinates = tl.Instance(Coordinates)
+    source = tl.Any(read_only=True)
+    native_coordinates = tl.Instance(Coordinates, read_only=True)
     interpolation = interpolation_trait()
     coordinate_index_type = tl.Enum(["list", "numpy", "xarray", "pandas"], default_value="numpy")
     nan_vals = tl.List(allow_none=True)
@@ -170,14 +170,21 @@ class DataSource(Node):
     # when native_coordinates is not defined, default calls get_native_coordinates
     @tl.default("native_coordinates")
     def _default_native_coordinates(self):
-        self.native_coordinates = self.get_native_coordinates()
-        return self.native_coordinates
+        return self.get_native_coordinates()
 
     # this adds a more helpful error message if user happens to try an inspect _interpolation before evaluate
     @tl.default("_interpolation")
     def _default_interpolation(self):
         self._set_interpolation()
         return self._interpolation
+
+    def _first_init(self, **kwargs):
+        if "source" in kwargs:
+            self.set_trait("source", kwargs.pop("source"))
+        if "native_coordinates" in kwargs:
+            self.set_trait("native_coordinates", kwargs.pop("native_coordinates"))
+
+        return super(DataSource, self)._first_init(**kwargs)
 
     # ------------------------------------------------------------------------------------------------------------------
     # Properties

--- a/podpac/core/data/datasource.py
+++ b/podpac/core/data/datasource.py
@@ -152,8 +152,8 @@ class DataSource(Node):
     Custom DataSource Nodes must implement the :meth:`get_data` and :meth:`get_native_coordinates` methods.
     """
 
-    source = tl.Any(read_only=True)
-    native_coordinates = tl.Instance(Coordinates, read_only=True)
+    source = tl.Any().tag(readonly=True)
+    native_coordinates = tl.Instance(Coordinates).tag(readonly=True)
     interpolation = interpolation_trait()
     coordinate_index_type = tl.Enum(["list", "numpy", "xarray", "pandas"], default_value="numpy")
     nan_vals = tl.List(allow_none=True)
@@ -177,14 +177,6 @@ class DataSource(Node):
     def _default_interpolation(self):
         self._set_interpolation()
         return self._interpolation
-
-    def _first_init(self, **kwargs):
-        if "source" in kwargs:
-            self.set_trait("source", kwargs.pop("source"))
-        if "native_coordinates" in kwargs:
-            self.set_trait("native_coordinates", kwargs.pop("native_coordinates"))
-
-        return super(DataSource, self)._first_init(**kwargs)
 
     # ------------------------------------------------------------------------------------------------------------------
     # Properties

--- a/podpac/core/data/test/test_interpolate.py
+++ b/podpac/core/data/test/test_interpolate.py
@@ -167,7 +167,8 @@ class TestInterpolation(object):
             Interpolation({"default": {"method": "nearest", "params": {"spatial_tolerance": "tol"}}})
 
         # should not allow undefined params
-        interp = Interpolation({"default": {"method": "nearest", "params": {"myarg": 1}}})
+        with pytest.warns(DeprecationWarning):  # eventually, Traitlets will raise an exception here
+            interp = Interpolation({"default": {"method": "nearest", "params": {"myarg": 1}}})
         with pytest.raises(AttributeError):
             assert interp.config[("default",)]["interpolators"][0].myarg == "tol"
 

--- a/podpac/core/data/test/test_types.py
+++ b/podpac/core/data/test/test_types.py
@@ -172,29 +172,10 @@ class TestPyDAP(object):
         assert node.auth_session is None
 
     def test_dataset(self):
-        """test dataset attribute and traitlet default """
+        """test dataset trait """
         self.mock_pydap()
 
         node = PyDAP(source=self.source, datakey=self.datakey)
-
-        # override/reset source on dataset opening
-        node._open_dataset(source="newsource")
-        assert node.source == "newsource"
-        assert isinstance(node.dataset, pydap.model.DatasetType)
-
-    def test_source(self):
-        """test source attribute and trailet observer """
-        self.mock_pydap()
-
-        node = PyDAP(source=self.source, datakey=self.datakey, native_coordinates=self.coordinates)
-
-        # observe source
-        node._update_dataset(change={"old": None})
-        assert node.source == self.source
-
-        output = node._update_dataset(change={"new": "newsource", "old": "oldsource"})
-        assert node.source == "newsource"
-        assert node.native_coordinates == self.coordinates
         assert isinstance(node.dataset, pydap.model.DatasetType)
 
     def test_get_data(self):
@@ -298,13 +279,6 @@ class TestRasterio(object):
             RasterReader = rasterio.io.DatasetReader  # Rasterio >= v1.0
         assert isinstance(node.dataset, RasterReader)
 
-        # update source when asked
-        with pytest.raises(rasterio.errors.RasterioIOError):
-            node.source = "assets/not-tiff"
-            node._open_dataset()
-
-        assert node.source == "assets/not-tiff"
-
         node.close_dataset()
 
     def test_default_native_coordinates(self):
@@ -348,19 +322,6 @@ class TestRasterio(object):
         numbers = node.get_band_numbers("STATISTICS_MINIMUM", "0")
         assert isinstance(numbers, np.ndarray)
         np.testing.assert_array_equal(numbers, np.arange(3) + 1)
-
-    def test_source(self):
-        """test source attribute and trailets observe"""
-
-        node = Rasterio(source=self.source)
-        assert node.source == self.source
-
-    def test_change_source(self):
-        node = Rasterio(source=self.source)
-        assert node.band_count == 3
-
-        node.source = self.source.replace("RGB.byte.tif", "h5raster.hdf5")
-        assert node.band_count == 1
 
 
 class TestH5PY(object):

--- a/podpac/core/data/types.py
+++ b/podpac/core/data/types.py
@@ -639,7 +639,7 @@ For example,
 
     source = tl.Unicode(read_only=True)
     dataset = tl.Any(read_only=True)
-    file_mode = tl.Unicode(default_value="r", read_only=True)
+    file_mode = tl.Unicode(default_value="r")
 
     # node attrs
     datakey = tl.Unicode().tag(attr=True)

--- a/podpac/core/data/types.py
+++ b/podpac/core/data/types.py
@@ -74,7 +74,7 @@ class Array(DataSource):
     `native_coordinates` need to supplied by the user when instantiating this node.
     """
 
-    source = ArrayTrait(read_only=True)
+    source = ArrayTrait().tag(readonly=True)
 
     @tl.validate("source")
     def _validate_source(self, d):
@@ -123,8 +123,8 @@ class PyDAP(DataSource):
         auth_session instead if you have security concerns.
     """
 
-    source = tl.Unicode(read_only=True)
-    dataset = tl.Instance("pydap.model.DatasetType", read_only=True)
+    source = tl.Unicode().tag(readonly=True)
+    dataset = tl.Instance("pydap.model.DatasetType").tag(readonly=True)
 
     # node attrs
     datakey = tl.Unicode().tag(attr=True)
@@ -260,8 +260,8 @@ class CSV(DataSource):
         Raw Pandas DataFrame used to read the data
     """
 
-    source = tl.Unicode(read_only=True)
-    dataset = tl.Instance(pd.DataFrame, read_only=True)
+    source = tl.Unicode().tag(readonly=True)
+    dataset = tl.Instance(pd.DataFrame).tag(readonly=True)
 
     # node attrs
     dims = tl.List(default_value=["alt", "lat", "lon", "time"]).tag(attr=True)
@@ -380,10 +380,10 @@ class Rasterio(DataSource):
     * Linux: export CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
     """
 
-    source = tl.Union([tl.Unicode(), tl.Instance(BytesIO)], read_only=True)
-    dataset = tl.Any(read_only=True)
+    source = tl.Union([tl.Unicode(), tl.Instance(BytesIO)]).tag(readonly=True)
+    dataset = tl.Any().tag(readonly=True)
 
-    # no deattrs
+    # node attrs
     band = tl.CInt(1).tag(attr=True)
 
     @tl.default("dataset")
@@ -637,9 +637,9 @@ For example,
         Default is 'r'. The mode used to open the HDF5 file. Options are r, r+, w, w- or x, a (see h5py.File).
     """
 
-    source = tl.Unicode(read_only=True)
-    dataset = tl.Any(read_only=True)
-    file_mode = tl.Unicode(default_value="r")
+    source = tl.Unicode().tag(readonly=True)
+    dataset = tl.Any().tag(readonly=True)
+    file_mode = tl.Unicode(default_value="r").tag(readonly=True)
 
     # node attrs
     datakey = tl.Unicode().tag(attr=True)
@@ -702,8 +702,8 @@ For example,
 
 
 class Zarr(DatasetCoordinatedMixin, DataSource):
-    source = tl.Unicode(read_only=True, default_value=None, allow_none=True)
-    dataset = tl.Any(read_only=True)
+    source = tl.Unicode(default_value=None, allow_none=True).tag(readonly=True)
+    dataset = tl.Any().tag(readonly=True)
 
     # node attrs
     datakey = tl.Unicode().tag(attr=True)
@@ -724,12 +724,6 @@ class Zarr(DatasetCoordinatedMixin, DataSource):
     @tl.default("region_name")
     def _get_region_name(self):
         return settings["AWS_REGION_NAME"]
-
-    def _first_init(self, **kwargs):
-        if "dataset" in kwargs:
-            self.set_trait("dataset", kwargs.pop("dataset"))
-
-        return super(Zarr, self)._first_init(**kwargs)
 
     def init(self):
         # check that source or dataset is provided
@@ -814,8 +808,8 @@ class WCS(DataSource):
         The coordinates of the WCS source
     """
 
-    source = tl.Unicode(read_only=True)
-    wcs_coordinates = tl.Instance(Coordinates)  # default below
+    source = tl.Unicode().tag(readonly=True)
+    wcs_coordinates = tl.Instance(Coordinates).tag(readonly=True)  # default below
 
     # node attrs
     layer_name = tl.Unicode().tag(attr=True)
@@ -1152,7 +1146,7 @@ class ReprojectedSource(DataSource):
         Coordinates where the source node should be evaluated. 
     """
 
-    source = NodeTrait(read_only=True)
+    source = NodeTrait().tag(readonly=True)
 
     # node attrs
     source_interpolation = interpolation_trait().tag(attr=True)
@@ -1236,8 +1230,8 @@ class Dataset(DataSource):
         For example, if the data contains ['lat', 'lon', 'channel'], the second channel can be selected using `extra_dim=dict(channel=1)`
     """
 
-    source = tl.Any(allow_none=True, read_only=True)
-    dataset = tl.Instance(xr.Dataset, read_only=True)
+    source = tl.Any(allow_none=True).tag(readonly=True)
+    dataset = tl.Instance(xr.Dataset).tag(readonly=True)
 
     # node attrs
     extra_dim = tl.Dict({}).tag(attr=True)
@@ -1246,12 +1240,6 @@ class Dataset(DataSource):
     @tl.default("dataset")
     def _dataset_default(self):
         return xr.open_dataset(self.source)
-
-    def _first_init(self, **kwargs):
-        if "dataset" in kwargs:
-            self.set_trait("dataset", kwargs.pop("dataset"))
-
-        return super(DataSet, self)._first_init(**kwargs)
 
     @property
     @common_doc(COMMON_DATA_DOC)

--- a/podpac/core/node.py
+++ b/podpac/core/node.py
@@ -139,7 +139,17 @@ class Node(tl.HasTraits):
 
     def __init__(self, **kwargs):
         """ Do not overwrite me """
+        # make tagged "readonly" and "attr" traits read_only
+        for name, trait in self.traits().items():
+            if trait.metadata.get("readonly") or trait.metadata.get("attr"):
+                trait.read_only = True
+
         tkwargs = self._first_init(**kwargs)
+
+        # set tagged "readonly" and "attr" traits using set_trait
+        for name, trait in self.traits().items():
+            if (trait.metadata.get("readonly") or trait.metadata.get("attr")) and name in tkwargs:
+                self.set_trait(name, tkwargs.pop(name))
 
         # Call traitlest constructor
         super(Node, self).__init__(**tkwargs)

--- a/podpac/core/node.py
+++ b/podpac/core/node.py
@@ -139,17 +139,17 @@ class Node(tl.HasTraits):
 
     def __init__(self, **kwargs):
         """ Do not overwrite me """
-        # make tagged "readonly" and "attr" traits read_only
-        for name, trait in self.traits().items():
-            if trait.metadata.get("readonly") or trait.metadata.get("attr"):
-                trait.read_only = True
 
         tkwargs = self._first_init(**kwargs)
 
-        # set tagged "readonly" and "attr" traits using set_trait
+        # make tagged "readonly" and "attr" traits read_only, and set them using set_trait
+        # NOTE: The set_trait is required because this sets the traits read_only at the *class* level;
+        #       on subsequent initializations, they will already be read_only.
         for name, trait in self.traits().items():
-            if (trait.metadata.get("readonly") or trait.metadata.get("attr")) and name in tkwargs:
-                self.set_trait(name, tkwargs.pop(name))
+            if trait.metadata.get("readonly") or trait.metadata.get("attr"):
+                if name in tkwargs:
+                    self.set_trait(name, tkwargs.pop(name))
+                trait.read_only = True
 
         # Call traitlest constructor
         super(Node, self).__init__(**tkwargs)

--- a/podpac/core/test/test_node.py
+++ b/podpac/core/test/test_node.py
@@ -314,9 +314,9 @@ class TestCachePropertyDecorator(object):
         assert t2.c2() == 2
         assert t2.d2() == 2
 
-        t.a = 2
+        t.set_trait("a", 2)
         assert t.a2() == 4
-        t.b = 2
+        t.set_trait("b", 2)
         assert t.b2() == 4  # This happens because the node definition changed
         t.rem_cache(key="*", coordinates="*")
         assert t.c2() == 2  # This forces the cache to update based on the new node definition
@@ -332,9 +332,9 @@ class TestCachePropertyDecorator(object):
         assert t2.c2() == 2
         assert t2.d2() == 2
 
-        t2.a = 2
+        t2.set_trait("a", 2)
         assert t2.get_cache("a2") == 4  # This was cached by t
-        t2.b = 2
+        t2.set_trait("b", 2)
         assert t2.get_cache("c2") == 4  # This was cached by t
         assert t2.get_cache("d2") == 2  # This was cached by t
 
@@ -385,9 +385,9 @@ class TestCachePropertyDecorator(object):
         assert t2.c2() == 2
         assert t2.d2() == 2
 
-        t.a = 2
+        t.set_trait("a", 2)
         assert t.a2() == 4
-        t.b = 2
+        t.set_trait("b", 2)
         assert t.b2() == 4  # This happens because the node definition changed
         t.rem_cache(key="*", coordinates="*")
         assert t.c2() == 2  # This forces the cache to update based on the new node definition

--- a/podpac/datalib/gfs.py
+++ b/podpac/datalib/gfs.py
@@ -31,7 +31,6 @@ class GFSSource(Rasterio):
     date = tl.Unicode().tag(attr=True)
     hour = tl.Unicode().tag(attr=True)
     forecast = tl.Unicode().tag(attr=True)
-    dataset = tl.Any()
 
     def init(self):
         self._logger = logging.getLogger(__name__)

--- a/podpac/datalib/intake.py
+++ b/podpac/datalib/intake.py
@@ -58,7 +58,7 @@ class IntakeCatalog(podpac.data.DataSource):
 
     # input parameters
     uri = tl.Unicode()
-    source = tl.Unicode()
+    source = tl.Unicode(read_only=True)
 
     # optional input parameters
     field = tl.Unicode(default_value=None, allow_none=True)

--- a/podpac/datalib/intake.py
+++ b/podpac/datalib/intake.py
@@ -57,8 +57,8 @@ class IntakeCatalog(podpac.data.DataSource):
     """
 
     # input parameters
+    source = tl.Unicode().tag(readonly=True)
     uri = tl.Unicode()
-    source = tl.Unicode(read_only=True)
 
     # optional input parameters
     field = tl.Unicode(default_value=None, allow_none=True)

--- a/podpac/datalib/smap.py
+++ b/podpac/datalib/smap.py
@@ -445,7 +445,7 @@ class SMAPProperties(SMAPSource):
 
     file_url_re = re.compile(r"SMAP.*_[0-9]{8}T[0-9]{6}_.*\.h5")
 
-    source = tl.Unicode()
+    source = tl.Unicode(read_only=True)
 
     @tl.default("source")
     def _property_source_default(self):

--- a/podpac/datalib/smap.py
+++ b/podpac/datalib/smap.py
@@ -445,7 +445,7 @@ class SMAPProperties(SMAPSource):
 
     file_url_re = re.compile(r"SMAP.*_[0-9]{8}T[0-9]{6}_.*\.h5")
 
-    source = tl.Unicode(read_only=True)
+    source = tl.Unicode().tag(readonly=True)
 
     @tl.default("source")
     def _property_source_default(self):

--- a/podpac/datalib/terraintiles.py
+++ b/podpac/datalib/terraintiles.py
@@ -76,14 +76,12 @@ class TerrainTilesSource(Rasterio):
     """
 
     # parameters
-    source = tl.Unicode(read_only=True)
+    source = tl.Unicode().tag(readonly=True)
 
     # attributes
     interpolation = interpolation_trait(
         default_value={"method": "nearest", "interpolators": [RasterioInterpolator, ScipyGrid, ScipyPoint]}
-    )
-
-    dataset = tl.Any()
+    ).tag(readonly=True)
 
     @tl.default("dataset")
     def open_dataset(self):

--- a/podpac/datalib/terraintiles.py
+++ b/podpac/datalib/terraintiles.py
@@ -76,7 +76,7 @@ class TerrainTilesSource(Rasterio):
     """
 
     # parameters
-    source = tl.Unicode()
+    source = tl.Unicode(read_only=True)
 
     # attributes
     interpolation = interpolation_trait(


### PR DESCRIPTION
Node traits tagged as 'readonly' or as 'attr' can be specified using keyword arguments during Node instatiation, but cannot be later modified. It uses the `read_only` flag under the hood but is a slightly more flexible.

```
class MyDataSource(DataSource)
    source = tl.Unicode().tag(readonly=True)
    my_attr = tl.Int().tag(attr=True)
```

```
>>> node = MyDataSource(source='mysource', my_attr=8)
>>> node.source = 'other'
...
traitlets.traitlets.TraitError: The "source" trait is read-only.
>>> node.my_attr = 6
traitlets.traitlets.TraitError: The "my_attr" trait is read-only.
```