### PR TITLE
node definition loops and caching

### DIFF
--- a/podpac/core/cache/cache_ctrl.py
+++ b/podpac/core/cache/cache_ctrl.py
@@ -101,7 +101,7 @@ class CacheCtrl(object):
 
         return [c for c in self._cache_stores if mode in c.cache_modes]
 
-    def put(self, node, data, key, coordinates=None, mode=None, update=False):
+    def put(self, node, data, key, coordinates=None, mode=None, update=True):
         """Cache data for specified node.
         
         Parameters

--- a/podpac/core/cache/cache_ctrl.py
+++ b/podpac/core/cache/cache_ctrl.py
@@ -4,11 +4,17 @@ import six
 
 import podpac
 from podpac.core.settings import settings
-
 from podpac.core.cache.utils import CacheWildCard, CacheException
 from podpac.core.cache.ram_cache_store import RamCacheStore
 from podpac.core.cache.disk_cache_store import DiskCacheStore
 from podpac.core.cache.s3_cache_store import S3CacheStore
+
+
+_CACHE_STORES = {"ram": RamCacheStore, "disk": DiskCacheStore, "s3": S3CacheStore}
+
+_CACHE_NAMES = {RamCacheStore: "ram", DiskCacheStore: "disk", S3CacheStore: "s3"}
+
+_CACHE_MODES = ["ram", "disk", "network", "all"]
 
 
 def get_default_cache_ctrl():
@@ -27,46 +33,39 @@ def get_default_cache_ctrl():
     return make_cache_ctrl(settings["DEFAULT_CACHE"])
 
 
-def make_cache_ctrl(stores):
+def make_cache_ctrl(names):
     """
     Make a cache_ctrl from a list of cache store types.
 
     Arguments
     ---------
-    stores : str or list
-        cache store or stores, e.g. 'ram' or ['ram', 'disk'].
+    names : str or list
+        cache name or names, e.g. 'ram' or ['ram', 'disk'].
 
     Returns
     -------
     ctrl : CacheCtrl
-        CachCtrl using the specified cache stores
+        CachCtrl using the specified cache names
     """
 
-    if isinstance(stores, six.string_types):
-        stores = [stores]
+    if isinstance(names, six.string_types):
+        names = [names]
 
-    cache_stores = []
-    for elem in stores:
-        if elem == "ram":
-            cache_stores.append(RamCacheStore())
-        elif elem == "disk":
-            cache_stores.append(DiskCacheStore())
-        elif elem == "s3":
-            cache_stores.append(S3CacheStore())
-        else:
-            raise ValueError("Unknown cache store type '%s'" % elem)
+    for name in names:
+        if name not in _CACHE_STORES:
+            raise ValueError("Unknown cache store type '%s', options are %s" % (name, list(_CACHE_STORES)))
 
-    return CacheCtrl(cache_stores)
+    return CacheCtrl([_CACHE_STORES[name]() for name in names])
 
 
-def clear_cache(mode=None):
+def clear_cache(mode="all"):
     """
     Clear the entire default cache_ctrl.
 
     Arguments
     ---------
     mode : str
-        determines what types of the `CacheStore` are affected: 'ram','disk','network','all'.
+        determines what types of the `CacheStore` are affected. Options: 'ram', 'disk', 'network', 'all'. Default 'all'.
     """
 
     cache_ctrl = get_default_cache_ctrl()
@@ -88,20 +87,22 @@ class CacheCtrl(object):
         Parameters
         ----------
         cache_stores : list, optional
-            list of CacheStore objects to manage, in the order that they should be interogated.
+            list of CacheStore objects to manage, in the order that they should be interrogated.
         """
+
         self._cache_stores = cache_stores
-        self._cache_mode = None
 
-    def _get_cache_stores(self, mode):
-        if mode is None:
-            mode = self._cache_mode
-            if mode is None:
-                mode = "all"
+    def __repr__(self):
+        return "CacheCtrl(cache_stores=%s)" % self.cache_stores
 
+    @property
+    def cache_stores(self):
+        return [_CACHE_NAMES[store.__class__] for store in self._cache_stores]
+
+    def _get_cache_stores_by_mode(self, mode="all"):
         return [c for c in self._cache_stores if mode in c.cache_modes]
 
-    def put(self, node, data, key, coordinates=None, mode=None, update=True):
+    def put(self, node, data, key, coordinates=None, mode="all", update=True):
         """Cache data for specified node.
         
         Parameters
@@ -115,30 +116,30 @@ class CacheCtrl(object):
         coordinates : Coordinates, optional
             Coordinates for which cached object should be retrieved, for coordinate-dependent data such as evaluation output
         mode : str
-            determines what types of the `CacheStore` are affected: 'ram','disk','network','all'. Defaults to `node._cache_mode` or 'all'. Overriden by `self._cache_mode` if `self._cache_mode` is not `None`.
+            determines what types of the `CacheStore` are affected. Options: 'ram', 'disk', 'network', 'all'. Default 'all'.
         update : bool
             If True existing data in cache will be updated with `data`, If False, error will be thrown if attempting put something into the cache with the same node, key, coordinates of an existing entry.
         """
 
         if not isinstance(node, podpac.Node):
-            raise TypeError("node must of type 'Node', not '%s'" % type(Node))
+            raise TypeError("Invalid node (must be of type Node, not '%s')" % type(node))
 
         if not isinstance(key, six.string_types):
-            raise TypeError("key must be a string type, not '%s'" % (type(key)))
+            raise TypeError("Invalid key (must be a string, not '%s')" % (type(key)))
 
         if not isinstance(coordinates, podpac.Coordinates) and coordinates is not None:
-            raise TypeError("coordinates must be of type 'Coordinates', not '%s'" % type(coordinates))
+            raise TypeError("Invalid coordinates (must be of type 'Coordinates', not '%s')" % type(coordinates))
 
-        if not isinstance(mode, six.string_types) and mode is not None:
-            raise TypeError("mode must be of type 'str', not '%s'" % type(mode))
+        if mode not in _CACHE_MODES:
+            raise ValueError("Invalid mode (must be one of %s, not '%s')" % (_CACHE_MODES, mode))
 
         if key == "*":
-            raise ValueError("key cannot be '*'")
+            raise ValueError("Invalid key ('*' is reserved)")
 
-        for c in self._get_cache_stores(mode):
+        for c in self._get_cache_stores_by_mode(mode):
             c.put(node=node, data=data, key=key, coordinates=coordinates, update=update)
 
-    def get(self, node, key, coordinates=None, mode=None):
+    def get(self, node, key, coordinates=None, mode="all"):
         """Get cached data for this node.
         
         Parameters
@@ -150,7 +151,7 @@ class CacheCtrl(object):
         coordinates : Coordinates, optional
             Coordinates for which cached object should be retrieved, for coordinate-dependent data such as evaluation output
         mode : str
-            determines what types of the `CacheStore` are affected: 'ram','disk','network','all'. Defaults to `node._cache_mode` or 'all'. Overriden by `self._cache_mode` if `self._cache_mode` is not `None`.
+            determines what types of the `CacheStore` are affected. Options: 'ram', 'disk', 'network', 'all'. Default 'all'.
             
         Returns
         -------
@@ -164,26 +165,26 @@ class CacheCtrl(object):
         """
 
         if not isinstance(node, podpac.Node):
-            raise TypeError("node must of type 'Node', not '%s'" % type(Node))
+            raise TypeError("Invalid node (must be of type Node, not '%s')" % type(node))
 
         if not isinstance(key, six.string_types):
-            raise TypeError("key must be a string type, not '%s'" % (type(key)))
+            raise TypeError("Invalid key (must be a string, not '%s')" % (type(key)))
 
         if not isinstance(coordinates, podpac.Coordinates) and coordinates is not None:
-            raise TypeError("coordinates must be of type 'Coordinates', not '%s'" % type(coordinates))
+            raise TypeError("Invalid coordinates (must be of type 'Coordinates', not '%s')" % type(coordinates))
 
-        if not isinstance(mode, six.string_types) and mode is not None:
-            raise TypeError("mode must be of type 'str', not '%s'" % type(mode))
+        if mode not in _CACHE_MODES:
+            raise ValueError("Invalid mode (must be one of %s, not '%s')" % (_CACHE_MODES, mode))
 
         if key == "*":
-            raise ValueError("key cannot be '*'")
+            raise ValueError("Invalid key ('*' is reserved)")
 
-        for c in self._get_cache_stores(mode):
+        for c in self._get_cache_stores_by_mode(mode):
             if c.has(node=node, key=key, coordinates=coordinates):
                 return c.get(node=node, key=key, coordinates=coordinates)
         raise CacheException("Requested data is not in any cache stores.")
 
-    def has(self, node, key, coordinates=None, mode=None):
+    def has(self, node, key, coordinates=None, mode="all"):
         """Check for cached data for this node
         
         Parameters
@@ -195,7 +196,7 @@ class CacheCtrl(object):
         coordinates: Coordinate, optional
             Coordinates for which cached object should be checked
         mode : str
-            determines what types of the `CacheStore` are affected: 'ram','disk','network','all'. Defaults to `node._cache_mode` or 'all'. Overriden by `self._cache_mode` if `self._cache_mode` is not `None`.
+            determines what types of the `CacheStore` are affected. Options: 'ram', 'disk', 'network', 'all'. Default 'all'.
         
         Returns
         -------
@@ -204,27 +205,27 @@ class CacheCtrl(object):
         """
 
         if not isinstance(node, podpac.Node):
-            raise TypeError("node must of type 'Node', not '%s'" % type(Node))
+            raise TypeError("Invalid node (must be of type Node, not '%s')" % type(node))
 
         if not isinstance(key, six.string_types):
-            raise TypeError("key must be a string type, not '%s'" % (type(key)))
+            raise TypeError("Invalid key (must be a string, not '%s')" % (type(key)))
 
         if not isinstance(coordinates, podpac.Coordinates) and coordinates is not None:
-            raise TypeError("coordinates must be of type 'Coordinates', not '%s'" % type(coordinates))
+            raise TypeError("Invalid coordinates (must be of type 'Coordinates', not '%s')" % type(coordinates))
 
-        if not isinstance(mode, six.string_types) and mode is not None:
-            raise TypeError("mode must be of type 'str', not '%s'" % type(mode))
+        if mode not in _CACHE_MODES:
+            raise ValueError("Invalid mode (must be one of %s, not '%s')" % (_CACHE_MODES, mode))
 
         if key == "*":
-            raise ValueError("key cannot be '*'")
+            raise ValueError("Invalid key ('*' is reserved)")
 
-        for c in self._get_cache_stores(mode):
+        for c in self._get_cache_stores_by_mode(mode):
             if c.has(node=node, key=key, coordinates=coordinates):
                 return True
 
         return False
 
-    def rem(self, node, key, coordinates=None, mode=None):
+    def rem(self, node, key, coordinates=None, mode="all"):
         """Delete cached data for this node.
         
         Parameters
@@ -236,20 +237,20 @@ class CacheCtrl(object):
         coordinates : Coordinates, str
             Delete only cached objects for these coordinates. Use `'*'` to match all coordinates.
         mode : str
-            determines what types of the `CacheStore` are affected: 'ram','disk','network','all'. Defaults to `node._cache_mode` or 'all'. Overriden by `self._cache_mode` if `self._cache_mode` is not `None`.
+            determines what types of the `CacheStore` are affected. Options: 'ram', 'disk', 'network', 'all'. Default 'all'.
         """
 
         if not isinstance(node, podpac.Node):
-            raise TypeError("node must of type 'Node', not '%s'" % type(podpac.Node))
+            raise TypeError("Invalid node (must be of type Node, not '%s')" % type(node))
 
         if not isinstance(key, six.string_types):
-            raise TypeError("key must be a string type, not '%s'" % (type(key)))
+            raise TypeError("Invalid key (must be a string, not '%s')" % (type(key)))
 
         if not isinstance(coordinates, podpac.Coordinates) and coordinates is not None and coordinates != "*":
-            raise TypeError("coordinates must be '*' or of type 'Coordinates' not '%s'" % type(coordinates))
+            raise TypeError("Invalid coordinates (must be '*' or of type 'Coordinates', not '%s')" % type(coordinates))
 
-        if not isinstance(mode, six.string_types) and mode is not None:
-            raise TypeError("mode must be of type 'str', not '%s'" % type(mode))
+        if mode not in _CACHE_MODES:
+            raise ValueError("Invalid mode (must be one of %s, not '%s')" % (_CACHE_MODES, mode))
 
         if key == "*":
             key = CacheWildCard()
@@ -257,21 +258,21 @@ class CacheCtrl(object):
         if coordinates == "*":
             coordinates = CacheWildCard()
 
-        for c in self._get_cache_stores(mode):
+        for c in self._get_cache_stores_by_mode(mode):
             c.rem(node=node, key=key, coordinates=coordinates)
 
-    def clear(self, mode=None):
+    def clear(self, mode="all"):
         """
         Clear all cached data.
 
         Parameters
         ------------
         mode : str
-            determines what types of the `CacheStore` are affected: 'ram','disk','network','all'. Defaults to `node._cache_mode` or 'all'. Overriden by `self._cache_mode` if `self._cache_mode` is not `None`.
+            determines what types of the `CacheStore` are affected. Options: 'ram', 'disk', 'network', 'all'. Default 'all'.
         """
 
-        if not isinstance(mode, six.string_types) and mode is not None:
-            raise TypeError("mode must be of type 'str', not '%s'" % type(mode))
+        if mode not in _CACHE_MODES:
+            raise ValueError("Invalid mode (must be one of %s, not '%s')" % (_CACHE_MODES, mode))
 
-        for c in self._get_cache_stores(mode):
+        for c in self._get_cache_stores_by_mode(mode):
             c.clear()

--- a/podpac/core/cache/cache_store.py
+++ b/podpac/core/cache/cache_store.py
@@ -29,7 +29,7 @@ class CacheStore(object):
 
         raise NotImplementedError
 
-    def put(self, node, data, key, coordinates=None, update=False):
+    def put(self, node, data, key, coordinates=None, update=True):
         """Cache data for specified node.
         
         Parameters

--- a/podpac/core/cache/file_cache_store.py
+++ b/podpac/core/cache/file_cache_store.py
@@ -36,7 +36,7 @@ class FileCacheStore(CacheStore):
     # public cache API methods
     # -----------------------------------------------------------------------------------------------------------------
 
-    def put(self, node, data, key, coordinates=None, update=False):
+    def put(self, node, data, key, coordinates=None, update=True):
         """Cache data for specified node.
         
         Parameters
@@ -54,10 +54,10 @@ class FileCacheStore(CacheStore):
         """
 
         # check for existing entry
-        if self.has(node, key, coordinates):
-            if not update:
-                raise CacheException("Cache entry already exists. Use `update=True` to overwrite.")
-            self.rem(node, key, coordinates)
+        if not update and self.has(node, key, coordinates):
+            raise CacheException("Cache entry already exists. Use `update=True` to overwrite.")
+
+        self.rem(node, key, coordinates)
 
         # serialize
         path_root = self._path_join(self._get_node_dir(node), self._get_filename(node, key, coordinates))

--- a/podpac/core/cache/ram_cache_store.py
+++ b/podpac/core/cache/ram_cache_store.py
@@ -55,7 +55,7 @@ class RamCacheStore(CacheStore):
         process = psutil.Process(os.getpid())
         return process.memory_info().rss  # this is actually the total size of the process
 
-    def put(self, node, data, key, coordinates=None, update=False):
+    def put(self, node, data, key, coordinates=None, update=True):
         """Cache data for specified node.
         
         Parameters
@@ -77,9 +77,10 @@ class RamCacheStore(CacheStore):
 
         full_key = self._get_full_key(node, key, coordinates)
 
-        if full_key in _thread_local.cache:
-            if not update:
-                raise CacheException("Cache entry already exists. Use update=True to overwrite.")
+        if not update and full_key in _thread_local.cache:
+            raise CacheException("Cache entry already exists. Use update=True to overwrite.")
+
+        self.rem(node, key, coordinates)
 
         if self.max_size is not None and self.size >= self.max_size:
             #     # TODO removal policy

--- a/podpac/core/cache/test/test_cache_ctrl.py
+++ b/podpac/core/cache/test/test_cache_ctrl.py
@@ -9,18 +9,245 @@ from podpac.core.cache.cache_ctrl import CacheCtrl
 from podpac.core.cache.cache_ctrl import get_default_cache_ctrl, make_cache_ctrl, clear_cache
 
 
+class CacheCtrlTestNode(podpac.Node):
+    pass
+
+
+NODE = CacheCtrlTestNode()
+
+
 class TestCacheCtrl(object):
-    def test_init(self):
+    def test_init_default(self):
+        ctrl = CacheCtrl()
+        assert len(ctrl._cache_stores) == 0
+        assert ctrl.cache_stores == []
+        repr(ctrl)
+
+    def test_init_list(self):
+        ctrl = CacheCtrl(cache_stores=[])
+        assert len(ctrl._cache_stores) == 0
+        assert ctrl.cache_stores == []
+        repr(ctrl)
+
+        ctrl = CacheCtrl(cache_stores=[RamCacheStore()])
+        assert len(ctrl._cache_stores) == 1
+        assert isinstance(ctrl._cache_stores[0], RamCacheStore)
+        assert ctrl.cache_stores == ["ram"]
+        repr(ctrl)
+
+        ctrl = CacheCtrl(cache_stores=[RamCacheStore(), DiskCacheStore()])
+        assert len(ctrl._cache_stores) == 2
+        assert isinstance(ctrl._cache_stores[0], RamCacheStore)
+        assert isinstance(ctrl._cache_stores[1], DiskCacheStore)
+        assert ctrl.cache_stores == ["ram", "disk"]
+        repr(ctrl)
+
+    def test_put_has_get(self):
+        ctrl = CacheCtrl(cache_stores=[RamCacheStore(), DiskCacheStore()])
+        ctrl.clear()
+
+        # has False
+        assert not ctrl._cache_stores[0].has(NODE, "key")
+        assert not ctrl._cache_stores[1].has(NODE, "key")
+        assert not ctrl.has(NODE, "key")
+
+        # put
+        ctrl.put(NODE, 10, "key")
+
+        # has True
+        assert ctrl._cache_stores[0].has(NODE, "key")
+        assert ctrl._cache_stores[1].has(NODE, "key")
+        assert ctrl.has(NODE, "key")
+
+        # get value
+        assert ctrl._cache_stores[0].get(NODE, "key") == 10
+        assert ctrl._cache_stores[1].get(NODE, "key") == 10
+        assert ctrl.get(NODE, "key") == 10
+
+    def test_partial_has_get(self):
+        ctrl = CacheCtrl(cache_stores=[RamCacheStore(), DiskCacheStore()])
+        ctrl.clear()
+
+        # has False
+        assert not ctrl._cache_stores[0].has(NODE, "key")
+        assert not ctrl._cache_stores[1].has(NODE, "key")
+        assert not ctrl.has(NODE, "key")
+
+        # put only in disk
+        ctrl._cache_stores[1].put(NODE, 10, "key")
+
+        # has
+        assert not ctrl._cache_stores[0].has(NODE, "key")
+        assert ctrl._cache_stores[1].has(NODE, "key")
+        assert ctrl.has(NODE, "key")
+
+        # get
+        with pytest.raises(CacheException, match="Cache miss"):
+            ctrl._cache_stores[0].get(NODE, "key")
+        assert ctrl._cache_stores[1].get(NODE, "key") == 10
+        assert ctrl.get(NODE, "key") == 10
+
+    def test_get_cache_miss(self):
+        ctrl = CacheCtrl(cache_stores=[RamCacheStore(), DiskCacheStore()])
+        ctrl.clear()
+
+        with pytest.raises(CacheException, match="Requested data is not in any cache stores"):
+            ctrl.get(NODE, "key")
+
+    def test_put_rem(self):
+        ctrl = CacheCtrl(cache_stores=[RamCacheStore(), DiskCacheStore()])
+
+        # put and check has
+        ctrl.put(NODE, 10, "key")
+        assert ctrl.has(NODE, "key")
+
+        # rem other and check has
+        ctrl.rem(NODE, "other")
+        assert ctrl.has(NODE, "key")
+
+        # rem and check has
+        ctrl.rem(NODE, "key")
+        assert not ctrl.has(NODE, "key")
+
+    def test_rem_wildcard_key(self):
+        ctrl = CacheCtrl(cache_stores=[RamCacheStore(), DiskCacheStore()])
+
+        # put and check has
+        ctrl.put(NODE, 10, "key")
+        assert ctrl.has(NODE, "key")
+
+        # rem other and check has
+        ctrl.rem(NODE, key="*")
+        assert not ctrl.has(NODE, "key")
+
+    def test_rem_wildcard_coordinates(self):
         pass
+
+    def test_put_clear(self):
+        ctrl = CacheCtrl(cache_stores=[RamCacheStore(), DiskCacheStore()])
+
+        # put and check has
+        ctrl.put(NODE, 10, "key")
+        assert ctrl.has(NODE, "key")
+
+        # clear and check has
+        ctrl.clear()
+
+        # check has
+        assert not ctrl.has(NODE, "key")
+
+    def test_put_has_mode(self):
+        ctrl = CacheCtrl(cache_stores=[RamCacheStore(), DiskCacheStore()])
+
+        # put disk and check has
+        ctrl.clear()
+        assert not ctrl.has(NODE, "key")
+
+        ctrl.put(NODE, 10, "key", mode="disk")
+        assert not ctrl._cache_stores[0].has(NODE, "key")
+        assert not ctrl.has(NODE, "key", mode="ram")
+        assert ctrl._cache_stores[1].has(NODE, "key")
+        assert ctrl.has(NODE, "key", mode="disk")
+        assert ctrl.has(NODE, "key")
+
+        # put ram and check has
+        ctrl.clear()
+        assert not ctrl.has(NODE, "key")
+
+        ctrl.put(NODE, 10, "key", mode="ram")
+        assert ctrl._cache_stores[0].has(NODE, "key")
+        assert ctrl.has(NODE, "key", mode="ram")
+        assert not ctrl._cache_stores[1].has(NODE, "key")
+        assert not ctrl.has(NODE, "key", mode="disk")
+        assert ctrl.has(NODE, "key")
+
+    def test_invalid_node(self):
+        ctrl = CacheCtrl(cache_stores=[RamCacheStore(), DiskCacheStore()])
+
+        # type
+        with pytest.raises(TypeError, match="Invalid node"):
+            ctrl.put("node", 10, "key")
+
+        with pytest.raises(TypeError, match="Invalid node"):
+            ctrl.get("node", "key")
+
+        with pytest.raises(TypeError, match="Invalid node"):
+            ctrl.has("node", "key")
+
+        with pytest.raises(TypeError, match="Invalid node"):
+            ctrl.rem("node", "key")
+
+    def test_invalid_key(self):
+        ctrl = CacheCtrl(cache_stores=[RamCacheStore(), DiskCacheStore()])
+
+        # type
+        with pytest.raises(TypeError, match="Invalid key"):
+            ctrl.put(NODE, 10, 10)
+
+        with pytest.raises(TypeError, match="Invalid key"):
+            ctrl.get(NODE, 10)
+
+        with pytest.raises(TypeError, match="Invalid key"):
+            ctrl.has(NODE, 10)
+
+        with pytest.raises(TypeError, match="Invalid key"):
+            ctrl.rem(NODE, 10)
+
+        # wildcard
+        with pytest.raises(ValueError, match="Invalid key"):
+            ctrl.put(NODE, 10, "*")
+
+        with pytest.raises(ValueError, match="Invalid key"):
+            ctrl.get(NODE, "*")
+
+        with pytest.raises(ValueError, match="Invalid key"):
+            ctrl.has(NODE, "*")
+
+        # allowed
+        ctrl.rem(NODE, "*")
+
+    def test_invalid_coordinates(self):
+        ctrl = CacheCtrl(cache_stores=[RamCacheStore(), DiskCacheStore()])
+
+        # type
+        with pytest.raises(TypeError, match="Invalid coordinates"):
+            ctrl.put(NODE, 10, "key", coordinates="coords")
+
+        with pytest.raises(TypeError, match="Invalid coordinates"):
+            ctrl.get(NODE, "key", coordinates="coords")
+
+        with pytest.raises(TypeError, match="Invalid coordinates"):
+            ctrl.has(NODE, "key", coordinates="coords")
+
+        with pytest.raises(TypeError, match="Invalid coordinates"):
+            ctrl.rem(NODE, "key", coordinates="coords")
+
+    def test_invalid_mode(self):
+        ctrl = CacheCtrl(cache_stores=[RamCacheStore(), DiskCacheStore()])
+
+        with pytest.raises(ValueError, match="Invalid mode"):
+            ctrl.put(NODE, 10, "key", mode="other")
+
+        with pytest.raises(ValueError, match="Invalid mode"):
+            ctrl.get(NODE, "key", mode="other")
+
+        with pytest.raises(ValueError, match="Invalid mode"):
+            ctrl.has(NODE, "key", mode="other")
+
+        with pytest.raises(ValueError, match="Invalid mode"):
+            ctrl.rem(NODE, "key", mode="other")
+
+        with pytest.raises(ValueError, match="Invalid mode"):
+            ctrl.clear(mode="other")
 
 
 def test_get_default_cache_ctrl():
-    ctrl = get_default_cache_ctrl()
-
-    assert isinstance(ctrl, CacheCtrl)
-    assert ctrl._cache_stores == []
-
     with podpac.settings:
+        podpac.settings["DEFAULT_CACHE"] = []
+        ctrl = get_default_cache_ctrl()
+        assert isinstance(ctrl, CacheCtrl)
+        assert ctrl._cache_stores == []
+
         podpac.settings["DEFAULT_CACHE"] = ["ram"]
         ctrl = get_default_cache_ctrl()
         assert isinstance(ctrl, CacheCtrl)
@@ -28,35 +255,47 @@ def test_get_default_cache_ctrl():
         assert isinstance(ctrl._cache_stores[0], RamCacheStore)
 
 
-def test_make_cache_ctrl():
-    ctrl = make_cache_ctrl("ram")
-    assert isinstance(ctrl, CacheCtrl)
-    assert len(ctrl._cache_stores) == 1
-    assert isinstance(ctrl._cache_stores[0], RamCacheStore)
+class TestMakeCacheCtrl(object):
+    def test_str(self):
+        ctrl = make_cache_ctrl("ram")
+        assert isinstance(ctrl, CacheCtrl)
+        assert len(ctrl._cache_stores) == 1
+        assert isinstance(ctrl._cache_stores[0], RamCacheStore)
 
-    ctrl = make_cache_ctrl("disk")
-    assert len(ctrl._cache_stores) == 1
-    assert isinstance(ctrl._cache_stores[0], DiskCacheStore)
+        ctrl = make_cache_ctrl("disk")
+        assert len(ctrl._cache_stores) == 1
+        assert isinstance(ctrl._cache_stores[0], DiskCacheStore)
 
-    ctrl = make_cache_ctrl(["ram", "disk"])
-    assert len(ctrl._cache_stores) == 2
-    assert isinstance(ctrl._cache_stores[0], RamCacheStore)
-    assert isinstance(ctrl._cache_stores[1], DiskCacheStore)
+    def test_list(self):
+        ctrl = make_cache_ctrl(["ram", "disk"])
+        assert len(ctrl._cache_stores) == 2
+        assert isinstance(ctrl._cache_stores[0], RamCacheStore)
+        assert isinstance(ctrl._cache_stores[1], DiskCacheStore)
 
-    with pytest.raises(ValueError, match="Unknown cache store type"):
-        ctrl = make_cache_ctrl("other")
+        ctrl = make_cache_ctrl(["ram", "disk"])
+        assert len(ctrl._cache_stores) == 2
+        assert isinstance(ctrl._cache_stores[0], RamCacheStore)
+        assert isinstance(ctrl._cache_stores[1], DiskCacheStore)
+
+    def test_invalid(self):
+        with pytest.raises(ValueError, match="Unknown cache store type"):
+            ctrl = make_cache_ctrl("other")
+
+        with pytest.raises(ValueError, match="Unknown cache store type"):
+            ctrl = make_cache_ctrl(["other"])
 
 
-def test_clear_cache():
-    with podpac.settings:
-        # make a default cache
-        podpac.settings["DEFAULT_CACHE"] = ["ram"]
+class TestClearCache(object):
+    def test_clear_cache(self):
+        with podpac.settings:
+            # make a default cache
+            podpac.settings["DEFAULT_CACHE"] = ["ram"]
 
-        # fill the default cache
-        node = podpac.algorithm.Arange()
-        node.put_cache(0, "mykey")
-        assert node.has_cache("mykey")
+            # fill the default cache
+            node = podpac.algorithm.Arange()
+            node.put_cache(0, "mykey")
+            assert node.has_cache("mykey")
 
-        clear_cache()
+            clear_cache()
 
-        assert not node.has_cache("mykey")
+            assert not node.has_cache("mykey")

--- a/podpac/core/cache/test/test_cache_stores.py
+++ b/podpac/core/cache/test/test_cache_stores.py
@@ -87,11 +87,11 @@ class BaseCacheStoreTests(object):
 
         # raise exception and do not change
         with pytest.raises(CacheException, match="Cache entry already exists."):
-            store.put(NODE1, 10, "mykey1")
+            store.put(NODE1, 10, "mykey1", update=False)
         assert store.get(NODE1, "mykey1") == 10
 
         # update
-        store.put(NODE1, 20, "mykey1", update=True)
+        store.put(NODE1, 20, "mykey1")
         assert store.get(NODE1, "mykey1") == 20
 
     def test_get_put_none(self):

--- a/podpac/core/data/csv_source.py
+++ b/podpac/core/data/csv_source.py
@@ -68,6 +68,13 @@ class CSV(FileKeysMixin, LoadFileMixin, BaseFileSource):
 
         return d["value"]
 
+    @tl.default("outputs")
+    def _default_outputs(self):
+        if not isinstance(self.data_key, list):
+            return None
+        else:
+            return [self._get_key(elem) for elem in self.data_key]
+
     # -------------------------------------------------------------------------
     # public api methods
     # -------------------------------------------------------------------------

--- a/podpac/core/data/ogc.py
+++ b/podpac/core/data/ogc.py
@@ -262,7 +262,7 @@ class WCS(DataSource):
                         with rasterio.open(io) as dataset:
                             output.data[i, ...] = dataset.read()
                     except Exception as e:  # Probably python 2
-                        print(e)
+                        print (e)
                         tmppath = os.path.join(settings["DISK_CACHE_DIR"], "wcs_temp.tiff")
 
                         if not os.path.exists(os.path.split(tmppath)[0]):
@@ -332,7 +332,7 @@ class WCS(DataSource):
                         else:
                             output.data[:] = dataset.read()
                 except Exception as e:  # Probably python 2
-                    print(e)
+                    print (e)
                     tmppath = os.path.join(settings["DISK_CACHE_DIR"], "wcs_temp.tiff")
                     if not os.path.exists(os.path.split(tmppath)[0]):
                         os.makedirs(os.path.split(tmppath)[0])
@@ -360,4 +360,7 @@ class WCS(DataSource):
     @property
     def base_ref(self):
         """ definition base_ref """
+        if not self.layer_name:
+            return super(WCS, self).base_ref
+
         return self.layer_name.rsplit(".", 1)[1]

--- a/podpac/core/data/test/test_csv.py
+++ b/podpac/core/data/test/test_csv.py
@@ -111,10 +111,13 @@ class TestCSV(object):
         # specify multiple
         node = CSV(source=self.source_multiple, data_key=[4, 5], alt_key="altitude", crs="+proj=merc +vunits=m")
         assert node.data_key == [4, 5]
+        assert node.outputs == ["data", "other"]
 
         # specify one
         node = CSV(source=self.source_multiple, data_key=4, alt_key="altitude", crs="+proj=merc +vunits=m")
+
         assert node.data_key == 4
+        assert node.outputs is None
 
         # specify multiple: invalid item
         with pytest.raises(ValueError, match="Invalid data_key"):

--- a/podpac/core/data/test/test_file_source.py
+++ b/podpac/core/data/test/test_file_source.py
@@ -81,7 +81,7 @@ class TestLoadFile(object):
         node = MockLoadFile(source="file:///%s" % path)
         node.dataset
 
-    def test_cache(self):
+    def test_cache_dataset(self):
         path = os.path.join(os.path.dirname(__file__), "assets/points-single.csv")
 
         with podpac.settings:
@@ -90,11 +90,11 @@ class TestLoadFile(object):
             node.dataset
 
             # node caches dataset object
-            assert node.has_cache("dataset")
+            assert node._dataset_caching_node.has_cache("dataset")
 
             # another node can get cached object
             node2 = MockLoadFile(source="file:///%s" % path)
-            assert node2.has_cache("dataset")
+            assert node2._dataset_caching_node.has_cache("dataset")
             node2.dataset
 
 

--- a/podpac/core/node.py
+++ b/podpac/core/node.py
@@ -580,7 +580,7 @@ class Node(tl.HasTraits):
         with thread_manager.cache_lock:
             return self.cache_ctrl.has(self, key, coordinates=coordinates)
 
-    def rem_cache(self, key, coordinates=None, mode=None):
+    def rem_cache(self, key, coordinates=None, mode="all"):
         """
         Clear cached data for this node.
 


### PR DESCRIPTION
 * raise a `NodeDefinitionError` when a circular node definition is detected
 * raise a `NodeDefinitionError` when the node definition is accessed before the node traits are fully initialized
 * catch `NodeDefinitionError` in node caching methods and add a more informative message, including the `key`
 * cache put methods overwrite/update the cache by default
 * `LoadFileMixin` caches the `dataset` independent of the other node attrs (such as `interpolation` or `data_key`).
 * `Node.__init__` calls the `tl.HasTraits.__init__` *within* the `hold_trait_notifications` context in order to avoid calling some validation methods before other traits have even ben initialized.
 * CacheCtrl is cleaned up, with bugfixes and tests
 * small bugfixes in CSV and WCS nodes

The circular node definition handling prevents the cache deadlock. Then I had to change `LoadFileMixin` dataset caching in order to avoid hitting those exceptions, and it is better now. As a result, we do not have to remove the lock in `has_cache` if we don't want to.

Note also that I did not return `False` in `has_cache` when the `NodeDefinitionError` occurs, as we discussed. If that error is reached, the code trying to use the cache will *never* succeed. It is not like it is going to succeed in another state. The user should just not be caching that object, or needs to find another way/place to cache it. (Same for `put_cache`, etc).

Note also that I did not have to omit default traits from the node definition, so I did not yet add the podpac version to the definition.

The meat of this PR is in commit a425106.