### PR TITLE
Bugfix: compositor auto_outputs flag

### DIFF
--- a/podpac/core/compositor/compositor.py
+++ b/podpac/core/compositor/compositor.py
@@ -52,6 +52,8 @@ class BaseCompositor(Node):
     interpolation = InterpolationTrait(allow_none=True, default_value=None).tag(attr=True)
     source_coordinates = tl.Instance(Coordinates, allow_none=True, default_value=None).tag(attr=True)
 
+    auto_outputs = tl.Bool(False)
+
     # debug traits
     _eval_sources = tl.Any()
 
@@ -87,6 +89,10 @@ class BaseCompositor(Node):
 
     @tl.default("outputs")
     def _default_outputs(self):
+        if not self.auto_outputs:
+            return None
+
+        # autodetect outputs from sources
         if all(source.outputs is None for source in self.sources):
             outputs = None
 

--- a/podpac/core/compositor/test/test_base_compositor.py
+++ b/podpac/core/compositor/test/test_base_compositor.py
@@ -203,30 +203,40 @@ class TestBaseCompositor(object):
         node = BaseCompositor(sources=[ARRAY_LAT, ARRAY_LON, ARRAY_TIME])
         assert node.outputs is None
 
-        # multi-output
+        # even if the sources have multiple outputs, the default here is outputs
         node = BaseCompositor(sources=[MULTI_0_XY, MULTI_1_XY])
+        assert node.outputs is None
+
+    def test_auto_outputs(self):
+        # autodetect single-output
+        node = BaseCompositor(sources=[ARRAY_LAT, ARRAY_LON, ARRAY_TIME], auto_outputs=True)
+        assert node.outputs is None
+
+        # autodetect multi-output
+        node = BaseCompositor(sources=[MULTI_0_XY, MULTI_1_XY], auto_outputs=True)
         assert node.outputs == ["x", "y"]
 
-        node = BaseCompositor(sources=[MULTI_0_XY, MULTI_3_Z])
+        node = BaseCompositor(sources=[MULTI_0_XY, MULTI_3_Z], auto_outputs=True)
         assert node.outputs == ["x", "y", "z"]
 
-        node = BaseCompositor(sources=[MULTI_3_Z, MULTI_0_XY])
+        node = BaseCompositor(sources=[MULTI_3_Z, MULTI_0_XY], auto_outputs=True)
         assert node.outputs == ["z", "x", "y"]
 
-        node = BaseCompositor(sources=[MULTI_0_XY, MULTI_4_YX])
+        node = BaseCompositor(sources=[MULTI_0_XY, MULTI_4_YX], auto_outputs=True)
         assert node.outputs == ["x", "y"]
 
         # mixed
         with pytest.raises(ValueError, match="Cannot composite standard sources with multi-output sources."):
-            node = BaseCompositor(sources=[MULTI_2_X, ARRAY_LAT])
+            node = BaseCompositor(sources=[MULTI_2_X, ARRAY_LAT], auto_outputs=True)
 
         # no sources
-        node = BaseCompositor(sources=[])
+        node = BaseCompositor(sources=[], auto_outputs=True)
         assert node.outputs is None
 
     def test_forced_invalid_sources(self):
         class MyCompositor(BaseCompositor):
             sources = [MULTI_2_X, ARRAY_LAT]
+            auto_outputs = True
 
         node = MyCompositor()
         with pytest.raises(RuntimeError, match="Compositor sources were not validated correctly"):

--- a/podpac/core/compositor/test/test_ordered_compositor.py
+++ b/podpac/core/compositor/test/test_ordered_compositor.py
@@ -115,14 +115,14 @@ class TestOrderedCompositor(object):
         np.testing.assert_array_equal(result, a.source)
 
     def test_composite_multiple_outputs(self):
-        node = OrderedCompositor(sources=[MULTI_0_XY, MULTI_1_XY])
+        node = OrderedCompositor(sources=[MULTI_0_XY, MULTI_1_XY], auto_outputs=True)
         output = node.eval(COORDS)
         assert output.dims == ("lat", "lon", "time", "output")
         np.testing.assert_array_equal(output["output"], ["x", "y"])
         np.testing.assert_array_equal(output.sel(output="x"), np.full(COORDS.shape, 0))
         np.testing.assert_array_equal(output.sel(output="y"), np.full(COORDS.shape, 0))
 
-        node = OrderedCompositor(sources=[MULTI_1_XY, MULTI_0_XY])
+        node = OrderedCompositor(sources=[MULTI_1_XY, MULTI_0_XY], auto_outputs=True)
         output = node.eval(COORDS)
         assert output.dims == ("lat", "lon", "time", "output")
         np.testing.assert_array_equal(output["output"], ["x", "y"])
@@ -130,7 +130,7 @@ class TestOrderedCompositor(object):
         np.testing.assert_array_equal(output.sel(output="y"), np.full(COORDS.shape, 1))
 
     def test_composite_combine_multiple_outputs(self):
-        node = OrderedCompositor(sources=[MULTI_0_XY, MULTI_1_XY, MULTI_2_X, MULTI_3_Z])
+        node = OrderedCompositor(sources=[MULTI_0_XY, MULTI_1_XY, MULTI_2_X, MULTI_3_Z], auto_outputs=True)
         output = node.eval(COORDS)
         assert output.dims == ("lat", "lon", "time", "output")
         np.testing.assert_array_equal(output["output"], ["x", "y", "z"])
@@ -138,7 +138,7 @@ class TestOrderedCompositor(object):
         np.testing.assert_array_equal(output.sel(output="y"), np.full(COORDS.shape, 0))
         np.testing.assert_array_equal(output.sel(output="z"), np.full(COORDS.shape, 3))
 
-        node = OrderedCompositor(sources=[MULTI_3_Z, MULTI_2_X, MULTI_0_XY, MULTI_1_XY])
+        node = OrderedCompositor(sources=[MULTI_3_Z, MULTI_2_X, MULTI_0_XY, MULTI_1_XY], auto_outputs=True)
         output = node.eval(COORDS)
         assert output.dims == ("lat", "lon", "time", "output")
         np.testing.assert_array_equal(output["output"], ["z", "x", "y"])
@@ -146,7 +146,7 @@ class TestOrderedCompositor(object):
         np.testing.assert_array_equal(output.sel(output="y"), np.full(COORDS.shape, 0))
         np.testing.assert_array_equal(output.sel(output="z"), np.full(COORDS.shape, 3))
 
-        node = OrderedCompositor(sources=[MULTI_2_X, MULTI_4_YX])
+        node = OrderedCompositor(sources=[MULTI_2_X, MULTI_4_YX], auto_outputs=True)
         output = node.eval(COORDS)
         assert output.dims == ("lat", "lon", "time", "output")
         np.testing.assert_array_equal(output["output"], ["x", "y"])

--- a/podpac/datalib/cosmos_stations.py
+++ b/podpac/datalib/cosmos_stations.py
@@ -135,7 +135,6 @@ class COSMOSStation(podpac.data.DataSource):
 class COSMOSStations(podpac.compositor.OrderedCompositor):
     url = tl.Unicode("http://cosmos.hwr.arizona.edu/Probes/")
     stations_url = tl.Unicode("sitesNoLegend.js")
-    outputs = None
 
     ## PROPERTIES
     @cached_property(use_cache_ctrl=True)

--- a/podpac/datalib/smap.py
+++ b/podpac/datalib/smap.py
@@ -634,7 +634,6 @@ class SMAPDateFolder(SMAPSessionMixin, DiskCacheMixin, SMAPCompositor):
     folder_date = tl.Unicode("").tag(attr=True)
     layer_key = tl.Unicode().tag(attr=True)
     latlon_delta = tl.Float(default_value=1.5).tag(attr=True)
-    outputs = None  # this is necessary because of the source caching backup
 
     file_url_re = re.compile(r".*_[0-9]{8}T[0-9]{6}_.*\.h5")
     file_url_re2 = re.compile(r".*_[0-9]{8}_.*\.h5")
@@ -836,8 +835,6 @@ class SMAP(SMAPSessionMixin, DiskCacheMixin, SMAPCompositor):
     product = tl.Enum(SMAP_PRODUCT_MAP.coords["product"].data.tolist(), default_value="SPL4SMAU").tag(attr=True)
     version = tl.Int(allow_none=True).tag(attr=True)
     layer_key = tl.Unicode().tag(attr=True)
-    outputs = None  # this is necessary because of the source caching backup
-    output = None  # might as well
 
     date_url_re = re.compile(r"[0-9]{4}\.[0-9]{2}\.[0-9]{2}")
 


### PR DESCRIPTION
Currently Compositors automatic detect `outputs` from the `sources`, which causes deadlock or infinite recursion in fairly normal usage, including SMAP and COSMOS. The problem is quite hard to diagnose, and the workaround is to explicitly set `outputs = None` in these compositor nodes.

The proposed solution is to add a `auto_outputs` flag to Compositors, which defaults to False.

The workaround can be removed from SMAP and COSMOS, and compositor child classes that want to autodetect multiple outputs from sources can enable this feature as follows:

```
class MyCompositor(podpac.core.OrderedCompositor):
    auto_outputs = True
```

*Note: either this PR or #388 should be merged, but not both.*