### PR TITLE
cleanup select sources

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -177,7 +177,6 @@ Stitch multiple data sources together
     :toctree: api/
     :template: class.rst
 
-    podpac.compositor.Compositor
     podpac.compositor.OrderedCompositor
 
 

--- a/podpac/compositor.py
+++ b/podpac/compositor.py
@@ -4,4 +4,4 @@ Compositor Public Module
 
 # REMINDER: update api docs (doc/source/user/api.rst) to reflect changes to this file
 
-from podpac.core.compositor import Compositor, OrderedCompositor
+from podpac.core.compositor import OrderedCompositor

--- a/podpac/core/algorithm/test/test_coord_select.py
+++ b/podpac/core/algorithm/test/test_coord_select.py
@@ -112,7 +112,7 @@ class TestYearSubstituteCoordinates(object):
 
     def test_year_substitution_missing_coords(self):
         source = Array(
-            data=[[1, 2, 3], [4, 5, 6]],
+            source=[[1, 2, 3], [4, 5, 6]],
             native_coordinates=podpac.Coordinates(
                 [podpac.crange("2018-01-01", "2018-01-02", "1,D"), podpac.clinspace(45, 66, 3)], dims=["time", "lat"]
             ),
@@ -124,7 +124,7 @@ class TestYearSubstituteCoordinates(object):
 
     def test_year_substitution_missing_coords_orig_coords(self):
         source = Array(
-            data=[[1, 2, 3], [4, 5, 6]],
+            source=[[1, 2, 3], [4, 5, 6]],
             native_coordinates=podpac.Coordinates(
                 [podpac.crange("2018-01-01", "2018-01-02", "1,D"), podpac.clinspace(45, 66, 3)], dims=["time", "lat"]
             ),

--- a/podpac/core/compositor.py
+++ b/podpac/core/compositor.py
@@ -12,7 +12,7 @@ import traitlets as tl
 
 # Internal imports
 from podpac.core.settings import settings
-from podpac.core.coordinates import Coordinates, merge_dims
+from podpac.core.coordinates import Coordinates, merge_dims, union
 from podpac.core.utils import common_doc, NodeTrait, trait_is_defined
 from podpac.core.units import UnitsDataArray
 from podpac.core.node import COMMON_NODE_DOC, node_eval, Node
@@ -24,29 +24,21 @@ COMMON_COMPOSITOR_DOC = COMMON_DATA_DOC.copy()  # superset of COMMON_NODE_DOC
 
 
 @common_doc(COMMON_COMPOSITOR_DOC)
-class Compositor(Node):
-    """Compositor
+class BaseCompositor(Node):
+    """A base class for compositor nodes.
     
     Attributes
     ----------
-    sources : :class:`np.ndarray`
-        An array of sources. This is a numpy array as opposed to a list so that boolean indexing may be used to
-        subselect the nodes that will be evaluated.
-    shared_coordinates : :class:`podpac.Coordinates`.
-        Coordinates that are shared amongst all of the composited sources. Optional.
+    sources : list
+        Source nodes.
     source_coordinates : :class:`podpac.Coordinates`
         Coordinates that make each source unique. Must the same size as ``sources`` and single-dimensional. Optional.
     interpolation : str, dict, optional
         {interpolation}
-    is_source_coordinates_complete : Bool
-        Default is False. The source_coordinates do not have to completely describe the source. For example, the source
-        coordinates could include the year-month-day of the source, but the actual source also has hour-minute-second
-        information. In that case, source_coordinates is incomplete. This flag is used to automatically construct
-        native_coordinates.
     
     Notes
     -----
-    Developers of new Compositor nodes need to implement the `composite` method.
+    Developers of compositor subclasses nodes need to implement the `composite` method.
 
     Multitheading::
       * When MULTITHREADING is False, the compositor stops evaluated sources once the output is completely filled.
@@ -59,17 +51,7 @@ class Compositor(Node):
 
     sources = tl.List(trait=NodeTrait()).tag(attr=True)
     interpolation = InterpolationTrait(allow_none=True, default_value=None).tag(attr=True)
-    shared_coordinates = tl.Instance(Coordinates, allow_none=True, default_value=None).tag(attr=True)
     source_coordinates = tl.Instance(Coordinates, allow_none=True, default_value=None).tag(attr=True)
-
-    is_source_coordinates_complete = tl.Bool(
-        False,
-        help=(
-            "This allows some optimizations but assumes that the sources have "
-            "native_coordinates=source_coordinate + shared_coordinate "
-            "IN THAT ORDER"
-        ),
-    )
 
     @tl.validate("sources")
     def _validate_sources(self, d):
@@ -87,15 +69,17 @@ class Compositor(Node):
 
     @tl.validate("source_coordinates")
     def _validate_source_coordinates(self, d):
-        if d["value"] is not None:
-            if d["value"].ndim != 1:
-                raise ValueError("Invalid source_coordinates, invalid ndim (%d != 1)" % d["value"].ndim)
+        if d["value"] is None:
+            return None
 
-            if d["value"].size != len(self.sources):
-                raise ValueError(
-                    "Invalid source_coordinates, source and source_coordinates size mismatch (%d != %d)"
-                    % (d["value"].size, len(self.sources))
-                )
+        if d["value"].ndim != 1:
+            raise ValueError("Invalid source_coordinates, invalid ndim (%d != 1)" % d["value"].ndim)
+
+        if d["value"].size != len(self.sources):
+            raise ValueError(
+                "Invalid source_coordinates, source and source_coordinates size mismatch (%d != %d)"
+                % (d["value"].size, len(self.sources))
+            )
 
         return d["value"]
 
@@ -123,10 +107,7 @@ class Compositor(Node):
         return outputs
 
     def select_sources(self, coordinates):
-        """Downselect compositor sources based on requested coordinates.
-        
-        This is used during the :meth:`eval` process as an optimization
-        when :attr:`source_coordinates` are not pre-defined.
+        """Select and prepare sources based on requested coordinates.
         
         Parameters
         ----------
@@ -135,41 +116,52 @@ class Compositor(Node):
         
         Returns
         -------
-        :class:`np.ndarray`
-            Array of downselected sources
+        sources : :class:`np.ndarray`
+            Array of sources
+
+        Notes
+        -----
+         * If :attr:`source_coordinates` is defined, only sources that intersect the requested coordinates are selected.
+         * Sets sources :attr:`interpolation`.
         """
 
-        # if source coordinates are defined, use intersect
-        if self.source_coordinates is not None:
-            # intersecting sources only
+        # select intersecting sources, if possible
+        if self.source_coordinates is None:
+            sources = np.array(self.sources)
+        else:
             try:
                 _, I = self.source_coordinates.intersect(coordinates, outer=True, return_indices=True)
-
-            except:  # Likely non-monotonic coordinates
+            except:
+                # Likely non-monotonic coordinates
                 _, I = self.source_coordinates.intersect(coordinates, outer=False, return_indices=True)
             i = I[0]
-            src_subset = np.array(self.sources)[i]
+            sources = np.array(self.sources)[i]
 
-        # no downselection possible - get all sources compositor
-        else:
-            src_subset = np.array(self.sources)
+        # set the interpolation properties for sources
+        if self.interpolation is not None:
+            for s in sources:
+                if s.trait_is_defined("interpolation"):
+                    s.set_trait("interpolation", self.interpolation)
 
-        return src_subset
+        return sources
 
-    def composite(self, coordinates, outputs, result=None):
-        """Implements the rules for compositing multiple sources together.
+    def composite(self, coordinates, data_arrays, result=None):
+        """Implements the rules for compositing multiple sources together. Must be implemented by child classes.
         
         Parameters
         ----------
-        outputs : list
-            A list of outputs that need to be composited together
+        coordinates : :class:`podpac.Coordinates`
+            {requested_coordinates}
+        data_arrays : list
+            Evaluated data from the sources.
         result : UnitDataArray, optional
             An optional pre-filled array may be supplied, otherwise the output will be allocated.
-        
-        Raises
-        ------
-        NotImplementedError
+
+        Returns
+        -------
+        {eval_return} 
         """
+
         raise NotImplementedError()
 
     def iteroutputs(self, coordinates):
@@ -185,34 +177,16 @@ class Compositor(Node):
         :class:`podpac.core.units.UnitsDataArray`
             Output from source node eval method
         """
-        # downselect sources based on coordinates
-        src_subset = self.select_sources(coordinates)
 
-        if len(src_subset) == 0:
+        # get sources, potentially downselected
+        sources = self.select_sources(coordinates)
+
+        if len(sources) == 0:
             yield self.create_output_array(coordinates)
             return
 
-        # Set the interpolation properties for sources
-        if self.interpolation is not None:
-            for s in src_subset.ravel():
-                if self.trait_is_defined("interpolation"):
-                    s.set_trait("interpolation", self.interpolation)
-
-        # Optimization: if coordinates complete and source coords is 1D,
-        # set native_coordinates unless they are set already
-        # WARNING: this assumes
-        #              native_coords = source_coords + shared_coordinates
-        #         NOT  native_coords = shared_coords + source_coords
-        if self.is_source_coordinates_complete and self.source_coordinates.ndim == 1:
-            coords_subset = list(self.source_coordinates.intersect(coordinates, outer=True).coords.values())[0]
-            coords_dim = list(self.source_coordinates.dims)[0]
-            crs = self.source_coordinates.crs
-            for s, c in zip(src_subset, coords_subset):
-                nc = merge_dims([Coordinates(np.atleast_1d(c), dims=[coords_dim], crs=crs), self.shared_coordinates])
-                s.set_native_coordinates(nc)
-
         if settings["MULTITHREADING"]:
-            n_threads = thread_manager.request_n_threads(len(src_subset))
+            n_threads = thread_manager.request_n_threads(len(sources))
             if n_threads == 1:
                 thread_manager.release_n_threads(n_threads)
         else:
@@ -222,7 +196,7 @@ class Compositor(Node):
             # evaluate nodes in parallel using thread pool
             self._multi_threaded = True
             pool = thread_manager.get_thread_pool(processes=n_threads)
-            outputs = pool.map(lambda src: src.eval(coordinates), src_subset)
+            outputs = pool.map(lambda src: src.eval(coordinates), sources)
             pool.close()
             thread_manager.release_n_threads(n_threads)
             for output in outputs:
@@ -231,7 +205,7 @@ class Compositor(Node):
         else:
             # evaluate nodes serially
             self._multi_threaded = False
-            for src in src_subset:
+            for src in sources:
                 yield src.eval(coordinates)
 
     @node_eval
@@ -252,7 +226,6 @@ class Compositor(Node):
         """
 
         self._requested_coordinates = coordinates
-
         outputs = self.iteroutputs(coordinates)
         output = self.composite(coordinates, outputs, output)
         return output
@@ -264,10 +237,10 @@ class Compositor(Node):
         Returns
         -------
         coords_list : list
-            list of available coordinates (Coordinate objects)
+            available coordinates from all of the sources.
         """
 
-        raise NotImplementedError("TODO")
+        return [coords for source in self.sources for coords in source.find_coordinates()]
 
     @property
     def _repr_keys(self):
@@ -278,21 +251,31 @@ class Compositor(Node):
         return keys
 
 
-class OrderedCompositor(Compositor):
-    """Compositor that combines sources based on their order in self.sources. Once a request contains no
-    nans, the result is returned. 
+class OrderedCompositor(BaseCompositor):
+    """Compositor that combines sources based on their order in self.sources.
+    
+    The requested data is interpolated by the sources before being composited.
+
+    Attributes
+    ----------
+    sources : list
+        Source nodes, in order of preference. Later sources are only used where earlier sources do not provide data.
+    source_coordinates : :class:`podpac.Coordinates`
+        Coordinates that make each source unique. Must the same size as ``sources`` and single-dimensional. Optional.
+    interpolation : str, dict, optional
+        {interpolation}
     """
 
     @common_doc(COMMON_COMPOSITOR_DOC)
     def composite(self, coordinates, data_arrays, result=None):
-        """Composites data_arrays in order that they appear.
+        """Composites data_arrays in order that they appear. Once a request contains no nans, the result is returned.
         
         Parameters
         ----------
         coordinates : :class:`podpac.Coordinates`
             {requested_coordinates}
         data_arrays : generator
-            Generator that gives UnitDataArray's with the source values.
+            Evaluated source data, in the same order as the sources.
         result : podpac.UnitsDataArray, optional
             {eval_output}
         

--- a/podpac/core/data/datasource.py
+++ b/podpac/core/data/datasource.py
@@ -500,6 +500,8 @@ class DataSource(Node):
         ---------
         coordinates : :class:`podpac.Coordinates`
             Coordinates to set. Usually these are coordinates that are shared across compositor sources.
+
+        NOTE: This is only currently used by SMAPCompositor. It should potentially be moved to the SMAPSource.
         """
 
         if not self.trait_is_defined("_native_coordinates"):

--- a/podpac/datalib/smap.py
+++ b/podpac/datalib/smap.py
@@ -50,8 +50,8 @@ from podpac import NodeException
 from podpac import authentication
 from podpac.coordinates import Coordinates
 from podpac.data import PyDAP
-from podpac.compositor import OrderedCompositor
 from podpac.utils import cached_property, DiskCacheMixin
+from podpac.compositor import OrderedCompositor
 from podpac.core.data.datasource import COMMON_DATA_DOC
 from podpac.core.utils import common_doc, _get_from_url
 
@@ -288,6 +288,61 @@ class SMAPSessionMixin(authentication.RequestsSessionMixin):
                     del headers["Authorization"]
 
         return
+
+
+class SMAPCompositor(OrderedCompositor):
+    """
+
+    Attributes
+    ----------
+    sources : list
+        Source nodes, in order of preference. Later sources are only used where earlier sources do not provide data.
+    source_coordinates : :class:`podpac.Coordinates`
+        Coordinates that make each source unique. Must the same size as ``sources`` and single-dimensional.
+    shared_coordinates : :class:`podpac.Coordinates`.
+        Coordinates that are shared amongst all of the composited sources.
+    is_source_coordinates_complete : Bool
+        This flag is used to automatically construct native_coordinates as on optimization. Default is False.
+        For example, if the source coordinates could include the year-month-day of the source, but the actual source
+        also has hour-minute-second information, the source_coordinates is incomplete.
+    """
+
+    is_source_coordinates_complete = tl.Bool(False)
+    shared_coordinates = tl.Instance(Coordinates, allow_none=True, default_value=None).tag(attr=True)
+
+    def select_sources(self, coordinates):
+        """Select sources based on requested coordinates, including setting native_coordinates, if possible.
+        
+        Parameters
+        ----------
+        coordinates : :class:`podpac.Coordinates`
+            Coordinates to evaluate at compositor sources
+        
+        Returns
+        -------
+        sources : :class:`np.ndarray`
+            Array of sources
+
+        Notes
+        -----
+         * If :attr:`source_coordinates` is defined, only sources that intersect the requested coordinates are selected.
+         * Sets sources :attr:`interpolation`.
+         * If source coordinates complete, sets sources :attr:`native_coordinates` as an optimization.
+        """
+
+        """ Optimization: . """
+
+        src_subset = super(self, SMAPCompositor).select_sources(coordinates)
+
+        if self.is_source_coordinates_complete:
+            coords_subset = list(self.source_coordinates.intersect(coordinates, outer=True).coords.values())[0]
+            coords_dim = list(self.source_coordinates.dims)[0]
+            crs = self.source_coordinates.crs
+            for s, c in zip(src_subset, coords_subset):
+                nc = merge_dims([Coordinates(np.atleast_1d(c), dims=[coords_dim], crs=crs), self.shared_coordinates])
+                s.set_native_coordinates(nc)
+
+        return src_subset
 
 
 @common_doc(COMMON_DOC)
@@ -540,7 +595,7 @@ class SMAPWilt(SMAPProperties):
 
 
 @common_doc(COMMON_DOC)
-class SMAPDateFolder(SMAPSessionMixin, DiskCacheMixin, OrderedCompositor):
+class SMAPDateFolder(SMAPSessionMixin, DiskCacheMixin, SMAPCompositor):
     """Compositor of all the SMAP source urls present in a particular folder which is defined for a particular date
 
     Attributes
@@ -596,6 +651,15 @@ class SMAPDateFolder(SMAPSessionMixin, DiskCacheMixin, OrderedCompositor):
     @tl.default("layer_key")
     def _layerkey_default(self):
         return SMAP_PRODUCT_MAP.sel(product=self.product, attr="layer_key").item()
+
+    @tl.default("shared_coordinates")
+    def shared_coordinates(self):
+        """Coordinates that are shared by all files in the folder."""
+
+        if self.product in SMAP_INCOMPLETE_SOURCE_COORDINATES:
+            return None
+        coords = copy.deepcopy(self.sources[0].native_coordinates)
+        return coords.drop("time")
 
     @cached_property
     def folder_url(self):
@@ -671,16 +735,6 @@ class SMAPDateFolder(SMAPSessionMixin, DiskCacheMixin, OrderedCompositor):
                 crds = Coordinates([times], dims=["time"])
             self.put_cache(crds, "source.coordinates", overwrite=True)
             return crds
-
-    @cached_property(use_cache_ctrl=True)
-    def shared_coordinates(self):
-        """Coordinates that are shared by all files in the folder."""
-
-        if self.product in SMAP_INCOMPLETE_SOURCE_COORDINATES:
-            return None
-
-        coords = copy.deepcopy(self.sources[0].native_coordinates)
-        return coords.drop("time")
 
     # TODO just return the elements, then return each actual thing separately
     @cached_property
@@ -760,7 +814,7 @@ class SMAPDateFolder(SMAPSessionMixin, DiskCacheMixin, OrderedCompositor):
 
 
 @common_doc(COMMON_DOC)
-class SMAP(SMAPSessionMixin, OrderedCompositor):
+class SMAP(SMAPSessionMixin, SMAPCompositor):
     """Compositor of all the SMAPDateFolder's for every available SMAP date. Essentially a compositor of all SMAP data
     for a particular product.
 
@@ -797,6 +851,22 @@ class SMAP(SMAPSessionMixin, OrderedCompositor):
     def _layerkey_default(self):
         return SMAP_PRODUCT_MAP.sel(product=self.product, attr="layer_key").item()
 
+    @tl.default("shared_coordinates")
+    def shared_coordinates(self):
+        """Coordinates that are shared by all files in the SMAP product family. 
+
+        Notes
+        ------
+        For example, the gridded SMAP data have the same lat-lon coordinates in every file (global at some resolution), 
+        and the only difference between files is the time coordinate. 
+        This is not true for the SMAP-Sentinel product, in which case this function returns None
+        """
+        if self.product in SMAP_INCOMPLETE_SOURCE_COORDINATES:
+            return None
+
+        sample_source = SMAPDateFolder(product=self.product, version=self.version, folder_date=self.available_dates[0])
+        return sample_source.shared_coordinates
+
     @cached_property
     def available_dates(self):
         """ Available dates in SMAP date format, sorted."""
@@ -818,8 +888,8 @@ class SMAP(SMAPSessionMixin, OrderedCompositor):
         kwargs = {
             "product": self.product,
             "version": self.version,
-            "shared_coordinates": self.shared_coordinates,
             "layer_key": self.layer_key,
+            "shared_coordinates": self.shared_coordinates,  # this is an optimization
         }
         return [SMAPDateFolder(folder_date=date, **kwargs) for date in self.available_dates]
 
@@ -830,23 +900,6 @@ class SMAP(SMAPSessionMixin, OrderedCompositor):
         """
         available_times = [np.datetime64(date.replace(".", "-")) for date in self.available_dates]
         return Coordinates([available_times], dims=["time"])
-
-    @cached_property  # (use_cache_ctrl=True)
-    def shared_coordinates(self):
-        """Coordinates that are shared by all files in the SMAP product family. 
-
-        Notes
-        ------
-        For example, the gridded SMAP data have the same lat-lon coordinates in every file (global at some resolution), 
-        and the only difference between files is the time coordinate. 
-        This is not true for the SMAP-Sentinel product, in which case this function returns None
-        """
-        if self.product in SMAP_INCOMPLETE_SOURCE_COORDINATES:
-            return None
-
-        sample_source = SMAPDateFolder(product=self.product, version=self.version, folder_date=self.available_dates[0])
-
-        return sample_source.shared_coordinates
 
     @property
     def base_ref(self):
@@ -1032,8 +1085,6 @@ class SMAPBestAvailable(OrderedCompositor):
     """Compositor of SMAP-Sentinel and the Level 4 SMAP Analysis Update soil moisture
     """
 
-    shared_coordinates = None
-
     @cached_property
     def sources(self):
         """Orders the compositor of SPL2SMAP_S in front of SPL4SMAU. """
@@ -1097,29 +1148,28 @@ if __name__ == "__main__":
     sm.set_credentials(username=username, password=password)
 
     # SMAP info
-    print(sm)
-    print("SMAP Definition:", sm.json_pretty)
-    print(
+    print (sm)
+    print ("SMAP Definition:", sm.json_pretty)
+    print (
         "SMAP available_dates:",
         "%s - %s (%d)" % (sm.available_dates[0], sm.available_dates[1], len(sm.available_dates)),
     )
-    print("SMAP source_coordinates:", sm.source_coordinates)
-    print("SMAP shared_coordinates:", sm.shared_coordinates)
-    print("Sources:", sm.sources)
+    print ("SMAP source_coordinates:", sm.source_coordinates)
+    print ("SMAP shared_coordinates:", sm.shared_coordinates)
+    print ("Sources:", sm.sources)
 
     # sample SMAPDateFolder info
     sm_datefolder = sm.sources[0]
-    print("Sample DateFolder:", sm_datefolder)
-    print("Sample DateFolder Definition:", sm_datefolder.json_pretty)
-    print("Sample DateFolder source_coordinates:", sm_datefolder.source_coordinates)
-    print("Sample DateFolder shared_coordinates:", sm_datefolder.shared_coordinates)
-    print("Sample DateFolder Sources:", sm_datefolder.sources)
+    print ("Sample DateFolder:", sm_datefolder)
+    print ("Sample DateFolder Definition:", sm_datefolder.json_pretty)
+    print ("Sample DateFolder source_coordinates:", sm_datefolder.source_coordinates)
+    print ("Sample DateFolder Sources:", sm_datefolder.sources)
 
     # sample SMAPSource info
     sm_source = sm_datefolder.sources[0]
-    print("Sample DAP Source:", sm_source)
-    print("Sample DAP Source Definition:", sm_source.json_pretty)
-    print("Sample DAP Native Coordinates:", sm_source.native_coordinates)
+    print ("Sample DAP Source:", sm_source)
+    print ("Sample DAP Source Definition:", sm_source.json_pretty)
+    print ("Sample DAP Native Coordinates:", sm_source.native_coordinates)
 
     # eval whole world
     c_world = Coordinates(
@@ -1140,4 +1190,4 @@ if __name__ == "__main__":
     pyplot.plot(ot.time, ot.data.T)
 
     pyplot.show()
-    print("Done")
+    print ("Done")


### PR DESCRIPTION
 * Moves `shared_coordinates` and `is_source_coordinates_complete` to `SMAPCompositor`
 * Moves set interpolation (and set native_coordinates) from `iteroutputs` to to `select_sources`
 * couple of bugfixes

Easy one. In preparation for further compositor work.