### PR TITLE
FIX: add `to_image` method to UnitsDataArray and rename `get_image` to `to_image` in units module

### DIFF
--- a/podpac/core/pipeline/output.py
+++ b/podpac/core/pipeline/output.py
@@ -19,7 +19,6 @@ import numpy as np
 import traitlets as tl
 
 from podpac.core.node import Node
-from podpac.core.units import get_image
 
 
 class Output(tl.HasTraits):
@@ -210,4 +209,4 @@ class ImageOutput(Output):
 
     # TODO: docstring?
     def write(self, output, coordinates):
-        self.image = get_image(output, format=self.format, vmin=self.vmin, vmax=self.vmax, return_base64=True)
+        self.image = output.to_image(format=self.format, vmin=self.vmin, vmax=self.vmax, return_base64=True)

--- a/podpac/core/test/test_units.py
+++ b/podpac/core/test/test_units.py
@@ -1,18 +1,18 @@
 from __future__ import division, unicode_literals, print_function, absolute_import
 
+import io
+
 import pytest
 import numpy as np
 import xarray as xr
 from pint.errors import DimensionalityError
-import traitlets as tl
 
 from podpac.core.coordinates import Coordinates
-from podpac.core.node import Node
 from podpac.core.style import Style
 
 from podpac.core.units import ureg
 from podpac.core.units import UnitsDataArray
-from podpac.core.units import get_image
+from podpac.core.units import to_image
 from podpac.core.units import create_dataarray  # DEPRECATED
 
 from podpac.data import Array
@@ -310,6 +310,16 @@ class TestUnitDataArray(object):
         with pytest.raises(DimensionalityError):
             a10 = a1 % a2
 
+    def test_to_image(self):
+        uda = UnitsDataArray(np.ones((10, 10)))
+        assert isinstance(uda.to_image(return_base64=True), bytes)
+        assert isinstance(uda.to_image(), io.BytesIO)
+
+    def test_to_image_vmin_vmax(self):
+        uda = UnitsDataArray(np.ones((10, 10)))
+        assert isinstance(uda.to_image(vmin=0, vmax=2, return_base64=True), bytes)
+        assert isinstance(uda.to_image(vmin=0, vmax=2), io.BytesIO)
+
     @pytest.mark.skip(reason="Error in xarray layer")
     def test_ufuncs(self):
         a1 = UnitsDataArray(np.ones((4, 3)), dims=["lat", "lon"], attrs={"units": ureg.meter})
@@ -458,14 +468,14 @@ class TestOpenDataArray(object):
         assert uda_2.attrs.get("crs") == uda.attrs.get("crs")
 
 
-class TestGetImage(object):
-    def test_get_image(self):
+class TestToImage(object):
+    def test_to_image(self):
         data = np.ones((10, 10))
-        assert isinstance(get_image(UnitsDataArray(data), return_base64=True), bytes)  # UnitsDataArray input
-        assert isinstance(get_image(xr.DataArray(data), return_base64=True), bytes)  # xr.DataArray input
-        assert isinstance(get_image(data, return_base64=True), bytes)  # np.ndarray input
-        assert isinstance(get_image(np.array([data]), return_base64=True), bytes)  # squeeze
+        assert isinstance(to_image(UnitsDataArray(data), return_base64=True), bytes)  # UnitsDataArray input
+        assert isinstance(to_image(xr.DataArray(data), return_base64=True), bytes)  # xr.DataArray input
+        assert isinstance(to_image(data, return_base64=True), bytes)  # np.ndarray input
+        assert isinstance(to_image(np.array([data]), return_base64=True), bytes)  # squeeze
 
-    def test_get_image_vmin_vmax(self):
+    def test_to_image_vmin_vmax(self):
         data = np.ones((10, 10))
-        assert isinstance(get_image(data, vmin=0, vmax=2, return_base64=True), bytes)
+        assert isinstance(to_image(data, vmin=0, vmax=2, return_base64=True), bytes)

--- a/podpac/core/units.py
+++ b/podpac/core/units.py
@@ -168,7 +168,7 @@ class UnitsDataArray(xr.DataArray):
             if format == "json":
                 r = json.dumps(r, cls=JSONEncoder)
         elif format in ["png", "jpg", "jpeg"]:
-            r = get_image(self, format, *args, **kwargs)
+            r = self.to_image(format, *args, **kwargs)
         elif format.upper() in ["TIFF", "TIF", "GEOTIFF"]:
             raise NotImplementedError("Format {} is not implemented.".format(format))
         elif format in ["pickle", "pkl"]:
@@ -180,6 +180,28 @@ class UnitsDataArray(xr.DataArray):
                 raise NotImplementedError("Format {} is not implemented.".format(format))
         self.deserialize()
         return r
+
+    def to_image(self, format="png", vmin=None, vmax=None, return_base64=False):
+        """Return a base64-encoded image of the data.
+
+        Parameters
+        ----------
+        format : str, optional
+            Default is 'png'. Type of image. 
+        vmin : number, optional
+            Minimum value of colormap
+        vmax : vmax, optional
+            Maximum value of colormap
+        return_base64: bool, optional
+            Default is False. Normally this returns an io.BytesIO, but if True, will return a base64 encoded string.
+            
+
+        Returns
+        -------
+        BytesIO/str
+            Binary or Base64 encoded image. 
+        """
+        return to_image(self, format, vmin, vmax, return_base64)
 
     def serialize(self):
         if self.attrs.get("units"):
@@ -423,8 +445,8 @@ def create_dataarray(coords, data=np.nan, dtype=float, **kwargs):
     return UnitsDataArray.create(coords, data, dtype, **kwargs)
 
 
-def get_image(data, format="png", vmin=None, vmax=None, return_base64=False):
-    """Return a base64-encoded image of the data
+def to_image(data, format="png", vmin=None, vmax=None, return_base64=False):
+    """Return a base64-encoded image of data
 
     Parameters
     ----------


### PR DESCRIPTION
This is a small change, but I think important.

I think its a little opaque to have a single `UnitsDataArray.to_format()` function with different formats and different corresponding args and kwargs. I think its better to write individual methods (i.e. `to_image()`) and then let the `to_format()` function just pick the best one based on the format. This is already mostly the case, but as a user I will look for the `to_image()` method if I'm trying to output the geotiff, not the `to()` method.

Also, `get_image` is not in keeping with the pandas/xarray standard of `to_format..()` for outputs. This again is not that important, but I want to try and keep this as consistent as possible.