### PR TITLE
FIX: Fixing time selection when precision is different

### DIFF
--- a/podpac/core/coordinates/coordinates1d.py
+++ b/podpac/core/coordinates/coordinates1d.py
@@ -350,19 +350,31 @@ class Coordinates1d(BaseCoordinates):
             index or slice for the selected coordinates (only if return_indices=True)
         """
 
+        # empty case
+        if self.dtype is None:
+            return self._select_empty(return_indices)
+
         if isinstance(bounds, dict):
             bounds = bounds.get(self.name)
             if bounds is None:
                 return self._select_full(return_indices)
 
         bounds = make_coord_value(bounds[0]), make_coord_value(bounds[1])
+
+        # check type
+        if not isinstance(bounds[0], self.dtype):
+            raise TypeError(
+                "Input bounds do match the coordinates dtype (%s != %s)" % (type(self.bounds[0]), self.dtype)
+            )
+        if not isinstance(bounds[1], self.dtype):
+            raise TypeError(
+                "Input bounds do match the coordinates dtype (%s != %s)" % (type(self.bounds[1]), self.dtype)
+            )
+
         my_bounds = self.area_bounds.copy()
 
         # If the bounds are of instance datetime64, then the comparison should happen at the lowest precision
         if self.dtype == np.datetime64:
-            if not isinstance(bounds[0], np.datetime64):
-                raise TypeError("Input bounds should be of type np.datetime64 when selecting data from:", str(self))
-
             my_bounds, bounds = lower_precision_time_bounds(my_bounds, bounds, outer)
 
         # full

--- a/podpac/core/coordinates/test/test_array_coordinates1d.py
+++ b/podpac/core/coordinates/test/test_array_coordinates1d.py
@@ -1039,6 +1039,14 @@ class TestArrayCoordinatesSelection(object):
         s = c.select({"time": [np.datetime64("2018-01-03"), "2018-02-06"]})
         assert_equal(s.coordinates, np.array(["2018-01-03", "2018-01-04"]).astype(np.datetime64))
 
+    def test_select_time_variable_precision(self):
+        c = ArrayCoordinates1d(["2012-05-19"], name="time")
+        c2 = ArrayCoordinates1d(["2012-05-19T12:00:00"], name="time")
+        s = c.select(c2.bounds)
+        s2 = c2.select(c.bounds)
+        assert s.size == 1
+        assert s2.size == 1
+
     def test_select_dtype(self):
         c = ArrayCoordinates1d([20.0, 40.0, 60.0, 10.0, 90.0, 50.0], name="lat")
         with pytest.raises(TypeError):

--- a/podpac/core/coordinates/test/test_array_coordinates1d.py
+++ b/podpac/core/coordinates/test/test_array_coordinates1d.py
@@ -1042,9 +1042,11 @@ class TestArrayCoordinatesSelection(object):
     def test_select_time_variable_precision(self):
         c = ArrayCoordinates1d(["2012-05-19"], name="time")
         c2 = ArrayCoordinates1d(["2012-05-19T12:00:00"], name="time")
-        s = c.select(c2.bounds)
+        s = c.select(c2.bounds, outer=True)
+        s1 = c.select(c2.bounds, outer=False)
         s2 = c2.select(c.bounds)
         assert s.size == 1
+        assert s1.size == 0
         assert s2.size == 1
 
     def test_select_dtype(self):

--- a/podpac/core/coordinates/test/test_uniform_coordinates1d.py
+++ b/podpac/core/coordinates/test/test_uniform_coordinates1d.py
@@ -1180,3 +1180,11 @@ class TestUniformCoordinatesSelection(object):
         assert isinstance(s, ArrayCoordinates1d)
         assert_equal(s.coordinates, [])
         assert_equal(c.coordinates[I], [])
+
+    def test_select_time_variable_precision(self):
+        c = UniformCoordinates1d("2012-05-19", "2012-05-20", "1,D", name="time")
+        c2 = UniformCoordinates1d("2012-05-20T12:00:00", "2012-05-21T12:00:00", "1,D", name="time")
+        s = c.select(c2.bounds)
+        s2 = c2.select(c.bounds)
+        assert s.size == 1
+        assert s2.size == 1

--- a/podpac/core/coordinates/test/test_uniform_coordinates1d.py
+++ b/podpac/core/coordinates/test/test_uniform_coordinates1d.py
@@ -1184,7 +1184,9 @@ class TestUniformCoordinatesSelection(object):
     def test_select_time_variable_precision(self):
         c = UniformCoordinates1d("2012-05-19", "2012-05-20", "1,D", name="time")
         c2 = UniformCoordinates1d("2012-05-20T12:00:00", "2012-05-21T12:00:00", "1,D", name="time")
-        s = c.select(c2.bounds)
+        s = c.select(c2.bounds, outer=True)
+        s1 = c.select(c2.bounds, outer=False)
         s2 = c2.select(c.bounds)
         assert s.size == 1
+        assert s1.size == 0
         assert s2.size == 1

--- a/podpac/core/coordinates/uniform_coordinates1d.py
+++ b/podpac/core/coordinates/uniform_coordinates1d.py
@@ -389,9 +389,6 @@ class UniformCoordinates1d(Coordinates1d):
 
         # If the bounds are of instance datetime64, then the comparison should happen at the lowest precision
         if self.dtype == np.datetime64:
-            if not isinstance(bounds[0], np.datetime64):
-                raise TypeError("Input bounds should be of type np.datetime64 when selecting data from:", str(self))
-
             my_bounds, bounds = lower_precision_time_bounds(my_bounds, bounds, outer)
 
         lo = max(bounds[0], my_bounds[0])


### PR DESCRIPTION
Consider: 
```
c1 = Coordinates(['2012-05-19'], ['time'])
c2 = Coordinates(['2012-05-19T12:00:00'], ['time'])
c12 = c1.intersect(c2)
c21 = c2.intersect(c1)
```

With this PR, I propose that c12 and c21 should contain an intersection. 