### PR TITLE
BUGFIX: Nearest Preview Select Coordinates

### DIFF
--- a/podpac/core/interpolation/interpolation_manager.py
+++ b/podpac/core/interpolation/interpolation_manager.py
@@ -481,7 +481,7 @@ class InterpolationManager(object):
                 selected_coords[d] = source_coordinates[d]
             # np.ix_ call doesn't work with slices, and fancy numpy indexing does not work well with mixed slice/index
             if isinstance(selected_coords_idx[d], slice) and index_type != "slice":
-                selected_coords_idx[d] = np.arange(selected_coords[d].size)
+                selected_coords_idx[d] = np.arange(source_coordinates[d].size)[selected_coords_idx[d]]
 
         selected_coords = Coordinates(
             [selected_coords[k] for k in source_coordinates.dims], source_coordinates.dims, crs=source_coordinates.crs

--- a/podpac/core/interpolation/nearest_neighbor_interpolator.py
+++ b/podpac/core/interpolation/nearest_neighbor_interpolator.py
@@ -401,21 +401,23 @@ class NearestPreview(NearestNeighbor):
                         src_delta = (src_stop - src_start) / (src_coords.size - 1)
 
                 ndelta = max(1, np.round(np.abs(dst_delta / src_delta)))
+                idx_offset = 0
                 if src_coords.size == 1:
                     c = src_coords.copy()
                 else:
-                    c = UniformCoordinates1d(
-                        src_start,
-                        # src_stop + ndelta * src_delta / 2,  # The delta/2 ensures the endpoint is included
-                        src_stop,
-                        ndelta * src_delta,
-                        **src_coords.properties
-                    )
+                    c_test = UniformCoordinates1d(src_start, src_stop, ndelta * src_delta, **src_coords.properties)
+                    bounds = source_coordinates[src_dim].bounds
+                    # The delta/2 ensures the endpoint is included when there is a floating point rounding error
+                    # the delta/2 is more than needed, but does guarantee.
+                    src_stop = np.clip(src_stop + ndelta * src_delta / 2, bounds[0], bounds[1])
+                    c = UniformCoordinates1d(src_start, src_stop, ndelta * src_delta, **src_coords.properties)
+                    if c.size > c_test.size:  # need to adjust the index as well
+                        idx_offset = int(ndelta)
 
                 if isinstance(idx, slice):
-                    idx = slice(idx.start, idx.stop, int(ndelta))
+                    idx = slice(idx.start, idx.stop + idx_offset, int(ndelta))
                 else:
-                    idx = slice(idx[0], idx[-1], int(ndelta))
+                    idx = slice(idx[0], idx[-1] + idx_offset, int(ndelta))
             else:
                 c = source_coords[src_dim]
 

--- a/podpac/core/interpolation/nearest_neighbor_interpolator.py
+++ b/podpac/core/interpolation/nearest_neighbor_interpolator.py
@@ -406,7 +406,8 @@ class NearestPreview(NearestNeighbor):
                 else:
                     c = UniformCoordinates1d(
                         src_start,
-                        src_stop + ndelta * src_delta / 2,  # The delta/2 ensures the endpoint is included
+                        # src_stop + ndelta * src_delta / 2,  # The delta/2 ensures the endpoint is included
+                        src_stop,
                         ndelta * src_delta,
                         **src_coords.properties
                     )

--- a/podpac/core/interpolation/test/test_interpolators.py
+++ b/podpac/core/interpolation/test/test_interpolators.py
@@ -33,72 +33,58 @@ class MockArrayDataSource(InterpolationMixin, DataSource):
 
 class TestNearest(object):
     def test_nearest_preview_select(self):
+        reqcoords = Coordinates([[-0.5, 1.5, 3.5], [0.5, 2.5, 4.5]], dims=["lat", "lon"])
+        srccoords = Coordinates([[0, 1, 2, 3, 4, 5], [0, 1, 2, 3, 4, 5]], dims=["lat", "lon"])
 
         # test straight ahead functionality
-        reqcoords = Coordinates([[-0.5, 1.5, 3.5], [0.5, 2.5, 4.5]], dims=["lat", "lon"])
-        srccoords = Coordinates([[0, 1, 2, 3, 4, 5], [0, 1, 2, 3, 4, 5]], dims=["lat", "lon"])
-
         interp = InterpolationManager("nearest_preview")
-
         coords, cidx = interp.select_coordinates(srccoords, reqcoords)
-
-        assert len(coords) == len(srccoords) == len(cidx)
-        assert len(coords["lat"]) == len(reqcoords["lat"])
-        assert len(coords["lon"]) == len(reqcoords["lon"])
-        assert np.all(coords["lat"].coordinates == np.array([0, 2, 4]))
+        np.testing.assert_array_equal(coords["lat"].coordinates, [0, 2, 4])
+        np.testing.assert_array_equal(coords["lon"].coordinates, [0, 2, 4])
+        assert srccoords[cidx] == coords
 
         # test when selection is applied serially
-        # this is equivalent to above
-        reqcoords = Coordinates([[-0.5, 1.5, 3.5], [0.5, 2.5, 4.5]], dims=["lat", "lon"])
-        srccoords = Coordinates([[0, 1, 2, 3, 4, 5], [0, 1, 2, 3, 4, 5]], dims=["lat", "lon"])
-
         interp = InterpolationManager(
             [{"method": "nearest_preview", "dims": ["lat"]}, {"method": "nearest_preview", "dims": ["lon"]}]
         )
 
         coords, cidx = interp.select_coordinates(srccoords, reqcoords)
+        np.testing.assert_array_equal(coords["lat"].coordinates, [0, 2, 4])
+        np.testing.assert_array_equal(coords["lon"].coordinates, [0, 2, 4])
+        assert srccoords[cidx] == coords
 
-        # test when coordinates are stacked and unstacked
-        # TODO: how to handle stacked/unstacked coordinate asynchrony?
-        # reqcoords = Coordinates([[-.5, 1.5, 3.5], [.5, 2.5, 4.5]], dims=['lat', 'lon'])
-        # srccoords = Coordinates([([0, 1, 2, 3, 4, 5], [0, 1, 2, 3, 4, 5])], dims=['lat_lon'])
+    # def test_nearest_preview_select_stacked(self):
+    #     # TODO: how to handle stacked/unstacked coordinate asynchrony?
+    #     reqcoords = Coordinates([[-.5, 1.5, 3.5], [.5, 2.5, 4.5]], dims=['lat', 'lon'])
+    #     srccoords = Coordinates([([0, 1, 2, 3, 4, 5], [0, 1, 2, 3, 4, 5])], dims=['lat_lon'])
 
-        # interp = InterpolationManager('nearest_preview')
+    #     interp = InterpolationManager('nearest_preview')
 
-        # srccoords, srccoords_index = srccoords.intersect(reqcoords, outer=True, return_index=True)
-        # coords, cidx = interp.select_coordinates(reqcoords, srccoords, srccoords_index)
+    #     srccoords, srccoords_index = srccoords.intersect(reqcoords, outer=True, return_index=True)
+    #     coords, cidx = interp.select_coordinates(reqcoords, srccoords, srccoords_index)
 
-        # assert len(coords) == len(srcoords) == len(cidx)
-        # assert len(coords['lat']) == len(reqcoords['lat'])
-        # assert len(coords['lon']) == len(reqcoords['lon'])
-        # assert np.all(coords['lat'].coordinates == np.array([0, 2, 4]))
+    #     assert len(coords) == len(srcoords) == len(cidx)
+    #     assert len(coords['lat']) == len(reqcoords['lat'])
+    #     assert len(coords['lon']) == len(reqcoords['lon'])
+    #     assert np.all(coords['lat'].coordinates == np.array([0, 2, 4]))
 
     def test_nearest_select_issue226(self):
         reqcoords = Coordinates([[-0.5, 1.5, 3.5], [0.5, 2.5, 4.5]], dims=["lat", "lon"])
         srccoords = Coordinates([[0, 1, 2, 3, 4, 5], [0, 1, 2, 3, 4, 5]], dims=["lat", "lon"])
 
+        # test straight ahead functionality
         interp = InterpolationManager("nearest")
-
         coords, cidx = interp.select_coordinates(srccoords, reqcoords)
-
-        assert len(coords) == len(srccoords) == len(cidx)
-        assert len(coords["lat"]) == len(reqcoords["lat"])
-        assert len(coords["lon"]) == len(reqcoords["lon"])
-        assert np.all(coords["lat"].coordinates == np.array([0, 2, 4]))
+        np.testing.assert_array_equal(coords["lat"].coordinates, [0, 2, 4])
+        np.testing.assert_array_equal(coords["lon"].coordinates, [0, 3, 5])
+        assert srccoords[cidx] == coords
 
         # test when selection is applied serially
-        # this is equivalent to above
-        reqcoords = Coordinates([[-0.5, 1.5, 3.5], [0.5, 2.5, 4.5]], dims=["lat", "lon"])
-        srccoords = Coordinates([[0, 1, 2, 3, 4, 5], [0, 1, 2, 3, 4, 5]], dims=["lat", "lon"])
-
         interp = InterpolationManager([{"method": "nearest", "dims": ["lat"]}, {"method": "nearest", "dims": ["lon"]}])
-
         coords, cidx = interp.select_coordinates(srccoords, reqcoords)
-
-        assert len(coords) == len(srccoords) == len(cidx)
-        assert len(coords["lat"]) == len(reqcoords["lat"])
-        assert len(coords["lon"]) == len(reqcoords["lon"])
-        assert np.all(coords["lat"].coordinates == np.array([0, 2, 4]))
+        np.testing.assert_array_equal(coords["lat"].coordinates, [0, 2, 4])
+        np.testing.assert_array_equal(coords["lon"].coordinates, [0, 3, 5])
+        assert srccoords[cidx] == coords
 
     def test_nearest_select_issue445(self):
         sc = Coordinates([clinspace(-59.9, 89.9, 100, name="lat"), clinspace(-179.9, 179.9, 100, name="lon")])


### PR DESCRIPTION
1. Fixes the tests for `test_nearest_preview_select`
    * check both lat and lon coordinates
    * check the returned coordinates index

2. Fixes the `InterpolationManager.select_coordinates` index reconstruction
    * need to reconstruct from the *source* coordinates, not the already selected coordinates
    * this fix applies to all interpolators

3. Fixes the `NearestPreview.select_coordinates` coordinates selection.
    * It appears that the UniformCoordinates1d `stop` sometimes needs a padding included, but not always. We need a test for both cases.