### PR TITLE
ENH: Add podpac version to node definition.

### DIFF
--- a/podpac/core/algorithm/generic.py
+++ b/podpac/core/algorithm/generic.py
@@ -33,6 +33,8 @@ class GenericInputs(Algorithm):
 
     inputs = tl.Dict(read_only=True)
 
+    _repr_keys = ["inputs"]
+
     def _first_init(self, **kwargs):
         trait_names = self.trait_names()
         for key in kwargs:
@@ -62,6 +64,8 @@ class Arithmetic(GenericInputs):
 
     eqn = tl.Unicode().tag(attr=True)
     params = tl.Dict().tag(attr=True)
+
+    _repr_keys = ["eqn"]
 
     def init(self):
         if not settings.allow_unsafe_eval:
@@ -158,7 +162,7 @@ class Generic(GenericInputs):
                 "NOTE: Allowing unsafe evaluation enables arbitrary execution of Python code through PODPAC "
                 "Node definitions."
             )
-        exec(self.code, inputs)
+        exec (self.code, inputs)
         return inputs["output"]
 
 
@@ -206,6 +210,8 @@ class Mask(Algorithm):
     bool_val = tl.Float(1).tag(attr=True)
     bool_op = tl.Enum(["==", "<", "<=", ">", ">="], default_value="==").tag(attr=True)
     in_place = tl.Bool(False).tag(attr=True)
+
+    _repr_keys = ["source", "mask"]
 
     def algorithm(self, inputs):
         """ Sets the values in inputs['source'] to self.masked_val using (inputs['mask'] <self.bool_op> <self.bool_val>)

--- a/podpac/core/node.py
+++ b/podpac/core/node.py
@@ -392,7 +392,7 @@ class Node(tl.HasTraits):
 
         return d
 
-    @property
+    @cached_property
     def definition(self):
         """
         Full node definition.
@@ -487,7 +487,8 @@ class Node(tl.HasTraits):
     def hash(self):
         """ hash for this node, used in caching and to determine equality. """
 
-        d = self.definition
+        # deepcopy so that the cached definition property is not modified by the deletes below
+        d = deepcopy(self.definition)
 
         # omit version
         if "podpac_version" in d:

--- a/podpac/core/node.py
+++ b/podpac/core/node.py
@@ -9,6 +9,7 @@ import functools
 import json
 import inspect
 import importlib
+import warnings
 from collections import OrderedDict
 from copy import deepcopy
 from hashlib import md5 as hash_alg
@@ -17,6 +18,7 @@ import numpy as np
 import traitlets as tl
 import six
 
+import podpac
 from podpac.core.settings import settings
 from podpac.core.units import ureg, UnitsDataArray
 from podpac.core.utils import common_doc
@@ -385,12 +387,12 @@ class Node(tl.HasTraits):
             d["inputs"] = inputs
 
         # style
-        if self.style != Style() and self.style.definition:
+        if self.style.definition:
             d["style"] = self.style.definition
 
         return d
 
-    @cached_property
+    @property
     def definition(self):
         """
         Full node definition.
@@ -407,12 +409,12 @@ class Node(tl.HasTraits):
         if not getattr(self, "_traits_initialized_guard", False):
             raise NodeDefinitionError("node is not yet fully initialized")
 
-        nodes = []
-        refs = []
-        definitions = []
-
         try:
             self._definition_guard = True
+
+            nodes = []
+            refs = []
+            definitions = []
 
             def add_node(node):
                 for ref, n in zip(refs, nodes):
@@ -462,6 +464,7 @@ class Node(tl.HasTraits):
 
             # finalize, verify serializable, and return
             definition = OrderedDict(zip(refs, definitions))
+            definition["podpac_version"] = podpac.__version__
             json.dumps(definition, cls=JSONEncoder)
             return definition
 
@@ -470,29 +473,33 @@ class Node(tl.HasTraits):
 
     @cached_property
     def json(self):
-        """definition for this node in json format
+        """Definition for this node in JSON format."""
 
-        Returns
-        -------
-        str
-            JSON-formatted node definition.
-        """
         return json.dumps(self.definition, separators=(",", ":"), cls=JSONEncoder)
 
     @cached_property
     def json_pretty(self):
+        """Definition for this node in JSON format, with indentation suitable for display."""
+
         return json.dumps(self.definition, indent=4, cls=JSONEncoder)
 
     @cached_property
     def hash(self):
-        # Style should not be part of the hash
-        defn = self.json
+        """ hash for this node, used in caching and to determine equality. """
 
-        # Note: this ONLY works because the Style node has NO dictionaries as part
-        # of its attributes
-        hashstr = re.sub(r'"style":\{.*?\},?', "", defn)
+        d = self.definition
 
-        return hash_alg(hashstr.encode("utf-8")).hexdigest()
+        # omit version
+        if "podpac_version" in d:
+            del d["podpac_version"]
+
+        # omit style in every node
+        for k in d:
+            if "style" in d[k]:
+                del d[k]["style"]
+
+        s = json.dumps(d, separators=(",", ":"), cls=JSONEncoder)
+        return hash_alg(s.encode("utf-8")).hexdigest()
 
     def save(self, path):
         """
@@ -676,12 +683,22 @@ class Node(tl.HasTraits):
         load : create a node from file
         """
 
+        if "podpac_version" in definition and definition["podpac_version"] != podpac.__version__:
+            warnings.warn(
+                "node definition version mismatch "
+                "(this node was created with podpac version '%s', "
+                "but your current podpac version is '%s')" % (definition["podpac_version"], podpac.__version__)
+            )
+
         if len(definition) == 0:
             raise ValueError("Invalid definition: definition cannot be empty.")
 
         # parse node definitions in order
         nodes = OrderedDict()
         for name, d in definition.items():
+            if name == "podpac_version":
+                continue
+
             if "node" not in d:
                 raise ValueError("Invalid definition for node '%s': 'node' property required" % name)
 

--- a/podpac/core/test/test_node.py
+++ b/podpac/core/test/test_node.py
@@ -727,6 +727,14 @@ class TestSerialization(object):
         assert n1.hash != n3.hash
         assert n1.hash != m1.hash
 
+    def test_hash_preserves_definition(self):
+        n = Node()
+        d_before = deepcopy(n.definition)
+        h = n.hash
+        d_after = deepcopy(n.definition)
+
+        assert d_before == d_after
+
     def test_hash_omit_style(self):
         class N(Node):
             my_attr = tl.Int().tag(attr=True)

--- a/podpac/core/utils.py
+++ b/podpac/core/utils.py
@@ -10,17 +10,17 @@ import json
 import datetime
 import functools
 import importlib
-from collections import OrderedDict
 import logging
+from collections import OrderedDict
 from copy import deepcopy
-from six import string_types
-import lazy_import
 
 try:
     import urllib.parse as urllib
 except:  # Python 2.7
     import urlparse as urllib
 
+from six import string_types
+import lazy_import
 import traitlets as tl
 import numpy as np
 import xarray as xr


### PR DESCRIPTION
 * Adds `"podpac_version"` to the node definition.
 * Warns about mismatching version when deserializing.
 * Omit hash (and style) from hash.

One question: since `__eq__` uses the hash, two nodes can be equal (as in `==`) even if their styles are different. I just want to check if that is what you want, or should equality depend on the json instead (which still includes the style)?

closes #390 