### PR TITLE
BUGFIX: Extracts automatic outputs detection from compositor sources …

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -180,6 +180,7 @@ Stitch multiple data sources together
     podpac.compositor.OrderedCompositor
     podpac.compositor.UniformTileCompositor
     podpac.compositor.UniformTileMixin
+    podpac.compositor.AutoOutputsMixin
 
 
 Datalib

--- a/podpac/compositor.py
+++ b/podpac/compositor.py
@@ -4,5 +4,6 @@ Compositor Public Module
 
 # REMINDER: update api docs (doc/source/user/api.rst) to reflect changes to this file
 
+from podpac.core.compositor.compositor import AutoOutputsMixin
 from podpac.core.compositor.ordered_compositor import OrderedCompositor
 from podpac.core.compositor.tile_compositor import UniformTileCompositor, UniformTileMixin

--- a/podpac/core/compositor/compositor.py
+++ b/podpac/core/compositor/compositor.py
@@ -85,29 +85,6 @@ class BaseCompositor(Node):
 
         return d["value"]
 
-    @tl.default("outputs")
-    def _default_outputs(self):
-        if all(source.outputs is None for source in self.sources):
-            outputs = None
-
-        elif all(source.outputs is not None and source.output is None for source in self.sources):
-            outputs = []
-            for source in self.sources:
-                for output in source.outputs:
-                    if output not in outputs:
-                        outputs.append(output)
-
-            if len(outputs) == 0:
-                outputs = None
-
-        else:
-            raise RuntimeError(
-                "Compositor sources were not validated correctly. "
-                "Cannot composite standard sources with multi-output sources."
-            )
-
-        return outputs
-
     def select_sources(self, coordinates):
         """Select and prepare sources based on requested coordinates.
         
@@ -254,3 +231,30 @@ class BaseCompositor(Node):
         if self.trait_is_defined("sources"):
             keys.append("sources")
         return keys
+
+
+class AutoOutputsMixin(tl.HasTraits):
+    """ Automatically compute multiple outputs from Compositor sources. """
+
+    @tl.default("outputs")
+    def _default_outputs(self):
+        if all(source.outputs is None for source in self.sources):
+            outputs = None
+
+        elif all(source.outputs is not None and source.output is None for source in self.sources):
+            outputs = []
+            for source in self.sources:
+                for output in source.outputs:
+                    if output not in outputs:
+                        outputs.append(output)
+
+            if len(outputs) == 0:
+                outputs = None
+
+        else:
+            raise RuntimeError(
+                "Compositor sources were not validated correctly. "
+                "Cannot composite standard sources with multi-output sources."
+            )
+
+        return outputs

--- a/podpac/datalib/cosmos_stations.py
+++ b/podpac/datalib/cosmos_stations.py
@@ -135,7 +135,6 @@ class COSMOSStation(podpac.data.DataSource):
 class COSMOSStations(podpac.compositor.OrderedCompositor):
     url = tl.Unicode("http://cosmos.hwr.arizona.edu/Probes/")
     stations_url = tl.Unicode("sitesNoLegend.js")
-    outputs = None
 
     ## PROPERTIES
     @cached_property(use_cache_ctrl=True)

--- a/podpac/datalib/smap.py
+++ b/podpac/datalib/smap.py
@@ -634,7 +634,6 @@ class SMAPDateFolder(SMAPSessionMixin, DiskCacheMixin, SMAPCompositor):
     folder_date = tl.Unicode("").tag(attr=True)
     layer_key = tl.Unicode().tag(attr=True)
     latlon_delta = tl.Float(default_value=1.5).tag(attr=True)
-    outputs = None  # this is necessary because of the source caching backup
 
     file_url_re = re.compile(r".*_[0-9]{8}T[0-9]{6}_.*\.h5")
     file_url_re2 = re.compile(r".*_[0-9]{8}_.*\.h5")
@@ -836,8 +835,6 @@ class SMAP(SMAPSessionMixin, DiskCacheMixin, SMAPCompositor):
     product = tl.Enum(SMAP_PRODUCT_MAP.coords["product"].data.tolist(), default_value="SPL4SMAU").tag(attr=True)
     version = tl.Int(allow_none=True).tag(attr=True)
     layer_key = tl.Unicode().tag(attr=True)
-    outputs = None  # this is necessary because of the source caching backup
-    output = None  # might as well
 
     date_url_re = re.compile(r"[0-9]{4}\.[0-9]{2}\.[0-9]{2}")
 


### PR DESCRIPTION
Currently Compositors automatic detect `outputs` from the `sources`, which causes deadlock or infinite recursion in fairly normal usage, including SMAP and COSMOS. The problem is quite hard to diagnose, and the workaround is to explicitly set `outputs = None` in these compositor nodes.

The proposed solution is to add factor out the automatic outputs detection into a mixin.

The workaround can be removed from SMAP and COSMOS, and then compositor child classes that want to autodetect multiple outputs from sources can enable this feature as follows:

```
class MyCompositor(podpac.compositor.AutoOutputs, podpac.compositor.OrderedCompositor):
    ...
```

*Note: either this PR or #388 should be merged, but not both.*