### PR TITLE
Remove Compositor extra dims using composite_dims

### DIFF
--- a/podpac/compositor.py
+++ b/podpac/compositor.py
@@ -5,4 +5,4 @@ Compositor Public Module
 # REMINDER: update api docs (doc/source/user/api.rst) to reflect changes to this file
 
 from podpac.core.compositor.ordered_compositor import OrderedCompositor
-from podpac.core.compositor.tile_compositor import UniformTileCompositor, UniformTileMixin
+from podpac.core.compositor.tile_compositor import UniformTileCompositor, UniformTileMixin, TileCompositor

--- a/podpac/core/compositor/compositor.py
+++ b/podpac/core/compositor/compositor.py
@@ -53,7 +53,7 @@ class BaseCompositor(Node):
     interpolation = InterpolationTrait(allow_none=True, default_value=None).tag(attr=True)
     source_coordinates = tl.Instance(Coordinates, allow_none=True, default_value=None).tag(attr=True)
 
-    composite_dims = tl.List(trait=Dimension())
+    dims = tl.List(trait=Dimension()).tag(attr=True)
     auto_outputs = tl.Bool(False)
 
     # debug traits
@@ -241,13 +241,14 @@ class BaseCompositor(Node):
         self._requested_coordinates = coordinates
 
         # remove extra dimensions
-        extra = [
-            c.name
-            for c in coordinates.values()
-            if (isinstance(c, Coordinates1d) and c.name not in self.composite_dims)
-            or (isinstance(c, StackedCoordinates) and all(dim not in self.composite_dims for dim in c.dims))
-        ]
-        coordinates = coordinates.drop(extra)
+        if self.dims:
+            extra = [
+                c.name
+                for c in coordinates.values()
+                if (isinstance(c, Coordinates1d) and c.name not in self.dims)
+                or (isinstance(c, StackedCoordinates) and all(dim not in self.dims for dim in c.dims))
+            ]
+            coordinates = coordinates.drop(extra)
 
         self._evaluated_coordinates = coordinates
         outputs = self.iteroutputs(coordinates)

--- a/podpac/core/compositor/ordered_compositor.py
+++ b/podpac/core/compositor/ordered_compositor.py
@@ -2,7 +2,7 @@ from __future__ import division, unicode_literals, print_function, absolute_impo
 
 import numpy as np
 
-# Internal imports
+from podpac.core.node import NodeException
 from podpac.core.units import UnitsDataArray
 from podpac.core.utils import common_doc
 from podpac.core.compositor.compositor import COMMON_COMPOSITOR_DOC, BaseCompositor
@@ -50,7 +50,15 @@ class OrderedCompositor(BaseCompositor):
         mask = UnitsDataArray.create(coordinates, outputs=self.outputs, data=0, dtype=bool)
         for data in data_arrays:
             if self.outputs is None:
-                data = data.transpose(*result.dims)
+                try:
+                    data = data.transpose(*result.dims)
+                except ValueError:
+                    raise NodeException(
+                        "Cannot evaluate compositor with requested dims %s. "
+                        "The compositor source dims are %s. "
+                        "Specify the compositor 'dims' attribute to ignore extra requested dims."
+                        % (coordinates.dims, data.dims)
+                    )
                 self._composite(result, data, mask)
             else:
                 for name in data["output"]:

--- a/podpac/core/compositor/test/test_base_compositor.py
+++ b/podpac/core/compositor/test/test_base_compositor.py
@@ -215,6 +215,17 @@ class TestBaseCompositor(object):
         np.testing.assert_array_equal(node.eval(coords), a.source)
         np.testing.assert_array_equal(node.eval(COORDS), a.source)
 
+        # drop stacked dimensions if none of its dimensions are needed
+        c = podpac.Coordinates(
+            [COORDS["lat"], COORDS["lon"], [COORDS["time"], [10, 20]]], dims=["lat", "lon", "time_alt"]
+        )
+        np.testing.assert_array_equal(node.eval(c), a.source)
+
+        # TODO
+        # but don't drop stacked dimensions if any of its dimensions are needed
+        # c = podpac.Coordinates([[COORDS['lat'], COORDS['lon'], np.arange(COORDS['lat'].size)]], dims=['lat_lon_alt'])
+        # np.testing.assert_array_equal(node.eval(c), np.ones(COORDS['lat'].size))
+
         # dims can also be specified by the node
         class MockComposite2(MockComposite):
             dims = ["lat", "lon"]

--- a/podpac/core/compositor/tile_compositor.py
+++ b/podpac/core/compositor/tile_compositor.py
@@ -41,11 +41,11 @@ class TileCompositor(DataSource):
 
         output = self.create_output_array(coordinates)
         for source in self.sources:
-            c, I = source.coordinates.intersect(coordinates, return_indices=True)
+            c, I = source.coordinates.intersect(coordinates, outer=True, return_indices=True)
             if c.size == 0:
                 continue
             source_data = source.get_data(c, I)
-            output.loc[source_data.coords] = source_data
+            output.loc[source_data.coords] = source_data.data
 
         return output
 

--- a/podpac/core/data/datasource.py
+++ b/podpac/core/data/datasource.py
@@ -382,14 +382,12 @@ class DataSource(Node):
                     raise ValueError("Cannot evaluate these coordinates, missing at least one dim in '%s'" % c.name)
 
         # remove extra dimensions
-        extra = []
-        for c in coordinates.values():
-            if isinstance(c, Coordinates1d):
-                if c.name not in self.coordinates.udims:
-                    extra.append(c.name)
-            elif isinstance(c, StackedCoordinates):
-                if all(dim not in self.coordinates.udims for dim in c.dims):
-                    extra.append(c.name)
+        extra = [
+            c.name
+            for c in coordinates.values()
+            if (isinstance(c, Coordinates1d) and c.name not in self.coordinates.udims)
+            or (isinstance(c, StackedCoordinates) and all(dim not in self.coordinates.udims for dim in c.dims))
+        ]
         coordinates = coordinates.drop(extra)
 
         # store input coordinates to evaluated coordinates

--- a/podpac/core/data/test/test_datasource.py
+++ b/podpac/core/data/test/test_datasource.py
@@ -385,6 +385,7 @@ class TestDataSource(object):
         output = node.eval(coords)
         assert output.dims == ("time",)  # lat_lon dropped
 
+        # TODO
         # but don't drop extra stacked dimension if any of its dimensions are needed
         # output = node.eval(Coordinates([[1, 11, '2018-01-01']], dims=['lat_lon_time']))
         # assert output.dims == ('lat_lon_time') # lat and lon not dropped

--- a/podpac/datalib/modis_pds.py
+++ b/podpac/datalib/modis_pds.py
@@ -124,7 +124,7 @@ class MODISSource(Rasterio):
     vertical = tl.Unicode(help="row in the MODIS Sinusoidal Tiling System, e.g. '07'").tag(attr=True)
     date = tl.Unicode(help="year and three-digit day of year, e.g. '2011460'").tag(attr=True)
     data_key = tl.Unicode(help="data to retrieve (varies by product)").tag(attr=True)
-
+    anon = tl.Bool(True)
     check_exists = tl.Bool(True)
 
     _repr_keys = ["prefix", "data_key"]
@@ -181,7 +181,7 @@ class MODISTile(S3Mixin, DataSource):
     horizontal = tl.Unicode(help="column in the MODIS Sinusoidal Tiling System, e.g. '21'").tag(attr=True)
     vertical = tl.Unicode(help="row in the MODIS Sinusoidal Tiling System, e.g. '07'").tag(attr=True)
     data_key = tl.Unicode(help="data to retrieve (varies by product)").tag(attr=True)
-
+    anon = tl.Bool(True)
     _repr_keys = ["product", "data_key"]
 
     @cached_property
@@ -243,6 +243,7 @@ class MODIS(S3Mixin, OrderedCompositor):
     tile_width = (1, 2400, 2400)
     start_date = "2013-01-01"
     end_date = datetime.date.today().strftime("%Y-%m-%d")
+    anon = tl.Bool(True)
 
     _repr_keys = ["product", "data_key"]
 

--- a/podpac/datalib/terraintiles.py
+++ b/podpac/datalib/terraintiles.py
@@ -149,6 +149,7 @@ class TerrainTiles(OrderedCompositor):
     tile_format = tl.Enum(["geotiff", "terrarium", "normal"], default_value="geotiff").tag(attr=True)
     bucket = tl.Unicode(default_value="elevation-tiles-prod").tag(attr=True)
     sources = None  # these are loaded as needed
+    composite_dims = ["lat", "lon"]
 
     def select_sources(self, coordinates):
         # get all the tile sources for the requested zoom level and coordinates

--- a/podpac/datalib/terraintiles.py
+++ b/podpac/datalib/terraintiles.py
@@ -149,7 +149,7 @@ class TerrainTiles(OrderedCompositor):
     tile_format = tl.Enum(["geotiff", "terrarium", "normal"], default_value="geotiff").tag(attr=True)
     bucket = tl.Unicode(default_value="elevation-tiles-prod").tag(attr=True)
     sources = None  # these are loaded as needed
-    # dims = ["lat", "lon"]
+    dims = ["lat", "lon"]
 
     def select_sources(self, coordinates):
         # get all the tile sources for the requested zoom level and coordinates

--- a/podpac/datalib/terraintiles.py
+++ b/podpac/datalib/terraintiles.py
@@ -149,7 +149,7 @@ class TerrainTiles(OrderedCompositor):
     tile_format = tl.Enum(["geotiff", "terrarium", "normal"], default_value="geotiff").tag(attr=True)
     bucket = tl.Unicode(default_value="elevation-tiles-prod").tag(attr=True)
     sources = None  # these are loaded as needed
-    composite_dims = ["lat", "lon"]
+    dims = ["lat", "lon"]
 
     def select_sources(self, coordinates):
         # get all the tile sources for the requested zoom level and coordinates

--- a/podpac/datalib/terraintiles.py
+++ b/podpac/datalib/terraintiles.py
@@ -122,6 +122,7 @@ class TerrainTilesSource(Rasterio):
 
 class TerrainTilesComposite(S3Mixin, TileCompositor):
     urls = tl.List(trait=tl.Unicode()).tag(attr=True)
+    anon = tl.Bool(True)
 
     _repr_keys = ["urls"]
 
@@ -180,6 +181,7 @@ class TerrainTiles(S3Mixin, OrderedCompositor):
     bucket = tl.Unicode(default_value="elevation-tiles-prod").tag(attr=True)
     sources = None  # these are loaded as needed
     dims = ["lat", "lon"]
+    anon = tl.Bool(True)
 
     def select_sources(self, coordinates):
         # get all the tile sources for the requested zoom level and coordinates

--- a/podpac/datalib/terraintiles.py
+++ b/podpac/datalib/terraintiles.py
@@ -41,10 +41,13 @@ from io import BytesIO
 import traitlets as tl
 import numpy as np
 
+import podpac
 from podpac.data import Rasterio
-from podpac.compositor import OrderedCompositor
+from podpac.compositor import OrderedCompositor, TileCompositor
 from podpac.interpolators import Rasterio as RasterioInterpolator, ScipyGrid, ScipyPoint
 from podpac.data import InterpolationTrait
+from podpac.utils import cached_property
+from podpac.authentication import S3Mixin
 
 ####
 # private module attributes
@@ -67,6 +70,7 @@ class TerrainTilesSource(Rasterio):
     dataset : :class:`rasterio.io.DatasetReader`
         rasterio dataset
     """
+
     anon = tl.Bool(True)
     # attributes
     interpolation = InterpolationTrait(
@@ -106,8 +110,40 @@ class TerrainTilesSource(Rasterio):
         _logger.debug("Downloading terrain tile {} to filepath: {}".format(self.source, filepath))
         self.s3.get(self.source, filepath)
 
+    # this is a little crazy, but I get floating point issues with indexing if i don't round to 7 decimal digits
+    def get_coordinates(self):
+        coordinates = super(TerrainTilesSource, self).get_coordinates()
 
-class TerrainTiles(OrderedCompositor):
+        for dim in coordinates:
+            coordinates[dim] = np.round(coordinates[dim].coordinates, 6)
+
+        return coordinates
+
+
+class TerrainTilesComposite(S3Mixin, TileCompositor):
+    urls = tl.List(trait=tl.Unicode()).tag(attr=True)
+
+    _repr_keys = ["urls"]
+
+    @cached_property
+    def sources(self):
+        return [self._create_source(url) for url in self.urls]
+
+    def get_coordinates(self):
+        return podpac.coordinates.union([source.coordinates for source in self.sources])
+
+    def _create_source(self, url):
+        return TerrainTilesSource(
+            source=url,
+            cache_ctrl=self.cache_ctrl,
+            force_eval=self.force_eval,
+            cache_output=self.cache_output,
+            cache_dataset=True,
+            s3=self.s3,
+        )
+
+
+class TerrainTiles(S3Mixin, OrderedCompositor):
     """Terrain Tiles gridded elevation tiles data library
 
     Hosted on AWS S3
@@ -148,9 +184,10 @@ class TerrainTiles(OrderedCompositor):
     def select_sources(self, coordinates):
         # get all the tile sources for the requested zoom level and coordinates
         sources = get_tile_urls(self.tile_format, self.zoom, coordinates)
+        urls = ["s3://{}/{}".format(self.bucket, s) for s in sources]
 
         # create TerrainTilesSource classes for each url source
-        self.sources = [self._create_source(source) for source in sources]
+        self.sources = self._create_composite(urls)
         return self.sources
 
     def download(self, path="terraintiles"):
@@ -170,8 +207,17 @@ class TerrainTiles(OrderedCompositor):
         except tl.TraitError as e:
             raise ValueError("No terrain tile sources selected. Evaluate node at coordinates to select sources.")
 
-    def _create_source(self, source):
-        return TerrainTilesSource(source="s3://{}/{}".format(self.bucket, source), cache_ctrl=self.cache_ctrl)
+    def _create_composite(self, urls):
+        return [
+            TerrainTilesComposite(
+                urls=urls,
+                cache_ctrl=self.cache_ctrl,
+                force_eval=self.force_eval,
+                cache_output=self.cache_output,
+                cache_dataset=True,
+                s3=self.s3,
+            )
+        ]
 
 
 ############

--- a/podpac/datalib/terraintiles.py
+++ b/podpac/datalib/terraintiles.py
@@ -67,7 +67,7 @@ class TerrainTilesSource(Rasterio):
     dataset : :class:`rasterio.io.DatasetReader`
         rasterio dataset
     """
-
+    anon = tl.Bool(True)
     # attributes
     interpolation = InterpolationTrait(
         default_value={"method": "nearest", "interpolators": [RasterioInterpolator, ScipyGrid, ScipyPoint]}

--- a/podpac/datalib/terraintiles.py
+++ b/podpac/datalib/terraintiles.py
@@ -149,7 +149,7 @@ class TerrainTiles(OrderedCompositor):
     tile_format = tl.Enum(["geotiff", "terrarium", "normal"], default_value="geotiff").tag(attr=True)
     bucket = tl.Unicode(default_value="elevation-tiles-prod").tag(attr=True)
     sources = None  # these are loaded as needed
-    dims = ["lat", "lon"]
+    # dims = ["lat", "lon"]
 
     def select_sources(self, coordinates):
         # get all the tile sources for the requested zoom level and coordinates
@@ -419,10 +419,16 @@ if __name__ == "__main__":
     from podpac import Coordinates, clinspace
 
     c = Coordinates([clinspace(40, 43, 1000), clinspace(-76, -72, 1000)], dims=["lat", "lon"])
+    c2 = Coordinates(
+        [clinspace(40, 43, 1000), clinspace(-76, -72, 1000), ["2018-01-01", "2018-01-02"]], dims=["lat", "lon", "time"]
+    )
 
     print("TerrainTiles")
     node = TerrainTiles(tile_format="geotiff", zoom=8)
     output = node.eval(c)
+    print(output)
+
+    output = node.eval(c2)
     print(output)
 
     print("TerrainTiles cached")


### PR DESCRIPTION
Adds `composite_dims` trait and removes extra dimensions from the evaluation coordinates.

 - [x] autodetect, ignore, or fail if the `composite_dims` are not provided?
 - [x] tests

Autodetection could look like this at its simplest:

```
@tl.default("composite_dims")
    def _default_composite_dims(self):
        return self.sources[0].coordinates.udims
```