### PR TITLE
Feature/billing

### DIFF
--- a/podpac/core/managers/aws.py
+++ b/podpac/core/managers/aws.py
@@ -2627,7 +2627,7 @@ def create_budget(
 
     # alert the user that they must activate tags
     print(
-        "To finalize budget creation, you must visit https://console.aws.amazon.com/billing/home#/preferences/tags and 'Activate' the following User Defined Cost Allocation tags: {}.\nBudget tracking will not work if these User Defined Cost Allocation tags are not active.".format(
+        "To finalize budget creation, you must visit https://console.aws.amazon.com/billing/home#/preferences/tags and 'Activate' the following User Defined Cost Allocation tags: {}.\nBudget tracking will not work if these User Defined Cost Allocation tags are not active.\nBudget creation and usage updates may take 24 hours to take effect.".format(
             list(budget_filter_tags.keys())
         )
     )

--- a/podpac/core/managers/aws.py
+++ b/podpac/core/managers/aws.py
@@ -2639,8 +2639,8 @@ def delete_budget(session, budget_name):
     budgets = session.client("budgets")
 
     try:
-        response = client.delete_budget(AccountId=session.get_account_id(), BudgetName=budget_name)
-    except apigateway.exceptions.NotFoundException as e:
+        budgets.delete_budget(AccountId=session.get_account_id(), BudgetName=budget_name)
+    except budgets.exceptions.NotFoundException as e:
         pass
 
     _log.debug("Successfully removed budget with name '{}'".format(budget_name))

--- a/podpac/core/managers/aws.py
+++ b/podpac/core/managers/aws.py
@@ -646,6 +646,10 @@ Lambda Node {status}
             _log.info("Lambda function will only run for pipelines: {}".format(self.function_restrict_pipelines))
             self.function_env_variables["PODPAC_RESTRICT_PIPELINES"] = json.dumps(self.function_restrict_pipelines)
 
+        # add special tag - value is hash, for lack of better value at this point
+        self.function_tags["_podpac_resource"] = "valid"
+        self.function_tags["_podpac_resource_hash"] = self.hash
+
         # if function already exists, this will return existing function
         function = create_function(
             self.session,
@@ -765,6 +769,11 @@ Lambda Node {status}
     def create_role(self):
         """Create IAM role to execute podpac lambda function
         """
+
+        # add special tag - value is hash
+        self.function_role_tags["_podpac_resource"] = "valid"
+        self.function_role_tags["_podpac_resource_hash"] = self.hash
+
         role = create_role(
             self.session,
             self.function_role_name,
@@ -851,6 +860,10 @@ Lambda Node {status}
 
         if self._function_role_arn is None:
             raise ValueError("Function role must be created before creating a bucket")
+
+        # add special tags - value is hash
+        self.function_s3_tags["_podpac_resource"] = "valid"
+        self.function_s3_tags["_podpac_resource_hash"] = self.hash
 
         # create bucket
         bucket = create_bucket(
@@ -983,6 +996,10 @@ Lambda Node {status}
         if self._function_arn is None:
             raise ValueError("Lambda function must be created before creating an API bucket")
 
+        # add special tag - value is hash
+        self.function_api_tags["_podpac_resource"] = "valid"
+        self.function_api_tags["_podpac_resource_hash"] = self.hash
+
         # create api and resource
         api = create_api(
             self.session,
@@ -1107,6 +1124,15 @@ Lambda Node {status}
 
         log_group_name = "/aws/lambda/{}".format(self.function_name)
         return get_logs(self.session, log_group_name, limit=limit, start=start, end=end)
+
+    # Budget
+    def create_budget(self):
+        # self.session.get_account_id()
+        pass
+
+    def get_budget(self):
+        # self.session.get_account_id()
+        pass
 
     # -----------------------------------------------------------------------------------------------------------------
     # Internals

--- a/podpac/core/settings.py
+++ b/podpac/core/settings.py
@@ -47,6 +47,8 @@ DEFAULT_SETTINGS = {
     "AWS_SECRET_ACCESS_KEY": None,
     "AWS_REGION_NAME": None,
     "AWS_TAGS": None,
+    "AWS_BUDGET_AMOUNT": None,
+    "AWS_BUDGET_EMAIL": None,
     "S3_BUCKET_NAME": None,
     "FUNCTION_NAME": None,
     "FUNCTION_ROLE_NAME": None,
@@ -98,6 +100,10 @@ class PodpacSettings(dict):
         for more details.
     AWS_REGION_NAME : str
         Name of the AWS region, e.g. us-west-1, us-west-2, etc.
+    AWS_BUDGET_AMOUNT : float
+        Budget amount for AWS resources
+    AWS_BUDGET_EMAIL : str
+        Notification email for when AWS usage reaches 80% of the `AWS_BUDGET_AMOUNT`
     DEFAULT_CACHE : list
         Defines a default list of cache stores in priority order. Defaults to `['ram']`.
     CACHE_OUTPUT_DEFAULT : bool


### PR DESCRIPTION
Enable budgeting for podpac resources through the `aws` module.

Budgets can be made for function + associated resources or for all podpac created resources listed under an AWS account. Budget tracking/filtering is done through special tags created at resource generation: 

{`_podpac_resource`: `true`}
{`_podpac_resource_hash`: `hash`}

I anticipate corner cases for resources that were not created at the same time. This will need to get thoroughly tested before we make any promises about budgeting capabilities. For now this more of potential notification than a guaranteed notification.

To use the feature, create the settings:

```
settings["AWS_BUDGET_AMOUNT"] = 10.0 # budget for all podpac AWS resources, in USD
settings["AWS_BUDGET_EMAIL"] = "user@email.com" # notification e-mail for budget alarms
```

Also documented here: https://github.com/creare-com/podpac-examples/blob/develop/notebooks/developer/aws-lambda-tutorial.ipynb

Then use the `aws.Lambda` node as before.

See https://github.com/creare-com/podpac-examples/blob/develop/notebooks/developer/test/test-lambda.ipynb for an example of how to budget for all podpac resources created through the `aws` module.