### PR TITLE
ENH: adds "UnitsDataArray.open" and "UnitsDataArray.create" class methods

### DIFF
--- a/podpac/__init__.py
+++ b/podpac/__init__.py
@@ -44,7 +44,7 @@ from podpac.core.coordinates import Coordinates, crange, clinspace
 from podpac.core.node import Node, NodeException
 import podpac.core.authentication as authentication
 from podpac.core.utils import NodeTrait
-from podpac.core.units import ureg as units
+from podpac.core.units import ureg as units, open_dataarray, UnitsDataArray
 
 # Organized submodules
 # These files are simply wrappers to create a curated namespace of podpac modules

--- a/podpac/__init__.py
+++ b/podpac/__init__.py
@@ -44,7 +44,7 @@ from podpac.core.coordinates import Coordinates, crange, clinspace
 from podpac.core.node import Node, NodeException
 import podpac.core.authentication as authentication
 from podpac.core.utils import NodeTrait
-from podpac.core.units import ureg as units, open_dataarray, UnitsDataArray
+from podpac.core.units import ureg as units, UnitsDataArray
 
 # Organized submodules
 # These files are simply wrappers to create a curated namespace of podpac modules

--- a/podpac/core/managers/aws.py
+++ b/podpac/core/managers/aws.py
@@ -1604,7 +1604,7 @@ def create_function(
     elif function_source_dist_zip is not None:
         with open(function_source_dist_zip, "rb") as f:
             lambda_config["Code"] = {}  # reset the code dict to make sure S3Bucket and S3Key are overridden
-            lambda_config["Code"]["ZipFile"]: f.read()
+            lambda_config["Code"]["ZipFile"] = f.read()
 
     else:
         raise ValueError("Function source is not defined")

--- a/podpac/core/node.py
+++ b/podpac/core/node.py
@@ -18,7 +18,7 @@ import numpy as np
 import traitlets as tl
 
 from podpac.core.settings import settings
-from podpac.core.units import ureg, UnitsDataArray, create_dataarray
+from podpac.core.units import ureg, UnitsDataArray
 from podpac.core.utils import common_doc
 from podpac.core.utils import JSONEncoder, is_json_serializable
 from podpac.core.utils import _get_query_params_from_url, _get_from_url, _get_param
@@ -252,7 +252,7 @@ class Node(tl.HasTraits):
         if self.units is not None:
             attrs["units"] = ureg.Unit(self.units)
 
-        return create_dataarray(coords, data=data, dtype=self.dtype, attrs=attrs, **kwargs)
+        return UnitsDataArray.create(coords, data=data, dtype=self.dtype, attrs=attrs, **kwargs)
 
     # -----------------------------------------------------------------------------------------------------------------
     # Serialization

--- a/podpac/core/node.py
+++ b/podpac/core/node.py
@@ -18,7 +18,7 @@ import numpy as np
 import traitlets as tl
 
 from podpac.core.settings import settings
-from podpac.core.units import ureg, UnitsDataArray, create_data_array
+from podpac.core.units import ureg, UnitsDataArray, create_dataarray
 from podpac.core.utils import common_doc
 from podpac.core.utils import JSONEncoder, is_json_serializable
 from podpac.core.utils import _get_query_params_from_url, _get_from_url, _get_param
@@ -252,7 +252,7 @@ class Node(tl.HasTraits):
         if self.units is not None:
             attrs["units"] = ureg.Unit(self.units)
 
-        return create_data_array(coords, data=data, dtype=self.dtype, attrs=attrs, **kwargs)
+        return create_dataarray(coords, data=data, dtype=self.dtype, attrs=attrs, **kwargs)
 
     # -----------------------------------------------------------------------------------------------------------------
     # Serialization

--- a/podpac/core/test/test_units.py
+++ b/podpac/core/test/test_units.py
@@ -12,9 +12,8 @@ from podpac.core.style import Style
 
 from podpac.core.units import ureg
 from podpac.core.units import UnitsDataArray
-from podpac.core.units import create_dataarray
-from podpac.core.units import open_dataarray
 from podpac.core.units import get_image
+from podpac.core.units import create_dataarray  # DEPRECATED
 
 from podpac.data import Array
 
@@ -334,56 +333,56 @@ class TestCreateDataArray(object):
         cls.coords = Coordinates([[0, 1, 2], [0, 1, 2, 3]], dims=["lat", "lon"])
 
     def test_default(self):
-        a = create_dataarray(self.coords)
+        a = UnitsDataArray.create(self.coords)
         assert isinstance(a, UnitsDataArray)
         assert a.shape == self.coords.shape
         assert np.all(np.isnan(a))
 
     def test_empty(self):
-        a = create_dataarray(self.coords, data=None)
+        a = UnitsDataArray.create(self.coords, data=None)
         assert isinstance(a, UnitsDataArray)
         assert a.shape == self.coords.shape
         assert a.dtype == float
 
-        a = create_dataarray(self.coords, data=None, dtype=bool)
+        a = UnitsDataArray.create(self.coords, data=None, dtype=bool)
         assert isinstance(a, UnitsDataArray)
         assert a.shape == self.coords.shape
         assert a.dtype == bool
 
     def test_zeros(self):
-        a = create_dataarray(self.coords, data=0)
+        a = UnitsDataArray.create(self.coords, data=0)
         assert isinstance(a, UnitsDataArray)
         assert a.shape == self.coords.shape
         assert a.dtype == float
         assert np.all(a == 0.0)
 
-        a = create_dataarray(self.coords, data=0, dtype=bool)
+        a = UnitsDataArray.create(self.coords, data=0, dtype=bool)
         assert isinstance(a, UnitsDataArray)
         assert a.shape == self.coords.shape
         assert a.dtype == bool
         assert np.all(~a)
 
     def test_ones(self):
-        a = create_dataarray(self.coords, data=1)
+        a = UnitsDataArray.create(self.coords, data=1)
         assert isinstance(a, UnitsDataArray)
         assert a.shape == self.coords.shape
         assert a.dtype == float
         assert np.all(a == 1.0)
 
-        a = create_dataarray(self.coords, data=1, dtype=bool)
+        a = UnitsDataArray.create(self.coords, data=1, dtype=bool)
         assert isinstance(a, UnitsDataArray)
         assert a.shape == self.coords.shape
         assert a.dtype == bool
         assert np.all(a)
 
     def test_full(self):
-        a = create_dataarray(self.coords, data=10)
+        a = UnitsDataArray.create(self.coords, data=10)
         assert isinstance(a, UnitsDataArray)
         assert a.shape == self.coords.shape
         assert a.dtype == float
         assert np.all(a == 10)
 
-        a = create_dataarray(self.coords, data=10, dtype=int)
+        a = UnitsDataArray.create(self.coords, data=10, dtype=int)
         assert isinstance(a, UnitsDataArray)
         assert a.shape == self.coords.shape
         assert a.dtype == int
@@ -391,37 +390,41 @@ class TestCreateDataArray(object):
 
     def test_array(self):
         data = np.random.random(self.coords.shape)
-        a = create_dataarray(self.coords, data=data)
+        a = UnitsDataArray.create(self.coords, data=data)
         assert isinstance(a, UnitsDataArray)
         assert a.dtype == float
         np.testing.assert_equal(a.data, data)
 
         data = np.round(10 * np.random.random(self.coords.shape))
-        a = create_dataarray(self.coords, data=data, dtype=int)
+        a = UnitsDataArray.create(self.coords, data=data, dtype=int)
         assert isinstance(a, UnitsDataArray)
         assert a.dtype == int
         np.testing.assert_equal(a.data, data.astype(int))
 
     def test_invalid_coords(self):
         with pytest.raises(TypeError):
-            create_dataarray((3, 4))
+            UnitsDataArray.create((3, 4))
+
+    def test_deprecate_create_dataarray(self):
+        with pytest.deprecated_call():
+            create_dataarray(self.coords, data=10)
 
 
 class TestOpenDataArray(object):
     def test_open_after_create(self):
         coords = Coordinates([[0, 1, 2], [0, 1, 2, 3]], dims=["lat", "lon"])
-        uda_1 = create_dataarray(coords, data=np.random.rand(3, 4))
+        uda_1 = UnitsDataArray.create(coords, data=np.random.rand(3, 4))
         ncdf = uda_1.to_netcdf()
-        uda_2 = open_dataarray(ncdf)
+        uda_2 = UnitsDataArray.open(ncdf)
 
         assert isinstance(uda_2, UnitsDataArray)
         assert np.all(uda_2.data == uda_1.data)
 
     def test_open_after_create_with_attrs(self):
         coords = Coordinates([[0, 1, 2], [0, 1, 2, 3]], dims=["lat", "lon"], crs="EPSG:4193")
-        uda_1 = create_dataarray(coords, data=np.random.rand(3, 4), attrs={"some_attr": 5})
+        uda_1 = UnitsDataArray.create(coords, data=np.random.rand(3, 4), attrs={"some_attr": 5})
         ncdf = uda_1.to_netcdf()
-        uda_2 = open_dataarray(ncdf)
+        uda_2 = UnitsDataArray.open(ncdf)
 
         assert isinstance(uda_2, UnitsDataArray)
         assert np.all(uda_2.data == uda_1.data)
@@ -443,7 +446,7 @@ class TestOpenDataArray(object):
         uda = node.eval(node.native_coordinates)
 
         ncdf = uda.to_netcdf()
-        uda_2 = open_dataarray(ncdf)
+        uda_2 = UnitsDataArray.open(ncdf)
 
         assert isinstance(uda_2, UnitsDataArray)
         assert np.all(uda_2.data == uda.data)

--- a/podpac/datalib/egi.py
+++ b/podpac/datalib/egi.py
@@ -29,7 +29,7 @@ from podpac.compositor import OrderedCompositor
 from podpac.data import DataSource
 from podpac import authentication
 from podpac import settings
-from podpac.core.units import UnitsDataArray, create_dataarray
+from podpac.core.units import UnitsDataArray
 from podpac.core.node import node_eval
 
 # Set up logging

--- a/podpac/datalib/egi.py
+++ b/podpac/datalib/egi.py
@@ -29,7 +29,7 @@ from podpac.compositor import OrderedCompositor
 from podpac.data import DataSource
 from podpac import authentication
 from podpac import settings
-from podpac.core.units import UnitsDataArray, create_data_array
+from podpac.core.units import UnitsDataArray, create_dataarray
 from podpac.core.node import node_eval
 
 # Set up logging
@@ -225,7 +225,7 @@ class EGI(DataSource):
             )
             raise e
         # Force update on native_coordinates (in case of multiple evals)
-        self.set_trait('native_coordinates', self.get_native_coordinates())
+        self.set_trait("native_coordinates", self.get_native_coordinates())
 
         # run normal eval once self.data is prepared
         return super(EGI, self).eval(coordinates, output)

--- a/podpac/datalib/smap_egi.py
+++ b/podpac/datalib/smap_egi.py
@@ -37,7 +37,7 @@ import podpac
 import podpac.datalib
 from podpac.core.coordinates import Coordinates
 from podpac.datalib import EGI
-from podpac.core.units import create_dataarray
+from podpac.core.units import UnitsDataArray
 
 SMAP_PRODUCT_DICT = {
     #'shortname':    ['lat_key', 'lon_key', 'data_key', 'quality_flag', 'default_verison']
@@ -218,7 +218,7 @@ class SMAP(EGI):
             c = Coordinates([time, lon, lat], dims=["time", "lon", "lat"], crs="epsg:6933")
 
         # make units data array with coordinates and data
-        return create_dataarray(c, data=data)
+        return UnitsDataArray.create(c, data=data)
 
     def append_file(self, all_data, data):
         """Append data

--- a/podpac/datalib/smap_egi.py
+++ b/podpac/datalib/smap_egi.py
@@ -37,7 +37,7 @@ import podpac
 import podpac.datalib
 from podpac.core.coordinates import Coordinates
 from podpac.datalib import EGI
-from podpac.core.units import create_data_array
+from podpac.core.units import create_dataarray
 
 SMAP_PRODUCT_DICT = {
     #'shortname':    ['lat_key', 'lon_key', 'data_key', 'quality_flag', 'default_verison']
@@ -143,7 +143,6 @@ class SMAP(EGI):
         else:
             return (self.data_key, self.lat_key, self.lon_key)
 
-
     @tl.default("version")
     def _version_default(self):
         return SMAP_PRODUCT_DICT[self.product][4]
@@ -219,7 +218,7 @@ class SMAP(EGI):
             c = Coordinates([time, lon, lat], dims=["time", "lon", "lat"], crs="epsg:6933")
 
         # make units data array with coordinates and data
-        return create_data_array(c, data=data)
+        return create_dataarray(c, data=data)
 
     def append_file(self, all_data, data):
         """Append data


### PR DESCRIPTION
- Adds `UnitsDataArray.open` class method
- Changes `create_data_array` to `create_dataarray` to be consistent with xarray naming convention in methods.
- Deprecated `create_dataarray` in favor of `UnitsDataArray.create`

This feature adds the ability to symmetrically go between UnitsDataArray -> netcdf -> UnitsDataArray.  The goal is move away from pickle in the lambda function interface and more generally, provide users a way to export/import binary outputs from/to PODPAC.

~~Both `creare_dataarray` and `open_dataarray` could probably be classmethods, like we have done in the Coordinates module. It may also be useful to `export` and `import` methods on `UnitsDataArray` that uses the `to_netcdf` and `open_datarray` in the background.~~
Done in e9abbc485ba15ffd36d578fa590f5a63d9c7e808


## Example

```python
# Eval with simple example
from podpac.data import Array
from podpac import Coordinates, UnitsDataArray
import numpy as np

# mock data
data = np.random.rand(5, 5)

# create native coordinates for data
lat = np.linspace(-10, 10, 5)
lon = np.linspace(-10, 10, 5)
native_coords = Coordinates([lat, lon], ['lat', 'lon'])

# create Array DataSource node
node= Array(source=data, native_coordinates=native_coords)

# evaluate
output = node.eval(node_array.native_coordinates)

# export
output_netcdf = output.to_netcdf()

# import
output2 = UnitsDataArray.open(output_netcdf)

# goal:
# output2 == output

```