### PR TITLE
Creates a settings context manager for easy temporary settings.

### DIFF
--- a/podpac/core/algorithm/generic.py
+++ b/podpac/core/algorithm/generic.py
@@ -33,6 +33,9 @@ class GenericInputs(Algorithm):
 
     def _first_init(self, **kwargs):
         trait_names = self.trait_names()
+        for key in kwargs:
+            if key in trait_names and isinstance(kwargs[key], Node):
+                raise RuntimeError("Trait '%s' is reserved and cannot be used as an Generic Algorithm input" % key)
         input_keys = [key for key in kwargs if key not in trait_names and isinstance(kwargs[key], Node)]
         inputs = {key: kwargs.pop(key) for key in input_keys}
         return super(GenericInputs, self)._first_init(inputs=inputs, **kwargs)

--- a/podpac/core/algorithm/test/test_algorithm.py
+++ b/podpac/core/algorithm/test/test_algorithm.py
@@ -1,5 +1,7 @@
 from __future__ import division, unicode_literals, print_function, absolute_import
 
+import warnings
+
 import pytest
 from collections import OrderedDict
 
@@ -18,11 +20,11 @@ class TestAlgorithm(object):
 
     def test_base_definition(self):
         # note: any algorithm node with attrs and inputs would be fine here
-        setting = podpac.settings["ALLOW_PYTHON_EVAL_EXEC"]
-        podpac.settings.set_allow_python_eval_exec(True)
-        node = Arithmetic(A=Arange(), B=Arange(), eqn="A+B")
-        d = node.base_definition
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", "Insecure evaluation.*")
+            node = Arithmetic(A=Arange(), B=Arange(), eqn="A+B")
 
+        d = node.base_definition
         assert isinstance(d, OrderedDict)
         assert "node" in d
         assert "attrs" in d
@@ -38,4 +40,3 @@ class TestAlgorithm(object):
         assert "B" in d["inputs"]
 
         # TODO value of d['inputs']['A'], etc
-        podpac.settings.set_allow_python_eval_exec(setting)

--- a/podpac/core/algorithm/test/test_generic.py
+++ b/podpac/core/algorithm/test/test_generic.py
@@ -17,6 +17,10 @@ class TestGenericInputs(object):
         assert "a" in node.inputs
         assert "b" in node.inputs
 
+    def test_reserved_name(self):
+        with pytest.raises(RuntimeError, match="Trait .* is reserved"):
+            GenericInputs(style=SinCoords())
+
     def test_serialization(self):
         node = GenericInputs(a=Arange(), b=SinCoords())
         d = node.definition
@@ -28,41 +32,43 @@ class TestGenericInputs(object):
 
 
 class TestArithmetic(object):
-    def setup_method(self):
-        self.settings_orig = copy.deepcopy(podpac.settings)
-
-    def teardown_method(self):
-        for key in podpac.settings:
-            podpac.settings[key] = self.settings_orig[key]
-
     def test_evaluate(self):
-        podpac.settings.set_allow_python_eval_exec(True)
+        with podpac.settings:
+            podpac.settings.set_allow_python_eval_exec(True)
 
-        coords = podpac.Coordinates([podpac.crange(-90, 90, 1.0), podpac.crange(-180, 180, 1.0)], dims=["lat", "lon"])
-        sine_node = SinCoords()
-        node = Arithmetic(A=sine_node, B=sine_node, eqn="2*abs(A) - B + {offset}", params={"offset": 1})
-        output = node.eval(coords)
+            coords = podpac.Coordinates(
+                [podpac.crange(-90, 90, 1.0), podpac.crange(-180, 180, 1.0)], dims=["lat", "lon"]
+            )
+            sine_node = SinCoords()
+            node = Arithmetic(A=sine_node, B=sine_node, eqn="2*abs(A) - B + {offset}", params={"offset": 1})
+            output = node.eval(coords)
 
-        a = sine_node.eval(coords)
-        b = sine_node.eval(coords)
-        np.testing.assert_allclose(output, 2 * abs(a) - b + 1)
+            a = sine_node.eval(coords)
+            b = sine_node.eval(coords)
+            np.testing.assert_allclose(output, 2 * abs(a) - b + 1)
 
     def test_evaluate_not_allowed(self):
-        podpac.settings.set_allow_python_eval_exec(False)
+        with podpac.settings:
+            podpac.settings.set_allow_python_eval_exec(False)
 
-        coords = podpac.Coordinates([podpac.crange(-90, 90, 1.0), podpac.crange(-180, 180, 1.0)], dims=["lat", "lon"])
-        sine_node = SinCoords()
+            coords = podpac.Coordinates(
+                [podpac.crange(-90, 90, 1.0), podpac.crange(-180, 180, 1.0)], dims=["lat", "lon"]
+            )
+            sine_node = SinCoords()
 
-        with pytest.warns(UserWarning, match="Insecure evaluation"):
-            node = Arithmetic(A=sine_node, B=sine_node, eqn="2*abs(A) - B + {offset}", params={"offset": 1})
+            with pytest.warns(UserWarning, match="Insecure evaluation"):
+                node = Arithmetic(A=sine_node, B=sine_node, eqn="2*abs(A) - B + {offset}", params={"offset": 1})
 
-        with pytest.raises(PermissionError):
-            node.eval(coords)
+            with pytest.raises(PermissionError):
+                node.eval(coords)
 
     def test_missing_equation(self):
-        sine_node = SinCoords()
-        with pytest.raises(ValueError):
-            node = Arithmetic(A=sine_node, B=sine_node)
+        with podpac.settings:
+            podpac.settings.set_allow_python_eval_exec(True)
+
+            sine_node = SinCoords()
+            with pytest.raises(ValueError):
+                Arithmetic(A=sine_node, B=sine_node)
 
 
 class TestGeneric(object):
@@ -70,35 +76,42 @@ class TestGeneric(object):
         a = SinCoords()
         b = Arange()
 
-        podpac.settings.set_allow_python_eval_exec(True)
-        node = Generic(code="import numpy as np\noutput = np.minimum(a,b)", a=a, b=b)
-
-        podpac.settings.set_allow_python_eval_exec(False)
-        with pytest.warns(UserWarning, match="Insecure evaluation"):
+        with podpac.settings:
+            podpac.settings.set_allow_python_eval_exec(True)
             node = Generic(code="import numpy as np\noutput = np.minimum(a,b)", a=a, b=b)
+
+            podpac.settings.set_allow_python_eval_exec(False)
+            with pytest.warns(UserWarning, match="Insecure evaluation"):
+                node = Generic(code="import numpy as np\noutput = np.minimum(a,b)", a=a, b=b)
 
     def test_evaluate(self):
-        podpac.settings.set_allow_python_eval_exec(True)
+        with podpac.settings:
+            podpac.settings.set_allow_python_eval_exec(True)
 
-        coords = podpac.Coordinates([podpac.crange(-90, 90, 1.0), podpac.crange(-180, 180, 1.0)], dims=["lat", "lon"])
-        a = SinCoords()
-        b = Arange()
-        node = Generic(code="import numpy as np\noutput = np.minimum(a,b)", a=a, b=b)
-        output = node.eval(coords)
+            coords = podpac.Coordinates(
+                [podpac.crange(-90, 90, 1.0), podpac.crange(-180, 180, 1.0)], dims=["lat", "lon"]
+            )
+            a = SinCoords()
+            b = Arange()
+            node = Generic(code="import numpy as np\noutput = np.minimum(a,b)", a=a, b=b)
+            output = node.eval(coords)
 
-        a = node.eval(coords)
-        b = node.eval(coords)
-        np.testing.assert_allclose(output, np.minimum(a, b))
+            a = node.eval(coords)
+            b = node.eval(coords)
+            np.testing.assert_allclose(output, np.minimum(a, b))
 
     def test_evaluate_not_allowed(self):
-        podpac.settings.set_allow_python_eval_exec(False)
+        with podpac.settings:
+            podpac.settings.set_allow_python_eval_exec(False)
 
-        coords = podpac.Coordinates([podpac.crange(-90, 90, 1.0), podpac.crange(-180, 180, 1.0)], dims=["lat", "lon"])
-        a = SinCoords()
-        b = Arange()
+            coords = podpac.Coordinates(
+                [podpac.crange(-90, 90, 1.0), podpac.crange(-180, 180, 1.0)], dims=["lat", "lon"]
+            )
+            a = SinCoords()
+            b = Arange()
 
-        with pytest.warns(UserWarning, match="Insecure evaluation"):
-            node = Generic(code="import numpy as np\noutput = np.minimum(a,b)", a=a, b=b)
+            with pytest.warns(UserWarning, match="Insecure evaluation"):
+                node = Generic(code="import numpy as np\noutput = np.minimum(a,b)", a=a, b=b)
 
-        with pytest.raises(PermissionError):
-            node.eval(coords)
+            with pytest.raises(PermissionError):
+                node.eval(coords)

--- a/podpac/core/algorithm/test/test_generic.py
+++ b/podpac/core/algorithm/test/test_generic.py
@@ -37,9 +37,7 @@ class TestArithmetic(object):
 
         with podpac.settings:
             podpac.settings.set_allow_python_eval_exec(True)
-            with warnings.catch_warnings():
-                warnings.filterwarnings("error", "Insecure evaluation.*")
-                node = Arithmetic(A=sine_node, B=sine_node, eqn="2*abs(A) - B + {offset}", params={"offset": 1})
+            node = Arithmetic(A=sine_node, B=sine_node, eqn="2*abs(A) - B + {offset}", params={"offset": 1})
 
             podpac.settings.set_allow_python_eval_exec(False)
             with pytest.warns(UserWarning, match="Insecure evaluation"):
@@ -89,9 +87,7 @@ class TestGeneric(object):
 
         with podpac.settings:
             podpac.settings.set_allow_python_eval_exec(True)
-            with warnings.catch_warnings():
-                warnings.filterwarnings("error", "Insecure evaluation.*")
-                node = Generic(code="import numpy as np\noutput = np.minimum(a,b)", a=a, b=b)
+            node = Generic(code="import numpy as np\noutput = np.minimum(a,b)", a=a, b=b)
 
             podpac.settings.set_allow_python_eval_exec(False)
             with pytest.warns(UserWarning, match="Insecure evaluation"):

--- a/podpac/core/algorithm/test/test_signal.py
+++ b/podpac/core/algorithm/test/test_signal.py
@@ -6,7 +6,7 @@ import numpy as np
 from numpy.testing import assert_equal, assert_array_equal
 import traitlets as tl
 
-from podpac.core.settings import settings
+import podpac
 from podpac import Coordinates, clinspace, crange
 from podpac.algorithm import Arange
 from podpac.data import Array
@@ -85,33 +85,31 @@ class TestConvolution(object):
         assert_array_equal(a, o)
 
     def test_debuggable_source(self):
-        debug = settings["DEBUG"]
-        settings["DEBUG"] = False
-        lat = clinspace(45, 66, 30, name="lat")
-        lon = clinspace(-80, 70, 40, name="lon")
-        coords = Coordinates([lat, lon])
+        with podpac.settings:
+            podpac.settings["DEBUG"] = False
+            lat = clinspace(45, 66, 30, name="lat")
+            lon = clinspace(-80, 70, 40, name="lon")
+            coords = Coordinates([lat, lon])
 
-        # normal version
-        a = Arange()
-        node = Convolution(source=a, kernel=[[1, 2, 1]], kernel_ndim=2)
-        node.eval(coords)
+            # normal version
+            a = Arange()
+            node = Convolution(source=a, kernel=[[1, 2, 1]], kernel_ndim=2)
+            node.eval(coords)
 
-        assert node.source is a
+            assert node.source is a
 
-        # debuggable
-        settings["DEBUG"] = True
+            # debuggable
+            podpac.settings["DEBUG"] = True
 
-        a = Arange()
-        node = Convolution(source=a, kernel=[[1, 2, 1]], kernel_ndim=2)
-        node.eval(coords)
+            a = Arange()
+            node = Convolution(source=a, kernel=[[1, 2, 1]], kernel_ndim=2)
+            node.eval(coords)
 
-        assert node.source is not a
-        assert node._requested_coordinates == coords
-        assert node.source._requested_coordinates is not None
-        assert node.source._requested_coordinates != coords
-        assert a._requested_coordinates is None
-
-        settings["DEBUG"] = debug
+            assert node.source is not a
+            assert node._requested_coordinates == coords
+            assert node.source._requested_coordinates is not None
+            assert node.source._requested_coordinates != coords
+            assert a._requested_coordinates is None
 
 
 class TestSpatialConvolution(object):

--- a/podpac/core/algorithm/test/test_stats.py
+++ b/podpac/core/algorithm/test/test_stats.py
@@ -72,15 +72,19 @@ class BaseTests(object):
     """ Common tests for Reduce subclasses """
 
     def test_full(self):
-        node = self.NodeClass(source=source)
-        output = node.eval(coords)
-        # xr.testing.assert_allclose(output, self.expected_full)
-        np.testing.assert_allclose(output.data, self.expected_full.data)
+        with podpac.settings:
+            podpac.settings["CACHE_OUTPUT_DEFAULT"] = False
+            podpac.settings["CHUNK_SIZE"] = None
 
-        node = self.NodeClass(source=source, dims=coords.dims)
-        output = node.eval(coords)
-        # xr.testing.assert_allclose(output, self.expected_full)
-        np.testing.assert_allclose(output.data, self.expected_full.data)
+            node = self.NodeClass(source=source)
+            output = node.eval(coords)
+            # xr.testing.assert_allclose(output, self.expected_full)
+            np.testing.assert_allclose(output.data, self.expected_full.data)
+
+            node = self.NodeClass(source=source, dims=coords.dims)
+            output = node.eval(coords)
+            # xr.testing.assert_allclose(output, self.expected_full)
+            np.testing.assert_allclose(output.data, self.expected_full.data)
 
     def test_full_chunked(self):
         with podpac.settings:
@@ -94,6 +98,7 @@ class BaseTests(object):
     def test_lat_lon(self):
         with podpac.settings:
             podpac.settings["CACHE_OUTPUT_DEFAULT"] = False
+            podpac.settings["CHUNK_SIZE"] = None
             node = self.NodeClass(source=source, dims=["lat", "lon"])
             output = node.eval(coords)
             # xr.testing.assert_allclose(output, self.expected_latlon)
@@ -111,6 +116,7 @@ class BaseTests(object):
     def test_time(self):
         with podpac.settings:
             podpac.settings["CACHE_OUTPUT_DEFAULT"] = False
+            podpac.settings["CHUNK_SIZE"] = None
             node = self.NodeClass(source=source, dims="time")
             output = node.eval(coords)
             # xr.testing.assert_allclose(output, self.expected_time)

--- a/podpac/core/cache/test/test_cache_ctrl.py
+++ b/podpac/core/cache/test/test_cache_ctrl.py
@@ -20,13 +20,12 @@ def test_get_default_cache_ctrl():
     assert isinstance(ctrl, CacheCtrl)
     assert ctrl._cache_stores == []
 
-    podpac.settings["DEFAULT_CACHE"] = ["ram"]
-    ctrl = get_default_cache_ctrl()
-    assert isinstance(ctrl, CacheCtrl)
-    assert len(ctrl._cache_stores) == 1
-    assert isinstance(ctrl._cache_stores[0], RamCacheStore)
-
-    podpac.settings["DEFAULT_CACHE"] = []
+    with podpac.settings:
+        podpac.settings["DEFAULT_CACHE"] = ["ram"]
+        ctrl = get_default_cache_ctrl()
+        assert isinstance(ctrl, CacheCtrl)
+        assert len(ctrl._cache_stores) == 1
+        assert isinstance(ctrl._cache_stores[0], RamCacheStore)
 
 
 def test_make_cache_ctrl():
@@ -49,17 +48,15 @@ def test_make_cache_ctrl():
 
 
 def test_clear_cache():
-    # make a default cache
-    podpac.settings["DEFAULT_CACHE"] = ["ram"]
+    with podpac.settings:
+        # make a default cache
+        podpac.settings["DEFAULT_CACHE"] = ["ram"]
 
-    # fill the default cache
-    node = podpac.algorithm.Arange()
-    node.put_cache(0, "mykey")
-    assert node.has_cache("mykey")
+        # fill the default cache
+        node = podpac.algorithm.Arange()
+        node.put_cache(0, "mykey")
+        assert node.has_cache("mykey")
 
-    clear_cache()
+        clear_cache()
 
-    assert not node.has_cache("mykey")
-
-    # reset default cache
-    podpac.settings["DEFAULT_CACHE"] = []
+        assert not node.has_cache("mykey")

--- a/podpac/core/coordinates/test/test_array_coordinates1d.py
+++ b/podpac/core/coordinates/test/test_array_coordinates1d.py
@@ -12,7 +12,6 @@ from podpac.core.coordinates.array_coordinates1d import ArrayCoordinates1d
 from podpac.core.coordinates.uniform_coordinates1d import UniformCoordinates1d
 from podpac.core.coordinates.stacked_coordinates import StackedCoordinates
 from podpac.core.coordinates.coordinates import Coordinates
-from podpac.core.settings import settings
 
 
 class TestArrayCoordinatesInit(object):

--- a/podpac/core/data/test/test_types.py
+++ b/podpac/core/data/test/test_types.py
@@ -30,7 +30,6 @@ from podpac.core.node import COMMON_NODE_DOC, Node
 from podpac.core.data.datasource import COMMON_DATA_DOC, DataSource
 from podpac.core.data.types import WCS_DEFAULT_VERSION, WCS_DEFAULT_CRS
 from podpac.core.data.types import Array, PyDAP, Rasterio, WCS, ReprojectedSource, CSV, H5PY, Zarr
-from podpac.core.settings import settings
 
 # Trying to fix test
 pydap.client.open_url

--- a/podpac/core/node.py
+++ b/podpac/core/node.py
@@ -9,6 +9,7 @@ import functools
 import json
 import inspect
 import importlib
+import warnings
 from collections import OrderedDict
 from copy import deepcopy
 from hashlib import md5 as hash_alg
@@ -342,8 +343,9 @@ class Node(tl.HasTraits):
         definitions = []
 
         def add_node(node):
-            if node in nodes:
-                return refs[nodes.index(node)]
+            for ref, n in zip(refs, nodes):
+                if node.hash == n.hash:
+                    return ref
 
             # get base definition and then replace nodes with references, adding nodes depth first
             d = node.base_definition

--- a/podpac/core/pipeline/test/test_parse_pipeline_definition.py
+++ b/podpac/core/pipeline/test/test_parse_pipeline_definition.py
@@ -1,7 +1,9 @@
 from __future__ import division, unicode_literals, print_function, absolute_import
 
 import json
+import warnings
 from collections import OrderedDict
+
 import numpy as np
 import traitlets as tl
 import pytest
@@ -312,56 +314,59 @@ class TestParsePipelineDefinition(object):
         np.testing.assert_array_equal(output.node.source, [0, 1, 2])
 
     def test_algorithm_inputs(self):
-        # basic
-        s = """
-        {
-            "nodes": {
-                "source1": {"node": "algorithm.Arange"},
-                "source2": {"node": "algorithm.CoordData"},
-                "result": {        
-                    "node": "algorithm.Arithmetic",
-                    "inputs": {
-                        "A": "source1",
-                        "B": "source2"
-                    },
-                    "attrs": {
-                        "eqn": "A + B"
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", "Insecure evaluation.*")
+
+            # basic
+            s = """
+            {
+                "nodes": {
+                    "source1": {"node": "algorithm.Arange"},
+                    "source2": {"node": "algorithm.CoordData"},
+                    "result": {        
+                        "node": "algorithm.Arithmetic",
+                        "inputs": {
+                            "A": "source1",
+                            "B": "source2"
+                        },
+                        "attrs": {
+                            "eqn": "A + B"
+                        }
                     }
                 }
             }
-        }
-        """
+            """
 
-        d = json.loads(s, object_pairs_hook=OrderedDict)
-        output = parse_pipeline_definition(d)
+            d = json.loads(s, object_pairs_hook=OrderedDict)
+            output = parse_pipeline_definition(d)
 
-        assert isinstance(output.node.inputs["A"], podpac.algorithm.Arange)
-        assert isinstance(output.node.inputs["B"], podpac.algorithm.CoordData)
+            assert isinstance(output.node.inputs["A"], podpac.algorithm.Arange)
+            assert isinstance(output.node.inputs["B"], podpac.algorithm.CoordData)
 
-        # sub-node
-        s = """
-        {
-            "nodes": {
-                "mysource": {"node": "algorithm.Arange"},
-                "mean": {
-                    "node": "algorithm.Mean",
-                    "inputs": {"source": "mysource"}
-                },
-                "double": {
-                    "node": "algorithm.Arithmetic",
-                    "inputs": { "A": "mean.source" },
-                    "attrs": { "eqn": "2 * A" }
+            # sub-node
+            s = """
+            {
+                "nodes": {
+                    "mysource": {"node": "algorithm.Arange"},
+                    "mean": {
+                        "node": "algorithm.Mean",
+                        "inputs": {"source": "mysource"}
+                    },
+                    "double": {
+                        "node": "algorithm.Arithmetic",
+                        "inputs": { "A": "mean.source" },
+                        "attrs": { "eqn": "2 * A" }
+                    }
                 }
             }
-        }
-        """
+            """
 
-        d = json.loads(s, object_pairs_hook=OrderedDict)
-        output = parse_pipeline_definition(d)
+            d = json.loads(s, object_pairs_hook=OrderedDict)
+            output = parse_pipeline_definition(d)
 
-        assert isinstance(output.node.inputs["A"], podpac.algorithm.Arange)
+            assert isinstance(output.node.inputs["A"], podpac.algorithm.Arange)
 
-        # nonexistent node/attribute references are tested in test_datasource_lookup_source
+            # nonexistent node/attribute references are tested in test_datasource_lookup_source
 
     def test_compositor_sources(self):
         # basic
@@ -717,30 +722,33 @@ class TestParsePipelineDefinition(object):
             parse_pipeline_definition(d)
 
     def test_parse_output_implicit_node(self):
-        s = """
-        {
-            "nodes": {
-                "source1": {"node": "algorithm.Arange"},
-                "source2": {"node": "algorithm.Arange"},
-                "result": {        
-                    "node": "algorithm.Arithmetic",
-                    "inputs": {
-                        "A": "source1",
-                        "B": "source2"
-                    },
-                    "attrs": {
-                        "eqn": "A + B"
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", "Insecure evaluation.*")
+
+            s = """
+            {
+                "nodes": {
+                    "source1": {"node": "algorithm.Arange"},
+                    "source2": {"node": "algorithm.Arange"},
+                    "result": {        
+                        "node": "algorithm.Arithmetic",
+                        "inputs": {
+                            "A": "source1",
+                            "B": "source2"
+                        },
+                        "attrs": {
+                            "eqn": "A + B"
+                        }
                     }
+                },
+                "output": {
+                    "mode": "none"
                 }
-            },
-            "output": {
-                "mode": "none"
             }
-        }
-        """
-        d = json.loads(s, object_pairs_hook=OrderedDict)
-        output = parse_pipeline_definition(d)
-        assert isinstance(output.node, podpac.algorithm.Arithmetic)
+            """
+            d = json.loads(s, object_pairs_hook=OrderedDict)
+            output = parse_pipeline_definition(d)
+            assert isinstance(output.node, podpac.algorithm.Arithmetic)
 
     def test_parse_output_implicit(self):
         s = """

--- a/podpac/core/pipeline/test/test_pipeline.py
+++ b/podpac/core/pipeline/test/test_pipeline.py
@@ -160,13 +160,15 @@ class TestPipeline(object):
         }
         """
 
-        debug = podpac.core.settings.settings["DEBUG"]
-        podpac.core.settings.settings["DEBUG"] = False
-        with pytest.warns(DeprecationWarning):
-            pipeline = Pipeline(json=s)
-        assert pipeline.node.inputs["A"] is pipeline.node.inputs["B"].source
-        podpac.core.settings.settings["DEBUG"] = True
-        with pytest.warns(DeprecationWarning):
-            pipeline = Pipeline(json=s)
-        assert pipeline.node.inputs["A"] is not pipeline.node.inputs["B"].source
-        podpac.core.settings.settings["DEBUG"] = debug
+        with podpac.settings, warnings.catch_warnings():
+            warnings.filterwarnings("ignore", "Insecure evaluation.*")
+
+            podpac.core.settings.settings["DEBUG"] = False
+            with pytest.warns(DeprecationWarning):
+                pipeline = Pipeline(json=s)
+            assert pipeline.node.inputs["A"] is pipeline.node.inputs["B"].source
+
+            podpac.core.settings.settings["DEBUG"] = True
+            with pytest.warns(DeprecationWarning):
+                pipeline = Pipeline(json=s)
+            assert pipeline.node.inputs["A"] is not pipeline.node.inputs["B"].source

--- a/podpac/core/settings.py
+++ b/podpac/core/settings.py
@@ -331,6 +331,13 @@ class PodpacSettings(dict):
                     pass
             self["ALLOW_PYTHON_EVAL_EXEC"] = False
 
+    def __enter__(self):
+        self.original = {k: v for k, v in self.items()}
+
+    def __exit__(self, type, value, traceback):
+        for k, v in self.original.items():
+            self[k] = v
+
 
 # load settings dict when module is loaded
 settings = PodpacSettings()

--- a/podpac/core/settings.py
+++ b/podpac/core/settings.py
@@ -337,7 +337,7 @@ class PodpacSettings(dict):
 
     def __exit__(self, type, value, traceback):
         # restore eval/exec state (setting and file)
-        self.set_allow_python_eval_exec(self._original.get("ALLOW_PYTHON_EVAL_EXEC", False))
+        self.set_allow_python_eval_exec(self._original["ALLOW_PYTHON_EVAL_EXEC"])
 
         # restore original settings
         for k, v in self._original.items():

--- a/podpac/core/settings.py
+++ b/podpac/core/settings.py
@@ -332,10 +332,15 @@ class PodpacSettings(dict):
             self["ALLOW_PYTHON_EVAL_EXEC"] = False
 
     def __enter__(self):
-        self.original = {k: v for k, v in self.items()}
+        # save original settings
+        self._original = {k: v for k, v in self.items()}
 
     def __exit__(self, type, value, traceback):
-        for k, v in self.original.items():
+        # restore eval/exec state (setting and file)
+        self.set_allow_python_eval_exec(self._original.get("ALLOW_PYTHON_EVAL_EXEC", False))
+
+        # restore original settings
+        for k, v in self._original.items():
             self[k] = v
 
 

--- a/podpac/core/test/test_compositor.py
+++ b/podpac/core/test/test_compositor.py
@@ -67,42 +67,45 @@ class TestCompositor(object):
         np.testing.assert_array_equal(o.data, a.source[5, 5])
 
     def test_ordered_compositor(self):
-        # single thread
-        podpac.settings["MULTITHREADING"] = False
-        node = OrderedCompositor(
-            sources=self.sources, shared_coordinates=self.coord_src, cache_native_coordinates=False
-        )
-        result = node.eval(coordinates=self.coord_src)
+        with podpac.settings:
+            # single thread
+            podpac.settings["MULTITHREADING"] = False
+            node = OrderedCompositor(
+                sources=self.sources, shared_coordinates=self.coord_src, cache_native_coordinates=False
+            )
+            result = node.eval(coordinates=self.coord_src)
 
-        # multithreaded
-        podpac.settings["MULTITHREADING"] = True
-        node = OrderedCompositor(
-            sources=self.sources, shared_coordinates=self.coord_src, cache_native_coordinates=False
-        )
-        result = node.eval(coordinates=self.coord_src)
-        # assert self.node._native_coordinates_default().dims == self.coord_src.dims
+            # multithreaded
+            podpac.settings["MULTITHREADING"] = True
+            node = OrderedCompositor(
+                sources=self.sources, shared_coordinates=self.coord_src, cache_native_coordinates=False
+            )
+            result = node.eval(coordinates=self.coord_src)
+            # assert self.node._native_coordinates_default().dims == self.coord_src.dims
 
     def test_source_coordinates_ordered_compositor(self):
-        # single thread
-        podpac.settings["MULTITHREADING"] = False
-        node = OrderedCompositor(
-            sources=self.sources, shared_coordinates=self.coord_src, cache_native_coordinates=False
-        )
+        with podpac.settings:
+            # single thread
+            podpac.settings["MULTITHREADING"] = False
+            node = OrderedCompositor(
+                sources=self.sources, shared_coordinates=self.coord_src, cache_native_coordinates=False
+            )
 
-        # multithreaded
-        podpac.settings["MULTITHREADING"] = True
-        node = OrderedCompositor(
-            sources=self.sources, shared_coordinates=self.coord_src, cache_native_coordinates=False
-        )
+            # multithreaded
+            podpac.settings["MULTITHREADING"] = True
+            node = OrderedCompositor(
+                sources=self.sources, shared_coordinates=self.coord_src, cache_native_coordinates=False
+            )
 
     def test_caching_ordered_compositor(self):
-        # single thread
-        podpac.settings["MULTITHREADING"] = False
-        node = OrderedCompositor(sources=self.sources, shared_coordinates=self.coord_src)
+        with podpac.settings:
+            # single thread
+            podpac.settings["MULTITHREADING"] = False
+            node = OrderedCompositor(sources=self.sources, shared_coordinates=self.coord_src)
 
-        # multithreaded
-        podpac.settings["MULTITHREADING"] = True
-        node = OrderedCompositor(sources=self.sources, shared_coordinates=self.coord_src)
+            # multithreaded
+            podpac.settings["MULTITHREADING"] = True
+            node = OrderedCompositor(sources=self.sources, shared_coordinates=self.coord_src)
 
     def test_heterogeous_sources_composited(self):
         anative = podpac.Coordinates([podpac.clinspace((0, 1), (1, 2), size=3)], dims=["lat_lon"])

--- a/podpac/datalib/drought_monitor.py
+++ b/podpac/datalib/drought_monitor.py
@@ -9,7 +9,6 @@ from podpac.core.coordinates import ArrayCoordinates1d
 def drought_style():
     return Style(
         clim=[0, 6],
-        is_enumerated=True,
         enumeration_colors=[
             [0.45098039, 0.0, 0.0, 1.0],
             [0.90196078, 0.0, 0.0, 1.0],
@@ -22,7 +21,7 @@ def drought_style():
 
 
 def sm_style():
-    return Style(clim=[0, 0.6], cmap="gist_earth_r")
+    return Style(clim=[0, 0.6], colormap="gist_earth_r")
 
 
 class DroughtMonitorCategory(Zarr):


### PR DESCRIPTION
Pretty simple, the settings can be used in a context manager to restore original settings after exiting a block.

```
with podpac.settings:
    podpac.settings["CACHE_OUTPUT_DEFAUL"] = False
    ...

# settings are restored
assert podpac.settings["CACHE_OUTPUT_DEFAULT"] == True
```

This can replace setup_method and teardown_method in tests, which is what I used it for here, but it seems useful in general. If you like it, I will propagate it to other places in the tests.

Note that just setting and restoring the settings in a test method (instead of setup and teardown methods) isn't a good idea because if the test fails, the settings won't be restored. Other alternatives I considered are a decorator `@podpac.settings.temporary_settings` that would be applied to specific test methods (a bit harder to implement) and a base test class with setup and teardown methods that always restore all of the settings (inefficient).