### PR TITLE
REFACTOR: Eval refactor

### DIFF
--- a/podpac/core/algorithm/algorithm.py
+++ b/podpac/core/algorithm/algorithm.py
@@ -14,7 +14,7 @@ import traitlets as tl
 # Internal dependencies
 from podpac.core.coordinates import Coordinates, union
 from podpac.core.units import UnitsDataArray
-from podpac.core.node import Node, NodeException, node_eval, COMMON_NODE_DOC
+from podpac.core.node import Node, NodeException, COMMON_NODE_DOC
 from podpac.core.utils import common_doc, NodeTrait
 from podpac.core.settings import settings
 from podpac.core.managers.multi_threading import thread_manager
@@ -73,8 +73,7 @@ class Algorithm(BaseAlgorithm):
         raise NotImplementedError
 
     @common_doc(COMMON_DOC)
-    @node_eval
-    def eval(self, coordinates, output=None, selector=None):
+    def _eval(self, coordinates, output=None, _selector=None):
         """Evalutes this nodes using the supplied coordinates.
 
         Parameters
@@ -83,7 +82,7 @@ class Algorithm(BaseAlgorithm):
             {requested_coordinates}
         output : podpac.UnitsDataArray, optional
             {eval_output}
-        selector: callable(coordinates, request_coordinates)
+        _selector: callable(coordinates, request_coordinates)
             {eval_selector}
 
         Returns
@@ -105,7 +104,7 @@ class Algorithm(BaseAlgorithm):
         if settings["MULTITHREADING"] and n_threads > 1:
             # Create a function for each thread to execute asynchronously
             def f(node):
-                return node.eval(coordinates)
+                return node.eval(coordinates, _selector=_selector)
 
             # Create pool of size n_threads, note, this may be created from a sub-thread (i.e. not the main thread)
             pool = thread_manager.get_thread_pool(processes=n_threads)
@@ -126,7 +125,7 @@ class Algorithm(BaseAlgorithm):
         else:
             # Evaluate nodes in serial
             for key, node in self.inputs.items():
-                inputs[key] = node.eval(coordinates)
+                inputs[key] = node.eval(coordinates, output=output, _selector=_selector)
             self._multi_threaded = False
 
         # accumulate output coordinates

--- a/podpac/core/algorithm/coord_select.py
+++ b/podpac/core/algorithm/coord_select.py
@@ -46,7 +46,7 @@ class ModifyCoordinates(UnaryAlgorithm):
         return self.source
 
     @common_doc(COMMON_DOC)
-    def eval(self, coordinates, output=None, selector=None):
+    def _eval(self, coordinates, output=None, _selector=None):
         """Evaluates this nodes using the supplied coordinates.
 
         Parameters
@@ -55,7 +55,7 @@ class ModifyCoordinates(UnaryAlgorithm):
             {requested_coordinates}
         output : podpac.UnitsDataArray, optional
             {eval_output}
-        selector: callable(coordinates, request_coordinates)
+        _selector: callable(coordinates, request_coordinates)
             {eval_selector}
 
         Returns
@@ -79,7 +79,7 @@ class ModifyCoordinates(UnaryAlgorithm):
                 raise ValueError("Modified coordinates do not intersect with source data (dim '%s')" % dim)
 
         outputs = {}
-        outputs["source"] = self.source.eval(self._modified_coordinates, output=output)
+        outputs["source"] = self.source.eval(self._modified_coordinates, output=output, _selector=_selector)
 
         if self.substitute_eval_coords:
             dims = outputs["source"].dims

--- a/podpac/core/algorithm/reprojection.py
+++ b/podpac/core/algorithm/reprojection.py
@@ -62,7 +62,7 @@ class Reproject(Interpolate):
             raise TypeError("The coordinates attribute is of the wrong type.")
 
     def _source_eval(self, coordinates, selector, output=None):
-        return self.source.eval(self._coordinates, output, selector)
+        return self.source.eval(self._coordinates, output=output, _selector=selector)
 
     @property
     def base_ref(self):

--- a/podpac/core/algorithm/signal.py
+++ b/podpac/core/algorithm/signal.py
@@ -16,7 +16,7 @@ from podpac.core.coordinates import add_coord
 from podpac.core.node import Node
 from podpac.core.algorithm.algorithm import UnaryAlgorithm
 from podpac.core.utils import common_doc, ArrayTrait, NodeTrait
-from podpac.core.node import COMMON_NODE_DOC, node_eval
+from podpac.core.node import COMMON_NODE_DOC
 
 
 COMMON_DOC = COMMON_NODE_DOC.copy()
@@ -100,8 +100,7 @@ class Convolution(UnaryAlgorithm):
         return super(Convolution, self)._first_init(**kwargs)
 
     @common_doc(COMMON_DOC)
-    @node_eval
-    def eval(self, coordinates, output=None, selector=None):
+    def _eval(self, coordinates, output=None, _selector=None):
         """Evaluates this nodes using the supplied coordinates.
 
         Parameters
@@ -110,7 +109,7 @@ class Convolution(UnaryAlgorithm):
             {requested_coordinates}
         output : podpac.UnitsDataArray, optional
             {eval_output}
-        selector: callable(coordinates, request_coordinates)
+        _selector: callable(coordinates, request_coordinates)
             {eval_selector}
 
         Returns
@@ -162,7 +161,7 @@ class Convolution(UnaryAlgorithm):
             self._expanded_coordinates = expanded_coordinates
 
         # evaluate source using expanded coordinates, convolve, and then slice out original coordinates
-        source = self.source.eval(expanded_coordinates)
+        source = self.source.eval(expanded_coordinates, _selector=_selector)
 
         # Check dimensions
         if any([d not in kernel_dims for d in source.dims if d != "output"]):

--- a/podpac/core/data/datasource.py
+++ b/podpac/core/data/datasource.py
@@ -23,7 +23,6 @@ from podpac.core.coordinates.utils import VALID_DIMENSION_NAMES, make_coord_delt
 from podpac.core.node import Node, NodeException
 from podpac.core.utils import common_doc
 from podpac.core.node import COMMON_NODE_DOC
-from podpac.core.node import node_eval
 from podpac.core.interpolation.interpolation import Interpolate, InterpolationTrait
 
 log = logging.getLogger(__name__)
@@ -277,8 +276,7 @@ class DataSource(Node):
     # ------------------------------------------------------------------------------------------------------------------
 
     @common_doc(COMMON_DATA_DOC)
-    @node_eval
-    def eval(self, coordinates, output=None, selector=None):
+    def _eval(self, coordinates, output=None, _selector=None):
         """Evaluates this node using the supplied coordinates.
 
         The coordinates are mapped to the requested coordinates, interpolated if necessary, and set to
@@ -297,7 +295,7 @@ class DataSource(Node):
             Extra dimensions in the requested coordinates are dropped.
         output : :class:`podpac.UnitsDataArray`, optional
             {eval_output}
-        selector: callable(coordinates, request_coordinates)
+        _selector: callable(coordinates, request_coordinates)
             {eval_selector}
 
         Returns
@@ -364,8 +362,8 @@ class DataSource(Node):
             return output
 
         # Use the selector
-        if selector is not None:
-            (rsc, rsci) = selector(rsc, rsci, coordinates)
+        if _selector is not None:
+            (rsc, rsci) = _selector(rsc, rsci, coordinates)
 
         # Check the coordinate_index_type
         if self.coordinate_index_type == "slice":  # Most restrictive

--- a/podpac/core/interpolation/interpolation.py
+++ b/podpac/core/interpolation/interpolation.py
@@ -10,7 +10,7 @@ import traitlets as tl
 import numpy as np
 
 from podpac.core.settings import settings
-from podpac.core.node import Node, node_eval
+from podpac.core.node import Node
 from podpac.core.utils import NodeTrait, common_doc
 from podpac.core.units import UnitsDataArray
 from podpac.core.coordinates import merge_dims, Coordinates
@@ -26,12 +26,11 @@ def interpolation_decorator():
 class InterpolationMixin(tl.HasTraits):
     interpolation = InterpolationTrait().tag(attr=True)
 
-    @node_eval
-    def eval(self, coordinates, output=None, selector=None):
+    def _eval(self, coordinates, output=None, _selector=None):
         node = Interpolate(interpolation=self.interpolation)
         node._set_interpolation()
-        node._source_xr = super().eval(coordinates, selector=node._interpolation.select_coordinates)
-        return node.eval(coordinates, output)
+        node._source_xr = super()._eval(coordinates, _selector=node._interpolation.select_coordinates)
+        return node.eval(coordinates, output=output)
 
 
 class Interpolate(Node):
@@ -162,8 +161,7 @@ class Interpolate(Node):
         else:
             self._interpolation = InterpolationManager(self.interpolation)
 
-    @node_eval
-    def eval(self, coordinates, output=None, selector=None):
+    def _eval(self, coordinates, output=None, _selector=None):
         """Evaluates this node using the supplied coordinates.
 
         The coordinates are mapped to the requested coordinates, interpolated if necessary, and set to
@@ -182,7 +180,7 @@ class Interpolate(Node):
             Extra dimensions in the requested coordinates are dropped.
         output : :class:`podpac.UnitsDataArray`, optional
             {eval_output}
-        selector :
+        _selector :
             {eval_selector}
 
         Returns
@@ -243,7 +241,7 @@ class Interpolate(Node):
         if isinstance(self._source_xr, UnitsDataArray):
             return self._source_xr
         else:
-            return self.source.eval(coordinates, output, selector)
+            return self.source.eval(coordinates, output=output, _selector=selector)
 
     def find_coordinates(self):
         """

--- a/podpac/core/managers/multi_process.py
+++ b/podpac/core/managers/multi_process.py
@@ -45,7 +45,8 @@ class Process(Node):
     def outputs(self):
         return self.source.outputs
 
-    def eval(self, coordinates, output=None, selector=None):
+    def eval(self, coordinates, **kwargs):
+        output = kwargs.get("output")
         definition = self.source.json
         coords = coordinates.json
 

--- a/podpac/core/managers/parallel.py
+++ b/podpac/core/managers/parallel.py
@@ -67,7 +67,8 @@ class Parallel(Node):
     errors = tl.List()
     start_i = tl.Int(0)
 
-    def eval(self, coordinates, output=None, selector=None):
+    def eval(self, coordinates, **kwargs):
+        output = kwargs.get("output")
         # Make a thread pool to manage queue
         pool = ThreadPool(processes=self.number_of_workers)
 
@@ -202,7 +203,7 @@ class ParallelAsync(Parallel):
         while not success:
             if self.check_worker_available():
                 try:
-                    o = source.eval(coordinates, out)
+                    o = source.eval(coordinates, output=out)
                     success = True
                 except self.async_exception:
                     # This exception is fine and constitutes a success
@@ -273,7 +274,8 @@ class ZarrOutputMixin(tl.HasTraits):
     aws_client_kwargs = tl.Dict()
     aws_config_kwargs = tl.Dict()
 
-    def eval(self, coordinates, output=None, selector=None):
+    def eval(self, coordinates, **kwargs):
+        output = kwargs.get("output")
         if self.zarr_shape is None:
             self._shape = coordinates.shape
         else:
@@ -308,7 +310,7 @@ class ZarrOutputMixin(tl.HasTraits):
                 dk = dk[0]
             self._list_dir = self.zarr_node.list_dir(dk)
 
-        output = super(ZarrOutputMixin, self).eval(coordinates, output)
+        output = super(ZarrOutputMixin, self).eval(coordinates, output=output)
 
         # fill in the coordinates, this is guaranteed to be correct even if the user messed up.
         if output is not None:

--- a/podpac/core/managers/test/test_multiprocess.py
+++ b/podpac/core/managers/test/test_multiprocess.py
@@ -32,7 +32,7 @@ class TestProcess(object):
         output[:] = np.nan
 
         node_mp = Process(source=node)
-        o_mp = node_mp.eval(coords, output)
+        o_mp = node_mp.eval(coords, output=output)
 
         np.testing.assert_array_equal(o_sp, output)
 

--- a/podpac/core/managers/test/test_parallel.py
+++ b/podpac/core/managers/test/test_parallel.py
@@ -36,7 +36,7 @@ class TestParallel(object):
         o = node.eval(coords)
         o_p = o.copy()
         o_p[:] = np.nan
-        node_p.eval(coords, o_p)
+        node_p.eval(coords, output=o_p)
 
         np.testing.assert_array_equal(o, o_p)
 
@@ -48,7 +48,7 @@ class TestParallel(object):
         o = node.eval(coords)
         o_p = o.copy()
         o_p[:] = np.nan
-        node_p.eval(coords, o_p)
+        node_p.eval(coords, output=o_p)
         time.sleep(0.1)
 
         np.testing.assert_array_equal(o, o_p)

--- a/podpac/core/node.py
+++ b/podpac/core/node.py
@@ -251,7 +251,7 @@ class Node(tl.HasTraits):
         return "<%s(%s) attrs: %s>" % (self.__class__.__name__, self._repr_info, ", ".join(self.attrs))
 
     @common_doc(COMMON_DOC)
-    def eval(self, coordinates, output=None, selector=None):
+    def eval(self, coordinates, **kwargs):
         """
         Evaluate the node at the given coordinates.
 
@@ -259,16 +259,62 @@ class Node(tl.HasTraits):
         ----------
         coordinates : podpac.Coordinates
             {requested_coordinates}
-        output : podpac.UnitsDataArray, optional
-            {eval_output}
-        selector: callable(coordinates, request_coordinates)
-            {eval_selector}
+        **kwargs: **dict
+            Additional key-word arguments passed down the node pipelines, used internally
 
         Returns
         -------
         output : {eval_return}
         """
+        output = kwargs.get("output", None)
+        # check crs compatibility
+        if (output is not None) and ("crs" in output.attrs) and (output.attrs["crs"] != coordinates.crs):
+            raise ValueError(
+                "Output coordinate reference system ({}) does not match".format(output.crs)
+                + "request Coordinates coordinate reference system ({})".format(coordinates.crs)
+            )
 
+        if settings["DEBUG"]:
+            self._requested_coordinates = coordinates
+        key = "output"
+        cache_coordinates = coordinates.transpose(*sorted(coordinates.dims))  # order agnostic caching
+
+        if not self.force_eval and self.cache_output and self.has_cache(key, cache_coordinates):
+            data = self.get_cache(key, cache_coordinates)
+            if output is not None:
+                order = [dim for dim in output.dims if dim not in data.dims] + list(data.dims)
+                output.transpose(*order)[:] = data
+            self._from_cache = True
+        else:
+            data = self._eval(coordinates, **kwargs)
+            if self.cache_output:
+                self.put_cache(data, key, cache_coordinates)
+            self._from_cache = False
+
+        # extract single output, if necessary
+        # subclasses should extract single outputs themselves if possible, but this provides a backup
+        if "output" in data.dims and self.output is not None:
+            data = data.sel(output=self.output)
+
+        # transpose data to match the dims order of the requested coordinates
+        order = [dim for dim in coordinates.idims if dim in data.dims]
+        if "output" in data.dims:
+            order.append("output")
+        data = data.part_transpose(order)
+
+        if settings["DEBUG"]:
+            self._output = data
+
+        # Add style information
+        data.attrs["layer_style"] = self.style
+
+        # Add crs if it is missing
+        if "crs" not in data.attrs:
+            data.attrs["crs"] = coordinates.crs
+
+        return data
+
+    def _eval(self, coordinates, output=None, _selector=None):
         raise NotImplementedError
 
     def eval_group(self, group):
@@ -961,70 +1007,3 @@ class DiskCacheMixin(tl.HasTraits):
 # --------------------------------------------------------#
 #  Decorators
 # --------------------------------------------------------#
-
-
-def node_eval(fn):
-    """
-    Decorator for Node eval methods that handles caching and a user provided output argument.
-
-    fn : function
-        Node eval method to wrap
-
-    Returns
-    -------
-    wrapper : function
-        Wrapped node eval method
-    """
-
-    cache_key = "output"
-
-    @functools.wraps(fn)
-    def wrapper(self, coordinates, output=None, selector=None):
-        # check crs compatibility
-        if (output is not None) and ("crs" in output.attrs) and (output.attrs["crs"] != coordinates.crs):
-            raise ValueError(
-                "Output coordinate reference system ({}) does not match".format(output.crs)
-                + "request Coordinates coordinate reference system ({})".format(coordinates.crs)
-            )
-
-        if settings["DEBUG"]:
-            self._requested_coordinates = coordinates
-        key = cache_key
-        cache_coordinates = coordinates.transpose(*sorted(coordinates.dims))  # order agnostic caching
-
-        if not self.force_eval and self.cache_output and self.has_cache(key, cache_coordinates):
-            data = self.get_cache(key, cache_coordinates)
-            if output is not None:
-                order = [dim for dim in output.dims if dim not in data.dims] + list(data.dims)
-                output.transpose(*order)[:] = data
-            self._from_cache = True
-        else:
-            data = fn(self, coordinates, output=output, selector=selector)
-            if self.cache_output:
-                self.put_cache(data, key, cache_coordinates)
-            self._from_cache = False
-
-        # extract single output, if necessary
-        # subclasses should extract single outputs themselves if possible, but this provides a backup
-        if "output" in data.dims and self.output is not None:
-            data = data.sel(output=self.output)
-
-        # transpose data to match the dims order of the requested coordinates
-        order = [dim for dim in coordinates.idims if dim in data.dims]
-        if "output" in data.dims:
-            order.append("output")
-        data = data.part_transpose(order)
-
-        if settings["DEBUG"]:
-            self._output = data
-
-        # Add style information
-        data.attrs["layer_style"] = self.style
-
-        # Add crs if it is missing
-        if "crs" not in data.attrs:
-            data.attrs["crs"] = coordinates.crs
-
-        return data
-
-    return wrapper

--- a/podpac/core/test/test_node.py
+++ b/podpac/core/test/test_node.py
@@ -29,7 +29,6 @@ from podpac.core.units import UnitsDataArray
 from podpac.core.style import Style
 from podpac.core.cache import CacheCtrl, RamCacheStore, DiskCacheStore
 from podpac.core.node import Node, NodeException, NodeDefinitionError
-from podpac.core.node import node_eval
 from podpac.core.node import NoCacheMixin, DiskCacheMixin
 
 
@@ -203,10 +202,10 @@ class TestNode(object):
     def test_eval_not_implemented(self):
         node = Node()
         with pytest.raises(NotImplementedError):
-            node.eval(None)
+            node.eval(podpac.Coordinates([]))
 
         with pytest.raises(NotImplementedError):
-            node.eval(None, output=None)
+            node.eval(podpac.Coordinates([]), output=None)
 
     def test_find_coordinates_not_implemented(self):
         node = Node()
@@ -275,8 +274,7 @@ class TestNodeEval(object):
         class MyNode1(Node):
             outputs = ["a", "b", "c"]
 
-            @node_eval
-            def eval(self, coordinates, output=None, selector=None):
+            def _eval(self, coordinates, output=None, selector=None):
                 return self.create_output_array(coordinates)
 
         # don't extract when no output field is requested
@@ -293,8 +291,7 @@ class TestNodeEval(object):
         class MyNode2(Node):
             outputs = ["a", "b", "c"]
 
-            @node_eval
-            def eval(self, coordinates, output=None, selector=None):
+            def _eval(self, coordinates, output=None, selector=None):
                 out = self.create_output_array(coordinates)
                 return out.sel(output=self.output)
 

--- a/podpac/datalib/egi.py
+++ b/podpac/datalib/egi.py
@@ -227,7 +227,7 @@ class EGI(DataSource):
             raise e
 
         # run normal eval once self.data is prepared
-        return super(EGI, self).eval(coordinates, output=output, _selector=_selector)
+        return super(EGI, self)._eval(coordinates, output=output, _selector=_selector)
 
     ##########
     # Data I/O

--- a/podpac/datalib/egi.py
+++ b/podpac/datalib/egi.py
@@ -31,7 +31,6 @@ from podpac import authentication
 from podpac import settings
 from podpac import cached_property
 from podpac.core.units import UnitsDataArray
-from podpac.core.node import node_eval
 
 # Set up logging
 _log = logging.getLogger(__name__)
@@ -214,8 +213,7 @@ class EGI(DataSource):
             _log.warning("No data found in EGI source")
             return np.array([])
 
-    @node_eval
-    def eval(self, coordinates, output=None, selector=None):
+    def _eval(self, coordinates, output=None, _selector=None):
         # download data for coordinate bounds, then handle that data as an H5PY node
         zip_files = self._download(coordinates)
         try:
@@ -229,7 +227,7 @@ class EGI(DataSource):
             raise e
 
         # run normal eval once self.data is prepared
-        return super(EGI, self).eval(coordinates, output)
+        return super(EGI, self).eval(coordinates, output=output, _selector=_selector)
 
     ##########
     # Data I/O

--- a/podpac/datalib/satutils.py
+++ b/podpac/datalib/satutils.py
@@ -22,7 +22,6 @@ import podpac
 from podpac.compositor import OrderedCompositor
 from podpac.data import Rasterio
 from podpac.core.units import UnitsDataArray
-from podpac.core.node import node_eval
 from podpac.authentication import S3Mixin
 from podpac import settings
 
@@ -137,13 +136,12 @@ class SatUtils(S3Mixin, OrderedCompositor):
             for item_idx, item in enumerate(items)
         ]
 
-    @node_eval
-    def eval(self, coordinates, output=None, selector=None):
+    def _eval(self, coordinates, output=None, _selector=None):
         # update sources with search
         _ = self.search(coordinates)
 
         # run normal eval once self.data is prepared
-        return super(SatUtils, self).eval(coordinates, output)
+        return super(SatUtils, self)._eval(coordinates, output=output, _selector=_selector)
 
     ##########
     # Data I/O


### PR DESCRIPTION
* Eliminated `node_eval` decorator, moved functionality into public `eval`
* made specific implementations part of private `_eval` method instead.
* added **kwargs to public `eval` method