### PR TITLE
Feature/smap auth tag

### DIFF
--- a/podpac/core/authentication.py
+++ b/podpac/core/authentication.py
@@ -159,13 +159,9 @@ class EarthDataSession(Session):
         print("Updating login information for: ", self.hostname)
 
         if username is None:
-            username = input("Username: ")
-
-        settings["username@" + self.hostname] = username
+            self.username = input("Username: ")
 
         if password is None:
-            password = getpass.getpass()
+            self.password = getpass.getpass()
 
-        settings["password@" + self.hostname] = password
-
-        self.auth = (username, password)
+        self.auth = (self.username, self.password)

--- a/podpac/datalib/smap.py
+++ b/podpac/datalib/smap.py
@@ -872,8 +872,8 @@ class SMAP(podpac.compositor.OrderedCompositor):
 
     auth_session = tl.Instance(authentication.EarthDataSession)
     auth_class = tl.Type(authentication.EarthDataSession)
-    username = tl.Unicode(None, allow_none=True)
-    password = tl.Unicode(None, allow_none=True)
+    username = tl.Unicode(None, allow_none=True).tag(attr=True)
+    password = tl.Unicode(None, allow_none=True).tag(attr=True)
 
     @tl.default("auth_session")
     def _auth_session_default(self):


### PR DESCRIPTION
Passing EarthData credentials into the Lambda functions changed in v1.3.

This PR is more of a discussion - do we want to tag EarthData credentials as attrs?
