### PR TITLE
ENH: Adding a generic algorithm that can execute arbitrary multi-line…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ install:
 
   # install setup.py and dev extras
   - pip install .[devall]
+  - touch podpac/ALLOW_PYTHON_EVAL_EXEC
 
 # cache pip dependencies for faster builds
 cache: pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ install:
   - pip install .[devall]
   
   # Allow Python exec and eval functions for unit tests
+  - sudo mkdir /home/travis/.podpac
   - sudo touch /home/travis/.podpac/ALLOW_PYTHON_EVAL_EXEC
   
 # cache pip dependencies for faster builds

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,8 @@ install:
   - pip install .[devall]
   
   # Allow Python exec and eval functions for unit tests
-  - sudo touch podpac/ALLOW_PYTHON_EVAL_EXEC
-
+  - sudo touch /home/travis/.podpac/ALLOW_PYTHON_EVAL_EXEC
+  
 # cache pip dependencies for faster builds
 cache: pip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,9 @@ install:
 
   # install setup.py and dev extras
   - pip install .[devall]
-  - touch podpac/ALLOW_PYTHON_EVAL_EXEC
+  
+  # Allow Python exec and eval functions for unit tests
+  - sudo touch podpac/ALLOW_PYTHON_EVAL_EXEC
 
 # cache pip dependencies for faster builds
 cache: pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,8 @@ install:
   - pip install .[devall]
   
   # Allow Python exec and eval functions for unit tests
-  - sudo mkdir /home/travis/.podpac
-  - sudo touch /home/travis/.podpac/ALLOW_PYTHON_EVAL_EXEC
+  - mkdir /home/travis/.podpac
+  - touch /home/travis/.podpac/ALLOW_PYTHON_EVAL_EXEC
   
 # cache pip dependencies for faster builds
 cache: pip

--- a/podpac/algorithm.py
+++ b/podpac/algorithm.py
@@ -4,7 +4,7 @@ Algorithm Public Module
 
 # REMINDER: update api docs (doc/source/user/api.rst) to reflect changes to this file
 
-from podpac.core.algorithm.algorithm import Algorithm, Arithmetic, SinCoords, Arange, CoordData
+from podpac.core.algorithm.algorithm import Algorithm, Arithmetic, SinCoords, Arange, CoordData, Generic
 from podpac.core.algorithm.stats import (
     Min,
     Max,

--- a/podpac/core/algorithm/algorithm.py
+++ b/podpac/core/algorithm/algorithm.py
@@ -355,7 +355,7 @@ class Generic(Algorithm):
         return kwargs
 
     def algorithm(self, inputs):
-        exec (self.code, inputs)
+        exec(self.code, inputs)
         return inputs["output"]
 
     @property

--- a/podpac/core/algorithm/algorithm.py
+++ b/podpac/core/algorithm/algorithm.py
@@ -23,6 +23,7 @@ from podpac.core.node import COMMON_NODE_DOC
 from podpac.core.node import node_eval
 from podpac.core.utils import common_doc
 from podpac.core.utils import NodeTrait
+from podpac.core.settings import settings
 
 COMMON_DOC = COMMON_NODE_DOC.copy()
 
@@ -269,6 +270,19 @@ class Arithmetic(Algorithm):
     eqn = tl.Unicode().tag(attr=True)
     params = tl.Dict().tag(attr=True)
 
+    def _first_init(self, **kwargs):
+        if not settings["ALLOW_PYTHON_EVAL_EXEC"]:
+            raise PermissionError(
+                "Insecure evaluation of Python code using Arithmetic node has not been allowed. If "
+                "this is an error, use: `podpac.settings.set_allow_python_eval_exec(True)`. "
+                "Alternatively create the file ALLOW_PYTHON_EVAL_EXEC in {}".format(
+                    settings._allow_python_eval_exec_paths[-1]
+                )
+                + "NOTE: making this setting True allows arbitrary execution of Python code through PODPAC "
+                "Node definitions."
+            )
+        return kwargs
+
     def init(self):
         if self.eqn == "":
             raise ValueError("Arithmetic eqn cannot be empty")
@@ -300,3 +314,50 @@ class Arithmetic(Algorithm):
         res = res[0].copy()  # Make an xarray object with correct dimensions
         res[:] = result
         return res
+
+
+class Generic(Algorithm):
+    """
+    Generic Algorithm Node that allows arbitrary Python code to be executed.
+    
+    Attributes
+    ----------
+    code : str
+        The multi-line code that will be evaluated. This code should assign "output" to the desired result, and "output"
+        needs to be a "numpy array" or "xarray DataArray"
+    inputs : dict(str: podpac.Node)
+        A dictionary of PODPAC nodes that will serve as the input data for the Python script
+
+    Examples
+    ----------
+    a = SinCoords()
+    b = Arange()
+    code = '''import numpy as np
+    output = np.minimum(a, b)
+    '''
+    generic = Generic(code=code, inputs={'a': a, 'b': b'})
+    """
+
+    code = tl.Unicode().tag(attr=True, readonly=True)
+    inputs = tl.Dict().tag()
+
+    def _first_init(self, **kwargs):
+        if not settings["ALLOW_PYTHON_EVAL_EXEC"]:
+            raise PermissionError(
+                "Insecure evaluation of Python code using Generic node has not been allowed. If this "
+                "this is an error, use: `podpac.settings.set_allow_python_eval_exec(True)`. "
+                "Alternatively create the file ALLOW_PYTHON_EVAL_EXEC in {}".format(
+                    settings._allow_python_eval_exec_paths[-1]
+                )
+                + "NOTE: making this setting True allows arbitrary execution of Python code through PODPAC "
+                "Node definitions."
+            )
+        return kwargs
+
+    def algorithm(self, inputs):
+        exec (self.code, inputs)
+        return inputs["output"]
+
+    @property
+    def _inputs(self):
+        return self.inputs

--- a/podpac/core/algorithm/test/test_algorithm.py
+++ b/podpac/core/algorithm/test/test_algorithm.py
@@ -5,7 +5,7 @@ import numpy as np
 from collections import OrderedDict
 
 import podpac
-from podpac.core.algorithm.algorithm import Algorithm, Arange, CoordData, SinCoords, Arithmetic
+from podpac.core.algorithm.algorithm import Algorithm, Arange, CoordData, SinCoords, Arithmetic, Generic
 
 
 class TestAlgorithm(object):
@@ -17,6 +17,8 @@ class TestAlgorithm(object):
 
     def test_base_definition(self):
         # note: any algorithm node with attrs and inputs would be fine here
+        setting = podpac.settings["ALLOW_PYTHON_EVAL_EXEC"]
+        podpac.settings.set_allow_python_eval_exec(True)
         node = Arithmetic(A=Arange(), B=Arange(), eqn="A+B")
         d = node.base_definition
 
@@ -35,6 +37,7 @@ class TestAlgorithm(object):
         assert "B" in d["inputs"]
 
         # TODO value of d['inputs']['A'], etc
+        podpac.settings.set_allow_python_eval_exec(setting)
 
 
 class TestArange(object):
@@ -76,14 +79,44 @@ class TestArithmetic(object):
     def test_Arithmetic(self):
         coords = podpac.Coordinates([podpac.crange(-90, 90, 1.0), podpac.crange(-180, 180, 1.0)], dims=["lat", "lon"])
         sine_node = SinCoords()
+        setting = podpac.settings["ALLOW_PYTHON_EVAL_EXEC"]
+        podpac.settings.set_allow_python_eval_exec(True)
         node = Arithmetic(A=sine_node, B=sine_node, eqn="2*abs(A) - B + {offset}", params={"offset": 1})
         output = node.eval(coords)
 
         a = sine_node.eval(coords)
         b = sine_node.eval(coords)
         np.testing.assert_allclose(output, 2 * abs(a) - b + 1)
+        podpac.settings.set_allow_python_eval_exec(setting)
 
     def test_missing_equation(self):
+        setting = podpac.settings["ALLOW_PYTHON_EVAL_EXEC"]
+        podpac.settings.set_allow_python_eval_exec(True)
         sine_node = SinCoords()
         with pytest.raises(ValueError):
             node = Arithmetic(A=sine_node, B=sine_node)
+        podpac.settings.set_allow_python_eval_exec(setting)
+
+
+class TestGeneric(object):
+    def test_Generic_allowed(self):
+        setting = podpac.settings["ALLOW_PYTHON_EVAL_EXEC"]
+        podpac.settings.set_allow_python_eval_exec(True)
+        coords = podpac.Coordinates([podpac.crange(-90, 90, 1.0), podpac.crange(-180, 180, 1.0)], dims=["lat", "lon"])
+        a = SinCoords()
+        b = Arange()
+        node = Generic(code="import numpy as np\noutput = np.minimum(a,b)", inputs={"a": a, "b": b})
+        output = node.eval(coords)
+
+        a = node.eval(coords)
+        b = node.eval(coords)
+        np.testing.assert_allclose(output, np.minimum(a, b))
+        podpac.settings.set_allow_python_eval_exec(setting)
+
+    def test_Generic_not_allowed(self):
+        setting = podpac.settings["ALLOW_PYTHON_EVAL_EXEC"]
+        podpac.settings.set_allow_python_eval_exec(False)
+        a = SinCoords()
+        b = Arange()
+        with pytest.raises(PermissionError):
+            node = Generic(code="import numpy as np\noutput = np.minimum(a,b)", inputs={"a": a, "b": b})

--- a/podpac/core/algorithm/test/test_algorithm.py
+++ b/podpac/core/algorithm/test/test_algorithm.py
@@ -120,3 +120,4 @@ class TestGeneric(object):
         b = Arange()
         with pytest.raises(PermissionError):
             node = Generic(code="import numpy as np\noutput = np.minimum(a,b)", inputs={"a": a, "b": b})
+        podpac.settings.set_allow_python_eval_exec(setting)

--- a/podpac/core/authentication.py
+++ b/podpac/core/authentication.py
@@ -156,7 +156,7 @@ class EarthDataSession(Session):
         password : str, optional
             Password input
         """
-        print ("Updating login information for: ", self.hostname)
+        print("Updating login information for: ", self.hostname)
 
         if username is None:
             username = input("Username: ")

--- a/podpac/core/data/datasource.py
+++ b/podpac/core/data/datasource.py
@@ -349,9 +349,10 @@ class DataSource(Node):
         # intersect the native coordinates with requested coordinates
         # to get native coordinates within requested coordinates bounds
         # TODO: support coordinate_index_type parameter to define other index types
-        self._requested_source_coordinates, self._requested_source_coordinates_index = self.native_coordinates.intersect(
-            coordinates, outer=True, return_indices=True
-        )
+        (
+            self._requested_source_coordinates,
+            self._requested_source_coordinates_index,
+        ) = self.native_coordinates.intersect(coordinates, outer=True, return_indices=True)
 
         # if requested coordinates and native coordinates do not intersect, shortcut with nan UnitsDataArary
         if self._requested_source_coordinates.size == 0:
@@ -365,7 +366,10 @@ class DataSource(Node):
         self._set_interpolation()
 
         # interpolate requested coordinates before getting data
-        self._requested_source_coordinates, self._requested_source_coordinates_index = self._interpolation.select_coordinates(
+        (
+            self._requested_source_coordinates,
+            self._requested_source_coordinates_index,
+        ) = self._interpolation.select_coordinates(
             self._requested_source_coordinates, self._requested_source_coordinates_index, coordinates
         )
 

--- a/podpac/core/data/test/test_interpolate.py
+++ b/podpac/core/data/test/test_interpolate.py
@@ -487,8 +487,8 @@ class TestInterpolators(object):
             coords_dst = Coordinates([[1, 1.2, 1.5, 5, 9]], dims=["lat"])
             output = node.eval(coords_dst)
 
-            print (output)
-            print (source)
+            print(output)
+            print(source)
             assert isinstance(output, UnitsDataArray)
             assert np.all(output.lat.values == coords_dst.coords["lat"])
             assert output.values[0] == source[0] and np.isnan(output.values[1]) and output.values[2] == source[1]
@@ -601,7 +601,7 @@ class TestInterpolators(object):
 
             assert isinstance(output, UnitsDataArray)
             assert np.all(output.lat.values == coords_dst.coords["lat"])
-            print (output)
+            print(output)
             assert output.data[0, 0] == 0.0
             assert output.data[0, 3] == 3.0
             assert output.data[1, 3] == 8.0

--- a/podpac/core/data/types.py
+++ b/podpac/core/data/types.py
@@ -184,7 +184,7 @@ class PyDAP(DataSource):
                 dataset = self._open_url()
             except Exception:
                 # TODO: handle 403 error
-                print ("Warning, dataset could not be opened. Check login credentials.")
+                print("Warning, dataset could not be opened. Check login credentials.")
                 dataset = None
 
         return dataset
@@ -1025,7 +1025,7 @@ class WCS(DataSource):
                         with rasterio.open(io) as dataset:
                             output.data[i, ...] = dataset.read()
                     except Exception as e:  # Probably python 2
-                        print (e)
+                        print(e)
                         tmppath = os.path.join(settings["DISK_CACHE_DIR"], "wcs_temp.tiff")
 
                         if not os.path.exists(os.path.split(tmppath)[0]):
@@ -1095,7 +1095,7 @@ class WCS(DataSource):
                         else:
                             output.data[:] = dataset.read()
                 except Exception as e:  # Probably python 2
-                    print (e)
+                    print(e)
                     tmppath = os.path.join(settings["DISK_CACHE_DIR"], "wcs_temp.tiff")
                     if not os.path.exists(os.path.split(tmppath)[0]):
                         os.makedirs(os.path.split(tmppath)[0])

--- a/podpac/core/settings.py
+++ b/podpac/core/settings.py
@@ -92,7 +92,7 @@ class PodpacSettings(dict):
     DEFAULT_CACHE : list
         Defines a default list of cache stores in priority order. Defaults to `['ram']`.
     CACHE_OUTPUT_DEFAULT : bool
-        Default value for node ``cache_output`` trait.
+        Default value for node ``cache_output`` trait. If True, the outputs of nodes (eval) will be automatically cached.
     RAM_CACHE_MAX_BYTES : int
         Maximum RAM cache size in bytes. 
         Note, for RAM cache only, the limit is applied to the total amount of RAM used by the python process; 
@@ -304,6 +304,32 @@ class PodpacSettings(dict):
 
         if self["S3_CACHE_DIR"] is None:
             self["S3_CACHE_DIR"] = DEFAULT_SETTINGS["S3_CACHE_DIR"]
+
+        # This setting cannot come from the saved JSON file on disk but requires a file
+        # to exist at the root path of the code.
+        self["ALLOW_PYTHON_EVAL_EXEC"] = max([os.path.exists(p) for p in self._allow_python_eval_exec_paths])
+
+    @property
+    def _allow_python_eval_exec_paths(self):
+        return (
+            os.path.join(os.getcwd(), "ALLOW_PYTHON_EVAL_EXEC"),
+            os.path.join(os.path.dirname(__file__), "..", "ALLOW_PYTHON_EVAL_EXEC"),
+            os.path.join(self["ROOT_PATH"], "ALLOW_PYTHON_EVAL_EXEC"),
+        )
+
+    def set_allow_python_eval_exec(self, allow=False):
+        if allow:
+            f = open(self._allow_python_eval_exec_paths[-1], "w")
+            f.write("")
+            f.close()
+            self["ALLOW_PYTHON_EVAL_EXEC"] = True
+        else:
+            for p in self._allow_python_eval_exec_paths:
+                try:
+                    os.remove(p)
+                except FileNotFoundError as e:
+                    pass
+            self["ALLOW_PYTHON_EVAL_EXEC"] = False
 
 
 # load settings dict when module is loaded

--- a/podpac/datalib/airmoss.py
+++ b/podpac/datalib/airmoss.py
@@ -201,17 +201,17 @@ class AirMOSS(podpac.OrderedCompositor):
 
 if __name__ == "__main__":
     ams = AirMOSS_Site(interpolation="nearest_preview", site="BermsP")
-    print (ams.native_coordinates)
+    print(ams.native_coordinates)
 
     source = "https://thredds.daac.ornl.gov/thredds/dodsC/ornldaac/1421/L4RZSM_BermsP_20121025_v5.nc4"
     am = AirMOSS_Source(source=source, interpolation="nearest_preview")
     coords = am.native_coordinates
-    print (coords)
-    print (coords["time"].area_bounds)
+    print(coords)
+    print(coords["time"].area_bounds)
 
     lat, lon = am.native_coordinates.coords["lat"], am.native_coordinates.coords["lon"]
     lat = lat[::10][np.isfinite(lat[::10])]
     lon = lon[::10][np.isfinite(lon[::10])]
     coords = podpac.Coordinates([lat, lon], dims=["lat", "lon"])
     o = am.eval(coords)
-    print ("Done")
+    print("Done")

--- a/podpac/datalib/drought_monitor.py
+++ b/podpac/datalib/drought_monitor.py
@@ -69,16 +69,16 @@ if __name__ == "__main__":
     # local
     path = "droughtmonitor/beta_parameters.zarr"
     d0 = DroughtMonitorCategory(source=path, datakey="d0")
-    print (d0.native_coordinates)
-    print (d0.eval(c))
+    print(d0.native_coordinates)
+    print(d0.eval(c))
 
     # s3
     bucket = "podpac-internal-test"
     store = "drought_parameters.zarr"
     path = "s3://%s/%s" % (bucket, store)
     d0 = DroughtMonitorCategory(source=path, datakey="d0")
-    print (d0.native_coordinates)
-    print (d0.eval(c))
+    print(d0.native_coordinates)
+    print(d0.eval(c))
 
     # the Zarr node uses the podpac AWS settings by default, but credentials can be explicitly provided, too
     d0 = DroughtMonitorCategory(

--- a/podpac/datalib/egi.py
+++ b/podpac/datalib/egi.py
@@ -218,8 +218,8 @@ class EGI(DataSource):
         try:
             self.data = self._read_zips(zip_files)  # reads each file in zip archive and creates single dataarray
         except KeyError as e:
-            print ("This following error may occur if data_key, lat_key, or lon_key is not correct.")
-            print (
+            print("This following error may occur if data_key, lat_key, or lon_key is not correct.")
+            print(
                 "This error may also occur if the specified area bounds are smaller than the dataset pixel size, in"
                 " which case EGI is returning no data."
             )

--- a/podpac/version.py
+++ b/podpac/version.py
@@ -68,6 +68,6 @@ def version():
         version_full = version_full.replace("-", "+", 1).replace("-", ".")  # Make this consistent with PEP440
 
     except Exception as e:
-        print ("Could not determine PODPAC version from git repo.\n" + str(e))
+        print("Could not determine PODPAC version from git repo.\n" + str(e))
 
     return version_full


### PR DESCRIPTION
```python
import podpac
n1 = podpac.algorithm.Arange()
n2 = podpac.algorithm.SinCoords()
coords = podpac.Coordinates([podpac.clinspace(4800000, 4900000, 256), podpac.clinspace(-8500000, -8400000, 256)],
                     dims=['lat', 'lon'], crs='epsg:3857')
n = podpac.core.algorithm.algorithm.Generic(code='''import numpy as np
output = np.minimum(n1, n2)''', inputs={'n1':n1, 'n2': n2})
n.eval(coords)
```

Note, I've made this "secure", so you will need to set a setting when testing this: 
```python
podpac.settings.set_allow_python_eval_exec(True)
```

This doesn't use the usual 'settings' mechanism, and REQUIRES a file to exist in one of 3 locations (cwd, root podpac install, or ROOT_PATH as defined in the settings file.)