### PR TITLE
Skip crs Validation when possible

### DIFF
--- a/podpac/core/algorithm/coord_select.py
+++ b/podpac/core/algorithm/coord_select.py
@@ -67,7 +67,9 @@ class ModifyCoordinates(UnaryAlgorithm):
 
         self._requested_coordinates = coordinates
         self._modified_coordinates = Coordinates(
-            [self.get_modified_coordinates1d(coordinates, dim) for dim in coordinates.dims], crs=coordinates.crs
+            [self.get_modified_coordinates1d(coordinates, dim) for dim in coordinates.dims],
+            crs=coordinates.crs,
+            validate_crs=False,
         )
 
         for dim in self._modified_coordinates.udims:

--- a/podpac/core/algorithm/signal.py
+++ b/podpac/core/algorithm/signal.py
@@ -143,7 +143,7 @@ class Convolution(UnaryAlgorithm):
             )
             exp_slice.append(slice(-s_start, -s_end))
         exp_slice = tuple(exp_slice)
-        expanded_coordinates = Coordinates(exp_coords)
+        expanded_coordinates = Coordinates(exp_coords, crs=coordinates.crs, validate_crs=False)
 
         if settings["DEBUG"]:
             self._expanded_coordinates = expanded_coordinates

--- a/podpac/core/algorithm/stats.py
+++ b/podpac/core/algorithm/stats.py
@@ -875,6 +875,11 @@ class GroupReduce(UnaryAlgorithm):
         native_time_mask = np.in1d(N, E)
 
         # use requested spatial coordinates and filtered available times
+        import pdb
+
+        pdb.set_trace()  # breakpoint e7271746 //
+
+        # WHAT?
         coords = Coordinates(
             time=avail_time.data[native_time_mask],
             lat=requested_coordinates["lat"],

--- a/podpac/core/algorithm/stats.py
+++ b/podpac/core/algorithm/stats.py
@@ -875,19 +875,7 @@ class GroupReduce(UnaryAlgorithm):
         native_time_mask = np.in1d(N, E)
 
         # use requested spatial coordinates and filtered available times
-        import pdb
-
-        pdb.set_trace()  # breakpoint e7271746 //
-
-        # WHAT?
-        coords = Coordinates(
-            time=avail_time.data[native_time_mask],
-            lat=requested_coordinates["lat"],
-            lon=requested_coordinates["lon"],
-            order=("time", "lat", "lon"),
-        )
-
-        return coords
+        return coords[native_time_mask, :, :]
 
     @common_doc(COMMON_DOC)
     @node_eval

--- a/podpac/core/algorithm/utility.py
+++ b/podpac/core/algorithm/utility.py
@@ -63,7 +63,7 @@ class CoordData(Algorithm):
             raise ValueError("Coordinate name not in evaluated coordinates")
 
         c = self._requested_coordinates[self.coord_name]
-        coords = Coordinates([c])
+        coords = Coordinates([c], validate_crs=False)
         return self.create_output_array(coords, data=c.coordinates)
 
 

--- a/podpac/core/coordinates/array_coordinates1d.py
+++ b/podpac/core/coordinates/array_coordinates1d.py
@@ -43,7 +43,8 @@ class ArrayCoordinates1d(Coordinates1d):
     """
 
     coordinates = ArrayTrait(ndim=1, read_only=True)
-    coordinates.__doc__ = ":array: User-defined coordinate values"
+    # coordinates.__doc__ = ":array: User-defined coordinate values"
+    # coordinates = None
 
     def __init__(self, coordinates, name=None, ctype=None, segment_lengths=None):
         """
@@ -63,7 +64,9 @@ class ArrayCoordinates1d(Coordinates1d):
         """
 
         # validate and set coordinates
-        self.set_trait("coordinates", make_coord_array(coordinates))
+        coordinates = make_coord_array(coordinates)
+        self.set_trait("coordinates", coordinates)
+        self.not_a_trait = coordinates
 
         # precalculate once
         if self.coordinates.size == 0:

--- a/podpac/core/coordinates/coordinates1d.py
+++ b/podpac/core/coordinates/coordinates1d.py
@@ -76,7 +76,7 @@ class Coordinates1d(BaseCoordinates):
 
             self.set_trait("segment_lengths", segment_lengths)
 
-        # super(Coordinates1d, self).__init__()
+        super(Coordinates1d, self).__init__()
 
     @tl.observe("name", "ctype", "segment_lengths")
     def _set_property(self, d):

--- a/podpac/core/coordinates/coordinates1d.py
+++ b/podpac/core/coordinates/coordinates1d.py
@@ -76,7 +76,7 @@ class Coordinates1d(BaseCoordinates):
 
             self.set_trait("segment_lengths", segment_lengths)
 
-        super(Coordinates1d, self).__init__()
+        # super(Coordinates1d, self).__init__()
 
     @tl.observe("name", "ctype", "segment_lengths")
     def _set_property(self, d):

--- a/podpac/core/data/csv_source.py
+++ b/podpac/core/data/csv_source.py
@@ -116,7 +116,7 @@ class CSV(FileKeysMixin, LoadFileMixin, BaseFileSource):
         if len(coords) == 1:
             return coords
         stacked = StackedCoordinates(list(coords.values()))
-        return Coordinates([stacked], **coords.properties)
+        return Coordinates([stacked], validate_crs=False, **coords.properties)
 
     @common_doc(COMMON_DATA_DOC)
     def get_data(self, coordinates, coordinates_index):

--- a/podpac/core/data/reprojection.py
+++ b/podpac/core/data/reprojection.py
@@ -80,7 +80,8 @@ class ReprojectedSource(DataSource):
             [
                 rc[dim] if dim in rc.dims else self.source.native_coordinates[dim]
                 for dim in self.source.native_coordinates.dims
-            ]
+            ],
+            validate_crs=False,
         )
 
     @common_doc(COMMON_DATA_DOC)

--- a/podpac/core/data/test/test_h5py.py
+++ b/podpac/core/data/test/test_h5py.py
@@ -57,11 +57,11 @@ class TestH5PY(object):
         np.testing.assert_array_equal(o.sel(output="b").data.ravel(), np.arange(12))
         node.close_dataset()
 
-    def test_attrs(self):
+    def test_dataset_attrs(self):
         node = H5PY(source=self.source, data_key="/data/init", lat_key="/coords/lat", lon_key="/coords/lon")
-        assert node.attrs() == {}
-        assert node.attrs("data") == {"test": "test"}
-        assert node.attrs("coords/lat") == {"unit": "degrees"}
-        assert node.attrs("coords/lon") == {"unit": "degrees"}
-        assert node.attrs("coords") == {"crs": "EPSG:4326s"}
+        assert node.dataset_attrs() == {}
+        assert node.dataset_attrs("data") == {"test": "test"}
+        assert node.dataset_attrs("coords/lat") == {"unit": "degrees"}
+        assert node.dataset_attrs("coords/lon") == {"unit": "degrees"}
+        assert node.dataset_attrs("coords") == {"crs": "EPSG:4326s"}
         node.close_dataset()

--- a/podpac/core/interpolation/interpolators.py
+++ b/podpac/core/interpolation/interpolators.py
@@ -196,7 +196,7 @@ class NearestPreview(NearestNeighbor):
             new_coords.append(c)
             new_coords_idx.append(idx)
 
-        return Coordinates(new_coords), tuple(new_coords_idx)
+        return Coordinates(new_coords, validate_crs=False), tuple(new_coords_idx)
 
 
 @common_doc(COMMON_INTERPOLATOR_DOCS)

--- a/podpac/datalib/gfs.py
+++ b/podpac/datalib/gfs.py
@@ -63,7 +63,9 @@ class GFS(S3Mixin, DiskCacheMixin, DataSource):
         nc = self.sources[0].native_coordinates
         base_time = datetime.datetime.strptime("%s %s" % (self.date, self.hour), "%Y%m%d %H%M")
         forecast_times = [base_time + datetime.timedelta(hours=int(h)) for h in self.forecasts]
-        tc = Coordinates([[dt.strftime("%Y-%m-%d %H:%M") for dt in forecast_times]], dims=["time"], crs=nc.crs)
+        tc = Coordinates(
+            [[dt.strftime("%Y-%m-%d %H:%M") for dt in forecast_times]], dims=["time"], crs=nc.crs, validate_crs=False
+        )
         return merge_dims([nc, tc])
 
     def get_data(self, coordinates, coordinates_index):
@@ -105,7 +107,7 @@ if __name__ == "__main__":
     tomorrow = now + datetime.timedelta(1)
 
     # GFSSource (specify source date/time and forecast)
-    print("GFSSource node (parameter, level, date, hour)")
+    print ("GFSSource node (parameter, level, date, hour)")
     gfs_soim = GFSSource(
         parameter=parameter,
         level=level,
@@ -117,10 +119,10 @@ if __name__ == "__main__":
     )
 
     o = gfs_soim.eval(gfs_soim.native_coordinates)
-    print(o)
+    print (o)
 
     # GFS (specify source date/time, select forecast at evaluation)
-    print("GFS node (parameter, level, date, hour)")
+    print ("GFS node (parameter, level, date, hour)")
     gfs_soim = GFS(
         parameter=parameter,
         level=level,
@@ -135,20 +137,20 @@ if __name__ == "__main__":
         [gfs_soim.native_coordinates["lat"], gfs_soim.native_coordinates["lon"], tomorrow], dims=["lat", "lon", "time"]
     )
     o = gfs_soim.eval(c)
-    print(o)
+    print (o)
 
     # time series: get the forecast at lat=42, lon=275 every hour for the next 6 hours
     start = now
     stop = now + datetime.timedelta(hours=6)
     c = Coordinates([42, 282, podpac.crange(start, stop, "1,h")], dims=["lat", "lon", "time"])
     o = gfs_soim.eval(c)
-    print(o)
+    print (o)
 
     # latest (get latest source, select forecast at evaluation)
-    print("GFSLatest node (parameter, level)")
+    print ("GFSLatest node (parameter, level)")
     gfs_soim = GFSLatest(parameter=parameter, level=level, cache_ctrl=cache_ctrl, anon=True)
     c = Coordinates(
         [gfs_soim.native_coordinates["lat"], gfs_soim.native_coordinates["lon"], tomorrow], dims=["lat", "lon", "time"]
     )
     o = gfs_soim.eval(c)
-    print(o)
+    print (o)

--- a/podpac/datalib/smap.py
+++ b/podpac/datalib/smap.py
@@ -339,7 +339,12 @@ class SMAPCompositor(OrderedCompositor):
             coords_dim = list(self.source_coordinates.dims)[0]
             crs = self.source_coordinates.crs
             for s, c in zip(src_subset, coords_subset):
-                nc = merge_dims([Coordinates(np.atleast_1d(c), dims=[coords_dim], crs=crs), self.shared_coordinates])
+                nc = merge_dims(
+                    [
+                        Coordinates(np.atleast_1d(c), dims=[coords_dim], crs=crs, validate_crs=False),
+                        self.shared_coordinates,
+                    ]
+                )
                 s.set_native_coordinates(nc)
 
         return src_subset


### PR DESCRIPTION
CRS validation with pyproj is very slow, so this is an optimization. For example, when `Coordinates` is subselecting itself in `__getitem__`, it does not need to revalidate the crs.

@mpu-creare @mlshapiro any qualms?

This reduces the runtime for the tests on my machine from 80s to 50s.