### PR TITLE
FIX: Exception when bounds are lower precision than coordinates

### DIFF
--- a/podpac/core/coordinates/array_coordinates1d.py
+++ b/podpac/core/coordinates/array_coordinates1d.py
@@ -13,7 +13,7 @@ import traitlets as tl
 from collections import OrderedDict
 
 from podpac.core.utils import ArrayTrait
-from podpac.core.coordinates.utils import make_coord_array
+from podpac.core.coordinates.utils import make_coord_array, higher_precision_time_bounds
 from podpac.core.coordinates.coordinates1d import Coordinates1d
 
 
@@ -281,6 +281,9 @@ class ArrayCoordinates1d(Coordinates1d):
     # ------------------------------------------------------------------------------------------------------------------
 
     def _select(self, bounds, return_indices, outer):
+        if self.dtype == np.datetime64:
+            _, bounds = higher_precision_time_bounds(self.bounds, bounds, outer)
+
         if not outer:
             gt = self.coordinates >= bounds[0]
             lt = self.coordinates <= bounds[1]

--- a/podpac/core/coordinates/test/test_coordinates.py
+++ b/podpac/core/coordinates/test/test_coordinates.py
@@ -1320,6 +1320,15 @@ class TestCoordinatesMethods(object):
         assert c2["lat"] == c["lat"][1:4]
         assert c2["lon"] == c["lon"][2:5]
 
+        # Confusing time intersection
+        ct = Coordinates([["2012-05-19T12:00:00", "2012-05-19T13:00:00", "2012-05-20T14:00:00"]], ["time"])
+        cti = Coordinates([["2012-05-18", "2012-05-19"]], ["time"])
+        ct2 = ct.intersect(cti, outer=True)
+        assert ct2.size == 3
+
+        ct2 = ct.intersect(cti, outer=False)
+        assert ct2.size == 0  # Is this behavior desired?
+
     def test_intersect_dims(self):
         lat = ArrayCoordinates1d([0, 1, 2, 3, 4, 5], name="lat")
         lon = ArrayCoordinates1d([10, 20, 30, 40, 50, 60], name="lon")

--- a/podpac/core/coordinates/test/test_coordinates_utils.py
+++ b/podpac/core/coordinates/test/test_coordinates_utils.py
@@ -10,7 +10,7 @@ import pyproj
 from podpac.core.coordinates.utils import get_timedelta, get_timedelta_unit, make_timedelta_string
 from podpac.core.coordinates.utils import make_coord_value, make_coord_delta, make_coord_array, make_coord_delta_array
 from podpac.core.coordinates.utils import add_coord, divide_delta, divide_timedelta, timedelta_divisible
-from podpac.core.coordinates.utils import has_alt_units
+from podpac.core.coordinates.utils import has_alt_units, lower_precision_time_bounds, higher_precision_time_bounds
 
 
 def test_get_timedelta():

--- a/podpac/core/coordinates/utils.py
+++ b/podpac/core/coordinates/utils.py
@@ -539,6 +539,46 @@ def lower_precision_time_bounds(my_bounds, other_bounds, outer):
     return my_bounds, other_bounds
 
 
+def higher_precision_time_bounds(my_bounds, other_bounds, outer):
+    """
+    When given two bounds of np.datetime64, this function will convert both bounds to the higher-precision (in terms of 
+    time unit) numpy datetime4 object if outer==True, otherwise only my_bounds will be converted.
+    
+    Parameters
+    -----------
+    my_bounds : List(np.datetime64)
+        The bounds of the coordinates of the dataset
+    other_bounds : List(np.datetime64)
+        The bounds used for the selection
+    outer : bool
+        When the other_bounds are higher precision than the input_bounds, only convert these IF outer=True
+        
+    Returns
+    --------
+    my_bounds : List(np.datetime64)
+        The bounds of the coordinates of the dataset at the new precision
+    other_bounds : List(np.datetime64)
+        The bounds used for the selection at the new precision, if outer == True, otherwise return original coordinates    
+        
+    Notes
+    ------
+    When converting a YYYY-MM-DD to YYYY-MM-DD HH with outer=True, the largest value for HH is used, since the whole day is valid
+    """
+    if not isinstance(other_bounds[0], np.datetime64) or not isinstance(other_bounds[1], np.datetime64):
+        raise TypeError("Input bounds should be of type np.datetime64 when selecting data from:", str(my_bounds))
+
+    if not isinstance(my_bounds[0], np.datetime64) or not isinstance(my_bounds[1], np.datetime64):
+        raise TypeError("Native bounds should be of type np.datetime64 when selecting data using:", str(other_bounds))
+
+    if my_bounds[0].dtype > other_bounds[0].dtype and outer:
+        sign = [0, 1]
+        other_bounds = [(b + s).astype(my_bounds[0].dtype) - 1 for s, b in zip(sign, other_bounds)]
+    else:
+        my_bounds = [b.astype(other_bounds[0].dtype) for b in my_bounds]
+
+    return my_bounds, other_bounds
+
+
 def has_alt_units(crs):
     """
     Check if the CRS has vertical units.

--- a/podpac/core/coordinates/utils.py
+++ b/podpac/core/coordinates/utils.py
@@ -562,7 +562,8 @@ def higher_precision_time_bounds(my_bounds, other_bounds, outer):
         
     Notes
     ------
-    When converting a YYYY-MM-DD to YYYY-MM-DD HH with outer=True, the largest value for HH is used, since the whole day is valid
+    When converting the upper bound with outer=True, the whole lower-precision time unit is valid. E.g. when converting
+    YYYY-MM-DD to YYYY-MM-DD HH, the largest value for HH is used, since the whole day is valid.
     """
     if not isinstance(other_bounds[0], np.datetime64) or not isinstance(other_bounds[1], np.datetime64):
         raise TypeError("Input bounds should be of type np.datetime64 when selecting data from:", str(my_bounds))
@@ -571,8 +572,13 @@ def higher_precision_time_bounds(my_bounds, other_bounds, outer):
         raise TypeError("Native bounds should be of type np.datetime64 when selecting data using:", str(other_bounds))
 
     if my_bounds[0].dtype > other_bounds[0].dtype and outer:
-        sign = [0, 1]
-        other_bounds = [(b + s).astype(my_bounds[0].dtype) - 1 for s, b in zip(sign, other_bounds)]
+        # for the upper bound, the whole lower-precision time unit is valid (see note)
+        # select the largest value for the higher-precision time unit by adding one lower-precision time unit and
+        # subtracting one higher-precision time unit.
+        other_bounds = [
+            other_bounds[0].astype(my_bounds[0].dtype),
+            (other_bounds[1] + 1).astype(my_bounds[0].dtype) - 1,
+        ]
     else:
         my_bounds = [b.astype(other_bounds[0].dtype) for b in my_bounds]
 


### PR DESCRIPTION
Problem: 
```python
        # Confusing time intersection
        ct = Coordinates([["2012-05-19T12:00:00", "2012-05-19T13:00:00", "2012-05-20T14:00:00"]], ["time"])
        cti = Coordinates([["2012-05-18", "2012-05-19"]], ["time"])
        ct2 = ct.intersect(cti, outer=True)
```
This throws in error because `lt` is empty, since `np.datetime64('2020-01-01T00') < np.datetime64('2020-01-01') == False`

As a solution I change the bounds to be the same precision, so `np.datetime('2020-01-01')` --> `np.datetime('2020-01-01T23')`