### PR TITLE
Remove support for numpy return type in Algorithms

### DIFF
--- a/podpac/core/algorithm/algorithm.py
+++ b/podpac/core/algorithm/algorithm.py
@@ -63,7 +63,7 @@ class Algorithm(BaseAlgorithm):
         Arguments
         ----------
         inputs : dict
-            Evaluated outputs of the input nodes. The keys are the attribute names.
+            Evaluated outputs of the input nodes. The keys are the attribute names. Each item is a `UnitsDataArray`. 
         coordinates : podpac.Coordinates
             Requested coordinates.
             Note that the ``inputs`` may contain different coordinates than the requested coordinates

--- a/podpac/core/algorithm/algorithm.py
+++ b/podpac/core/algorithm/algorithm.py
@@ -58,18 +58,17 @@ class Algorithm(BaseAlgorithm):
     Developers of new Algorithm nodes need to implement the `algorithm` method.
     """
 
-    def algorithm(self, inputs):
+    def algorithm(self, inputs, coordinates):
         """
         Arguments
         ----------
         inputs : dict
             Evaluated outputs of the input nodes. The keys are the attribute names.
-
-        Raises
-        ------
-        NotImplementedError
-            Description
+        coordinates : podpac.Coordinates
+            Requested coordinates.
+            Note that the ``inputs`` may contain with different coordinates.
         """
+
         raise NotImplementedError
 
     @common_doc(COMMON_DOC)
@@ -128,33 +127,28 @@ class Algorithm(BaseAlgorithm):
                 inputs[key] = node.eval(coordinates, output=output, _selector=_selector)
             self._multi_threaded = False
 
-        # accumulate output coordinates
-        coords_list = [Coordinates.from_xarray(a.coords, crs=a.attrs.get("crs")) for a in inputs.values()]
-        output_coordinates = union([coordinates] + coords_list)
+        result = self.algorithm(inputs, coordinates)
 
-        result = self.algorithm(inputs)
-        if isinstance(result, UnitsDataArray):
-            if output is None:
-                output = result
-            else:
-                output[:] = result.data[:]
-        elif isinstance(result, xr.DataArray):
-            if output is None:
-                output = self.create_output_array(
-                    Coordinates.from_xarray(result.coords, crs=result.attrs.get("crs")), data=result.data
-                )
-            else:
-                output[:] = result.data
-        elif isinstance(result, np.ndarray):
-            if output is None:
-                output = self.create_output_array(output_coordinates, data=result)
-            else:
-                output.data[:] = result
+        if not isinstance(result, xr.DataArray):
+            raise NodeException("algorithm returned unsupported type '%s'" % type(result))
+
+        if "output" in result.dims and self.output is not None:
+            result = result.sel(output=self.output)
+
+        if output is not None:
+            missing = [dim for dim in result.dims if dim not in output.dims]
+            if any(missing):
+                raise NodeException("provided output is missing dims %s" % missing)
+
+            output_dims = output.dims
+            output = output.transpose(..., *result.dims)
+            output[:] = result.data
+            output = output.transpose(*output_dims)
+        elif isinstance(result, UnitsDataArray):
+            output = result
         else:
-            raise NodeException
-
-        if "output" in output.dims and self.output is not None:
-            output = output.sel(output=self.output)
+            output_coordinates = Coordinates.from_xarray(result)
+            output = self.create_output_array(output_coordinates, data=result.data)
 
         return output
 

--- a/podpac/core/algorithm/algorithm.py
+++ b/podpac/core/algorithm/algorithm.py
@@ -66,7 +66,7 @@ class Algorithm(BaseAlgorithm):
             Evaluated outputs of the input nodes. The keys are the attribute names.
         coordinates : podpac.Coordinates
             Requested coordinates.
-            Note that the ``inputs`` may contain with different coordinates.
+            Note that the ``inputs`` may contain different coordinates than the requested coordinates
         """
 
         raise NotImplementedError

--- a/podpac/core/algorithm/stats.py
+++ b/podpac/core/algorithm/stats.py
@@ -1077,7 +1077,7 @@ class DayOfYearWindow(Algorithm):
     scale_float = tl.List(default_value=None, allow_none=True).tag(attr=True)
     rescale = tl.Bool(False).tag(attr=True)
 
-    def algorithm(self, inputs):
+    def algorithm(self, inputs, coordinates):
         win = self.window // 2
         source = inputs["source"]
 
@@ -1103,12 +1103,12 @@ class DayOfYearWindow(Algorithm):
                 source.data[(source.data < 0) | (source.data > 1)] = np.nan
 
         # Make the output coordinates with day-of-year as time
-        coords = xr.Dataset({"time": self._requested_coordinates["time"].coordinates})
+        coords = xr.Dataset({"time": coordinates["time"].coordinates})
         dsdoy = np.sort(np.unique(coords.time.dt.dayofyear))
-        latlon_coords = self._requested_coordinates.drop("time")
+        latlon_coords = coordinates.drop("time")
         time_coords = podpac.Coordinates([dsdoy], ["time"])
         coords = podpac.coordinates.merge_dims([latlon_coords, time_coords])
-        coords = coords.transpose(*self._requested_coordinates.dims)
+        coords = coords.transpose(*coordinates.dims)
         output = self.create_output_array(coords)
 
         # if all-nan input, no need to calculate

--- a/podpac/core/algorithm/test/test_algorithm.py
+++ b/podpac/core/algorithm/test/test_algorithm.py
@@ -66,7 +66,9 @@ class TestAlgorithm(object):
         class MyAlgorithm(Algorithm):
             def algorithm(self, inputs, coordinates):
                 data = np.arange(coordinates.size).reshape(coordinates.shape)
-                return xr.DataArray(data, coords=coordinates.xcoords, dims=coordinates.dims)
+                return xr.DataArray(
+                    data, coords=coordinates.xcoords, dims=coordinates.dims, attrs={"crs": coordinates.crs}
+                )
 
         coords = podpac.Coordinates([[0, 1, 2], [10, 20]], dims=["lat", "lon"])
         node = MyAlgorithm()
@@ -186,7 +188,9 @@ class TestAlgorithm(object):
         class MyAlgorithm(Algorithm):
             def algorithm(self, inputs, coordinates):
                 data = np.arange(coordinates.size).reshape(coordinates.shape)
-                return xr.DataArray(data, coords=coordinates.xcoords, dims=coordinates.dims)
+                return xr.DataArray(
+                    data, coords=coordinates.xcoords, dims=coordinates.dims, attrs={"crs": coordinates.crs}
+                )
 
         coords = podpac.Coordinates([[0, 1, 2], [10, 20]], dims=["lat", "lon"])
         output = podpac.UnitsDataArray.create(coords)
@@ -279,7 +283,7 @@ class TestAlgorithm(object):
                 sum_ = inputs["x"] + inputs["y"]
                 prod = inputs["x"] * inputs["y"]
                 diff = inputs["x"] - inputs["y"]
-                coords = podpac.Coordinates.from_xarray(prod)
+                coords = podpac.Coordinates.from_xarray(prod, crs=coordinates.crs)
                 return self.create_output_array(coords, data=np.stack([sum_, prod, diff], -1))
 
         coords = podpac.Coordinates([[0, 1, 2], [10, 20]], dims=["lat", "lon"])

--- a/podpac/core/algorithm/utility.py
+++ b/podpac/core/algorithm/utility.py
@@ -16,21 +16,23 @@ from podpac.core.algorithm.algorithm import Algorithm
 class Arange(Algorithm):
     """A simple test node that gives each value in the output a number."""
 
-    def algorithm(self, inputs):
+    def algorithm(self, inputs, coordinates):
         """Uses np.arange to give each value in output a unique number
 
         Arguments
         ---------
         inputs : dict
             Unused, should be empty for this algorithm.
+        coordinates : podpac.Coordinates
+            Requested coordinates.
 
         Returns
         -------
         UnitsDataArray
             A row-majored numbered array of the requested size.
         """
-        data = np.arange(self._requested_coordinates.size).reshape(self._requested_coordinates.shape)
-        return self.create_output_array(self._requested_coordinates, data=data)
+        data = np.arange(coordinates.size).reshape(coordinates.shape)
+        return self.create_output_array(coordinates, data=data)
 
 
 class CoordData(Algorithm):
@@ -44,13 +46,16 @@ class CoordData(Algorithm):
 
     coord_name = tl.Unicode("").tag(attr=True)
 
-    def algorithm(self, inputs):
+    def algorithm(self, inputs, coordinates):
         """Extract coordinate from request and makes data available.
 
         Arguments
         ----------
         inputs : dict
             Unused, should be empty for this algorithm.
+        coordinates : podpac.Coordinates
+            Requested coordinates.
+            Note that the ``inputs`` may contain with different coordinates.
 
         Returns
         -------
@@ -58,10 +63,10 @@ class CoordData(Algorithm):
             The coordinates as data for the requested coordinate.
         """
 
-        if self.coord_name not in self._requested_coordinates.udims:
+        if self.coord_name not in coordinates.udims:
             raise ValueError("Coordinate name not in evaluated coordinates")
 
-        c = self._requested_coordinates[self.coord_name]
+        c = coordinates[self.coord_name]
         coords = Coordinates([c], validate_crs=False)
         return self.create_output_array(coords, data=c.coordinates)
 
@@ -69,20 +74,22 @@ class CoordData(Algorithm):
 class SinCoords(Algorithm):
     """A simple test node that creates a data based on coordinates and trigonometric (sin) functions."""
 
-    def algorithm(self, inputs):
+    def algorithm(self, inputs, coordinates):
         """Computes sinusoids of all the coordinates.
 
         Arguments
         ----------
         inputs : dict
             Unused, should be empty for this algorithm.
+        coordinates : podpac.Coordinates
+            Requested coordinates.
 
         Returns
         -------
         UnitsDataArray
             Sinusoids of a certain period for all of the requested coordinates
         """
-        out = self.create_output_array(self._requested_coordinates, data=1.0)
+        out = self.create_output_array(coordinates, data=1.0)
         crds = list(out.coords.values())
         try:
             i_time = list(out.coords.keys()).index("time")

--- a/podpac/core/coordinates/test/test_coordinates.py
+++ b/podpac/core/coordinates/test/test_coordinates.py
@@ -385,11 +385,18 @@ class TestCoordinateCreation(object):
 
         # from xarray
         x = xr.DataArray(np.empty(c.shape), coords=c.xcoords, dims=c.xdims)
+        c2 = Coordinates.from_xarray(x)
+        assert c2 == c
+
+        # from xarray coords
+        x = xr.DataArray(np.empty(c.shape), coords=c.xcoords, dims=c.xdims)
         c2 = Coordinates.from_xarray(x.coords)
         assert c2 == c
 
         # invalid
-        with pytest.raises(TypeError, match="Coordinates.from_xarray expects xarray DataArrayCoordinates"):
+        with pytest.raises(
+            TypeError, match="Coordinates.from_xarray expects an xarray DataArray or DataArrayCoordinates"
+        ):
             Coordinates.from_xarray([0, 10])
 
     def test_from_xarray_shaped(self):
@@ -400,7 +407,7 @@ class TestCoordinateCreation(object):
 
         # from xarray
         x = xr.DataArray(np.empty(c.shape), coords=c.xcoords, dims=c.xdims)
-        c2 = Coordinates.from_xarray(x.coords)
+        c2 = Coordinates.from_xarray(x)
         assert c2 == c
 
     def test_from_xarray_with_outputs(self):
@@ -415,7 +422,7 @@ class TestCoordinateCreation(object):
         shape = c.shape + (2,)
 
         x = xr.DataArray(np.empty(c.shape + (2,)), coords=coords, dims=dims)
-        c2 = Coordinates.from_xarray(x.coords)
+        c2 = Coordinates.from_xarray(x)
         assert c2 == c
 
     def test_crs(self):

--- a/podpac/core/data/dataset_source.py
+++ b/podpac/core/data/dataset_source.py
@@ -90,7 +90,7 @@ class DatasetRaw(FileKeysMixin, LoadFileMixin, BaseFileSource):
     def get_coordinates(self):
         """{get_coordinates}"""
         if self.infer_podpac_coords:
-            return Coordinates.from_xarray(self.dataset.coords)
+            return Coordinates.from_xarray(self.dataset, crs=self.crs)
         return super().get_coordinates()
 
 

--- a/podpac/core/interpolation/interpolation.py
+++ b/podpac/core/interpolation/interpolation.py
@@ -215,7 +215,7 @@ class Interpolate(Node):
         selector = self._interpolation.select_coordinates
 
         source_out = self._source_eval(self._evaluated_coordinates, selector)
-        source_coords = Coordinates.from_xarray(source_out.coords, crs=source_out.crs)
+        source_coords = Coordinates.from_xarray(source_out)
 
         # Drop extra coordinates
         extra_dims = [d for d in coordinates.udims if d not in source_coords.udims]

--- a/podpac/core/interpolation/nearest_neighbor_interpolator.py
+++ b/podpac/core/interpolation/nearest_neighbor_interpolator.py
@@ -80,8 +80,8 @@ class NearestNeighbor(Interpolator):
         def is_stacked(d):
             return "_" in d
 
-        if hasattr(source_data, "attrs"):
-            bounds = source_data.attrs.get("bounds", {d: None for d in source_coordinates.udims})
+        if hasattr(source_data, "attrs") and "bounds" in source_data.attrs:
+            bounds = source_data.attrs["bounds"]
             if "time" in bounds and bounds["time"]:
                 if "time" in eval_coordinates.udims:
                     bounds["time"] = [

--- a/podpac/core/managers/parallel.py
+++ b/podpac/core/managers/parallel.py
@@ -314,7 +314,7 @@ class ZarrOutputMixin(tl.HasTraits):
 
         # fill in the coordinates, this is guaranteed to be correct even if the user messed up.
         if output is not None:
-            self.set_zarr_coordinates(Coordinates.from_xarray(output.coords), data_key)
+            self.set_zarr_coordinates(Coordinates.from_xarray(output), data_key)
         else:
             return zf
 

--- a/podpac/core/units.py
+++ b/podpac/core/units.py
@@ -398,7 +398,7 @@ class UnitsDataArray(xr.DataArray):
         :class:`podpac.UnitsDataArray`
         """
         da = xr.open_dataarray(*args, **kwargs)
-        coords = Coordinates.from_xarray(da.coords, crs=da.attrs.get("crs"))
+        coords = Coordinates.from_xarray(da)
 
         # pass in kwargs to constructor
         uda_kwargs = {"attrs": da.attrs}

--- a/podpac/datalib/drought_monitor.py
+++ b/podpac/datalib/drought_monitor.py
@@ -4,8 +4,18 @@ from podpac.style import Style
 from podpac.utils import NodeTrait
 
 
-def drought_style():
-    return Style(
+class DroughtMonitorCategory(Zarr):
+    style = Style(clim=[0, 0.6], colormap="gist_earth_r")
+
+
+class DroughtCategory(Algorithm):
+    soil_moisture = NodeTrait().tag(attr=True)
+    d0 = NodeTrait().tag(attr=True)
+    d1 = NodeTrait().tag(attr=True)
+    d2 = NodeTrait().tag(attr=True)
+    d3 = NodeTrait().tag(attr=True)
+    d4 = NodeTrait().tag(attr=True)
+    style = Style(
         clim=[0, 6],
         enumeration_colors=[
             [0.45098039, 0.0, 0.0, 1.0],
@@ -17,25 +27,7 @@ def drought_style():
         ],
     )
 
-
-def sm_style():
-    return Style(clim=[0, 0.6], colormap="gist_earth_r")
-
-
-class DroughtMonitorCategory(Zarr):
-    style = sm_style()
-
-
-class DroughtCategory(Algorithm):
-    soil_moisture = NodeTrait().tag(attr=True)
-    d0 = NodeTrait().tag(attr=True)
-    d1 = NodeTrait().tag(attr=True)
-    d2 = NodeTrait().tag(attr=True)
-    d3 = NodeTrait().tag(attr=True)
-    d4 = NodeTrait().tag(attr=True)
-    style = drought_style()
-
-    def algorithm(self, inputs):
+    def algorithm(self, inputs, coordinates):
         sm = inputs["soil_moisture"]
         d0 = inputs["d0"]
         d1 = inputs["d1"]

--- a/podpac/datalib/egi.py
+++ b/podpac/datalib/egi.py
@@ -204,7 +204,7 @@ class EGI(InterpolationMixin, DataSource):
             _log.warning("No coordinates found in EGI source")
             return Coordinates([], dims=[])
 
-        return Coordinates.from_xarray(self.data.coords, crs=self.data.attrs["crs"])
+        return Coordinates.from_xarray(self.data)
 
     def get_data(self, coordinates, coordinates_index):
         if self.data is not None:


### PR DESCRIPTION
Backwards Incompatible changes
 * removes support for numpy return type from `Algorithm.algorithm`
 * passes `coordinates` into `Algorithm.algorithm`. Using `self._requested_coordinates` is no longer necessary.

Fixes
 * handles extra, missing, and transposed dimensions returned from `Algorithm.algorithm` correctly when `output` is provided.

Testing
 * more comprehensive `Algorithm.algorithm` testing
 * test the base `Algorithm` class without using any `Algorithm` subclasses such as `Arange` and `Arithmetic`

Additional Features
 * `Coordinates.from_xarray` accepts `DataArray` and `Dataset` types, extracting the `coords` and `crs` as needed. You can still pass in `DataArrayCoordinates` and `DatasetCoordinates`.