### PR TITLE
Discard extra dimensions when caching datasource and compositor outputs

### DIFF
--- a/podpac/core/compositor/__init__.py
+++ b/podpac/core/compositor/__init__.py
@@ -1,0 +1,3 @@
+from .compositor import BaseCompositor
+from .ordered_compositor import OrderedCompositor
+from .tile_compositor import TileCompositor

--- a/podpac/core/data/datasource.py
+++ b/podpac/core/data/datasource.py
@@ -21,7 +21,7 @@ from podpac.core.units import UnitsDataArray
 from podpac.core.coordinates import Coordinates, Coordinates1d, StackedCoordinates
 from podpac.core.coordinates.utils import VALID_DIMENSION_NAMES, make_coord_delta, make_coord_delta_array
 from podpac.core.node import Node
-from podpac.core.utils import common_doc
+from podpac.core.utils import common_doc, cached_property
 from podpac.core.node import COMMON_NODE_DOC
 
 log = logging.getLogger(__name__)
@@ -221,6 +221,12 @@ class DataSource(Node):
             if self.cache_coordinates:
                 self.put_cache(nc, "coordinates")
         return nc
+
+    @property
+    def dims(self):
+        """ datasource dims. """
+
+        return self.coordinates.dims
 
     # ------------------------------------------------------------------------------------------------------------------
     # Private Methods

--- a/podpac/core/node.py
+++ b/podpac/core/node.py
@@ -281,6 +281,10 @@ class Node(tl.HasTraits):
         key = "output"
         cache_coordinates = coordinates.transpose(*sorted(coordinates.dims))  # order agnostic caching
 
+        if isinstance(self, (podpac.data.DataSource, podpac.core.compositor.BaseCompositor)) and self.dims:
+            extra_dims = [dim for dim in cache_coordinates.dims if dim not in self.dims]
+            cache_coordinates = cache_coordinates.drop(extra_dims)
+
         if not self.force_eval and self.cache_output and self.has_cache(key, cache_coordinates):
             data = self.get_cache(key, cache_coordinates)
             if output is not None:


### PR DESCRIPTION
Closes #293 