### PR TITLE
Performance Optimizations + A few Bug Fixes

### DIFF
--- a/podpac/core/compositor/compositor.py
+++ b/podpac/core/compositor/compositor.py
@@ -32,6 +32,8 @@ class BaseCompositor(Node):
         Source nodes.
     source_coordinates : :class:`podpac.Coordinates`
         Coordinates that make each source unique. Must the same size as ``sources`` and single-dimensional. Optional.
+    eval_serial : bool, optional
+        Default is False. If True, will always evaluate the compositor in serial, ignoring any MULTITHREADING settings
 
     Notes
     -----
@@ -48,6 +50,7 @@ class BaseCompositor(Node):
 
     sources = tl.List(trait=NodeTrait()).tag(attr=True)
     source_coordinates = tl.Instance(Coordinates, allow_none=True, default_value=None).tag(attr=True)
+    eval_serial = tl.Bool(False)
 
     dims = tl.List(trait=Dimension()).tag(attr=True)
     auto_outputs = tl.Bool(False)
@@ -192,14 +195,14 @@ class BaseCompositor(Node):
             yield self.create_output_array(coordinates)
             return
 
-        if settings["MULTITHREADING"]:
+        if settings["MULTITHREADING"] and not self.eval_serial:
             n_threads = thread_manager.request_n_threads(len(sources))
             if n_threads == 1:
                 thread_manager.release_n_threads(n_threads)
         else:
             n_threads = 0
 
-        if settings["MULTITHREADING"] and n_threads > 1:
+        if settings["MULTITHREADING"] and n_threads > 1 and not self.eval_serial:
             # evaluate nodes in parallel using thread pool
             self._multi_threaded = True
             pool = thread_manager.get_thread_pool(processes=n_threads)

--- a/podpac/core/compositor/compositor.py
+++ b/podpac/core/compositor/compositor.py
@@ -32,7 +32,7 @@ class BaseCompositor(Node):
         Source nodes.
     source_coordinates : :class:`podpac.Coordinates`
         Coordinates that make each source unique. Must the same size as ``sources`` and single-dimensional. Optional.
-    eval_serial : bool, optional
+    multithreading : bool, optional
         Default is False. If True, will always evaluate the compositor in serial, ignoring any MULTITHREADING settings
 
     Notes
@@ -50,7 +50,11 @@ class BaseCompositor(Node):
 
     sources = tl.List(trait=NodeTrait()).tag(attr=True)
     source_coordinates = tl.Instance(Coordinates, allow_none=True, default_value=None).tag(attr=True)
-    eval_serial = tl.Bool(False)
+    multithreading = tl.Bool(False)
+
+    @tl.default("multithreading")
+    def _default_multithreading(self):
+        return settings["MULTITHREADING"]
 
     dims = tl.List(trait=Dimension()).tag(attr=True)
     auto_outputs = tl.Bool(False)
@@ -195,14 +199,14 @@ class BaseCompositor(Node):
             yield self.create_output_array(coordinates)
             return
 
-        if settings["MULTITHREADING"] and not self.eval_serial:
+        if self.multithreading:
             n_threads = thread_manager.request_n_threads(len(sources))
             if n_threads == 1:
                 thread_manager.release_n_threads(n_threads)
         else:
             n_threads = 0
 
-        if settings["MULTITHREADING"] and n_threads > 1 and not self.eval_serial:
+        if self.multithreading and n_threads > 1:
             # evaluate nodes in parallel using thread pool
             self._multi_threaded = True
             pool = thread_manager.get_thread_pool(processes=n_threads)

--- a/podpac/core/compositor/ordered_compositor.py
+++ b/podpac/core/compositor/ordered_compositor.py
@@ -21,12 +21,12 @@ class OrderedCompositor(BaseCompositor):
         Source nodes, in order of preference. Later sources are only used where earlier sources do not provide data.
     source_coordinates : :class:`podpac.Coordinates`
         Coordinates that make each source unique. Must the same size as ``sources`` and single-dimensional. Optional.
-    eval_serial : bool, optional
+    multithreading : bool, optional
         Default is True. If True, will always evaluate the compositor in serial, ignoring any MULTITHREADING settings
 
     """
 
-    eval_serial = tl.Bool(True)
+    multithreading = tl.Bool(False)
 
     @common_doc(COMMON_COMPOSITOR_DOC)
     def composite(self, coordinates, data_arrays, result=None):

--- a/podpac/core/compositor/ordered_compositor.py
+++ b/podpac/core/compositor/ordered_compositor.py
@@ -1,6 +1,7 @@
 from __future__ import division, unicode_literals, print_function, absolute_import
 
 import numpy as np
+import traitlets as tl
 
 from podpac.core.node import NodeException
 from podpac.core.units import UnitsDataArray
@@ -20,7 +21,12 @@ class OrderedCompositor(BaseCompositor):
         Source nodes, in order of preference. Later sources are only used where earlier sources do not provide data.
     source_coordinates : :class:`podpac.Coordinates`
         Coordinates that make each source unique. Must the same size as ``sources`` and single-dimensional. Optional.
+    eval_serial : bool, optional
+        Default is True. If True, will always evaluate the compositor in serial, ignoring any MULTITHREADING settings
+
     """
+
+    eval_serial = tl.Bool(True)
 
     @common_doc(COMMON_COMPOSITOR_DOC)
     def composite(self, coordinates, data_arrays, result=None):

--- a/podpac/core/compositor/test/test_ordered_compositor.py
+++ b/podpac/core/compositor/test/test_ordered_compositor.py
@@ -100,8 +100,8 @@ class TestOrderedCompositor(object):
             n_threads_before = podpac.core.managers.multi_threading.thread_manager._n_threads_used
             a = Array(source=np.ones(coords.shape), coordinates=coords, interpolation="bilinear")
             b = Array(source=np.zeros(coords.shape), coordinates=coords, interpolation="bilinear")
-            node = OrderedCompositor(sources=[a, b], eval_serial=False)
-            node2 = OrderedCompositor(sources=[a, b], eval_serial=True)
+            node = OrderedCompositor(sources=[a, b], multithreading=True)
+            node2 = OrderedCompositor(sources=[a, b], multithreading=False)
             output = node.eval(coords)
             output2 = node2.eval(coords)
             np.testing.assert_array_equal(output, a.source)

--- a/podpac/core/compositor/test/test_ordered_compositor.py
+++ b/podpac/core/compositor/test/test_ordered_compositor.py
@@ -100,10 +100,14 @@ class TestOrderedCompositor(object):
             n_threads_before = podpac.core.managers.multi_threading.thread_manager._n_threads_used
             a = Array(source=np.ones(coords.shape), coordinates=coords, interpolation="bilinear")
             b = Array(source=np.zeros(coords.shape), coordinates=coords, interpolation="bilinear")
-            node = OrderedCompositor(sources=[a, b])
+            node = OrderedCompositor(sources=[a, b], eval_serial=False)
+            node2 = OrderedCompositor(sources=[a, b], eval_serial=True)
             output = node.eval(coords)
+            output2 = node2.eval(coords)
             np.testing.assert_array_equal(output, a.source)
+            np.testing.assert_array_equal(output2, a.source)
             assert node._multi_threaded == True
+            assert node2._multi_threaded == False
             assert podpac.core.managers.multi_threading.thread_manager._n_threads_used == n_threads_before
 
     def test_composite_into_result(self):

--- a/podpac/core/coordinates/array_coordinates1d.py
+++ b/podpac/core/coordinates/array_coordinates1d.py
@@ -260,6 +260,7 @@ class ArrayCoordinates1d(Coordinates1d):
     # ------------------------------------------------------------------------------------------------------------------
 
     def __getitem__(self, index):
+        # The following 3 lines are copied by UniformCoordinates1d.__getitem__
         if self.ndim == 1 and np.ndim(index) > 1 and np.array(index).dtype == int:
             index = np.array(index).flatten().tolist()
         return ArrayCoordinates1d(self.coordinates[index], **self.properties)

--- a/podpac/core/coordinates/coordinates.py
+++ b/podpac/core/coordinates/coordinates.py
@@ -360,7 +360,7 @@ class Coordinates(tl.HasTraits):
                 # unstacked
                 d[dim] = ArrayCoordinates1d.from_xarray(xcoords[dim])
 
-        coords = cls(list(d.values()), crs=crs)
+        coords = cls(list(d.values()), crs=crs, validate_crs=False)
         return coords
 
     @classmethod
@@ -472,7 +472,7 @@ class Coordinates(tl.HasTraits):
         return cls.from_definition(coords)
 
     @classmethod
-    def from_geotransform(cls, geotransform, shape, crs=None):
+    def from_geotransform(cls, geotransform, shape, crs=None, validate_crs=True):
         """Creates Coordinates from GDAL Geotransform."""
         tol = 1e-15  # tolerance for deciding when a number is zero
         # Handle the case of rotated coordinates
@@ -504,6 +504,7 @@ class Coordinates(tl.HasTraits):
                 podpac.clinspace(origin[1], end[1], shape[::order][1], "lon"),
             ][::order],
             crs=crs,
+            validate_crs=validate_crs
         )
         return coords
 

--- a/podpac/core/coordinates/coordinates.py
+++ b/podpac/core/coordinates/coordinates.py
@@ -306,7 +306,7 @@ class Coordinates(tl.HasTraits):
         return cls([stacked], crs=crs)
 
     @classmethod
-    def from_xarray(cls, x, crs=None):
+    def from_xarray(cls, x, crs=None, validate_crs=False):
         """
         Create podpac Coordinates from xarray coords.
 
@@ -317,6 +317,8 @@ class Coordinates(tl.HasTraits):
         crs : str, optional
             Coordinate reference system. Supports any PROJ4 or PROJ6 compliant string (https://proj.org/).
             If not provided, the crs will be loaded from ``x.attrs`` if possible.
+        validate_crs: bool, optional
+            Default is False. If True, the crs will be validated.
 
         Returns
         -------
@@ -360,7 +362,7 @@ class Coordinates(tl.HasTraits):
                 # unstacked
                 d[dim] = ArrayCoordinates1d.from_xarray(xcoords[dim])
 
-        coords = cls(list(d.values()), crs=crs, validate_crs=False)
+        coords = cls(list(d.values()), crs=crs, validate_crs=validate_crs)
         return coords
 
     @classmethod

--- a/podpac/core/coordinates/coordinates.py
+++ b/podpac/core/coordinates/coordinates.py
@@ -23,7 +23,7 @@ import logging
 
 import podpac
 from podpac.core.settings import settings
-from podpac.core.utils import OrderedDictTrait, _get_query_params_from_url, _get_param
+from podpac.core.utils import OrderedDictTrait, _get_query_params_from_url, _get_param, cached_property
 from podpac.core.coordinates.utils import has_alt_units
 from podpac.core.coordinates.base_coordinates import BaseCoordinates
 from podpac.core.coordinates.coordinates1d import Coordinates1d
@@ -857,7 +857,7 @@ class Coordinates(tl.HasTraits):
 
         return json.dumps(self.definition, separators=(",", ":"), cls=podpac.core.utils.JSONEncoder)
 
-    @property
+    @cached_property
     def hash(self):
         """:str: Coordinates hash value."""
         # We can't use self.json for the hash because the CRS is not standardized.

--- a/podpac/core/coordinates/coordinates.py
+++ b/podpac/core/coordinates/coordinates.py
@@ -504,7 +504,7 @@ class Coordinates(tl.HasTraits):
                 podpac.clinspace(origin[1], end[1], shape[::order][1], "lon"),
             ][::order],
             crs=crs,
-            validate_crs=validate_crs
+            validate_crs=validate_crs,
         )
         return coords
 

--- a/podpac/core/coordinates/uniform_coordinates1d.py
+++ b/podpac/core/coordinates/uniform_coordinates1d.py
@@ -17,6 +17,7 @@ from podpac.core.coordinates.utils import (
 )
 from podpac.core.coordinates.coordinates1d import Coordinates1d
 from podpac.core.coordinates.array_coordinates1d import ArrayCoordinates1d
+from podpac.core.utils import cached_property
 
 
 class UniformCoordinates1d(Coordinates1d):
@@ -215,7 +216,10 @@ class UniformCoordinates1d(Coordinates1d):
     def __getitem__(self, index):
         # fallback for non-slices
         if not isinstance(index, slice):
-            return ArrayCoordinates1d(self.coordinates, **self.properties)[index]
+            # The following 3 lines is copied from ArrayCoordinates1d.__getitem__
+            if self.ndim == 1 and np.ndim(index) > 1 and np.array(index).dtype == int:
+                index = np.array(index).flatten().tolist()
+            return ArrayCoordinates1d(self.coordinates[index], **self.properties)
 
         # start, stop, step
         if index.start is None:
@@ -269,7 +273,7 @@ class UniformCoordinates1d(Coordinates1d):
     # Properties
     # ------------------------------------------------------------------------------------------------------------------
 
-    @property
+    @cached_property
     def coordinates(self):
         """:array, read-only: Coordinate values. """
 

--- a/podpac/core/data/rasterio_source.py
+++ b/podpac/core/data/rasterio_source.py
@@ -82,8 +82,10 @@ class RasterioRaw(S3Mixin, BaseFileSource):
                 aws_unsigned=self.anon,
             )
 
-        with rasterio.env.Env(**envargs) as env:
-            _logger.debug("Rasterio environment options: {}".format(env.options))
+            with rasterio.env.Env(**envargs) as env:
+                _logger.debug("Rasterio environment options: {}".format(env.options))
+                return rasterio.open(self.source)
+        else:
             return rasterio.open(self.source)
 
     @tl.default("band")

--- a/podpac/core/data/rasterio_source.py
+++ b/podpac/core/data/rasterio_source.py
@@ -17,7 +17,7 @@ rasterio = lazy_module("rasterio")
 boto3 = lazy_module("boto3")
 
 from podpac.core.utils import common_doc, cached_property
-from podpac.core.coordinates import UniformCoordinates1d, Coordinates
+from podpac.core.coordinates import UniformCoordinates1d, Coordinates, merge_dims
 from podpac.core.data.datasource import COMMON_DATA_DOC, DATA_DOC
 from podpac.core.data.file_source import BaseFileSource
 from podpac.core.authentication import S3Mixin
@@ -219,6 +219,9 @@ class RasterioRaw(S3Mixin, BaseFileSource):
             slc = (slice(window[0][0], window[0][1], 1), slice(window[1][0], window[1][1], 1))
             new_coords = Coordinates.from_geotransform(dataset.transform.to_gdal(), dataset.shape, crs=self.coordinates.crs)
             new_coords = new_coords[slc]
+            missing_coords = self.coordinates.drop(['lat', 'lon'])
+            new_coords = merge_dims([new_coords, missing_coords])
+            new_coords = new_coords.transpose(*self.coordinates.dims)
             coordinates_shape = new_coords.shape[:2]
 
             # The following lines are *nearly* copied/pasted from get_data

--- a/podpac/core/interpolation/interpolation_manager.py
+++ b/podpac/core/interpolation/interpolation_manager.py
@@ -485,7 +485,10 @@ class InterpolationManager(object):
                 selected_coords_idx[d] = np.arange(source_coordinates[d].size)[selected_coords_idx[d]]
 
         selected_coords = Coordinates(
-            [selected_coords[k] for k in source_coordinates.dims], source_coordinates.dims, crs=source_coordinates.crs, validate_crs=False
+            [selected_coords[k] for k in source_coordinates.dims],
+            source_coordinates.dims,
+            crs=source_coordinates.crs,
+            validate_crs=False,
         )
         if index_type == "numpy":
             selected_coords_idx2 = np.ix_(*[np.ravel(selected_coords_idx[k]) for k in source_coordinates.dims])

--- a/podpac/core/interpolation/interpolation_manager.py
+++ b/podpac/core/interpolation/interpolation_manager.py
@@ -485,7 +485,7 @@ class InterpolationManager(object):
                 selected_coords_idx[d] = np.arange(source_coordinates[d].size)[selected_coords_idx[d]]
 
         selected_coords = Coordinates(
-            [selected_coords[k] for k in source_coordinates.dims], source_coordinates.dims, crs=source_coordinates.crs
+            [selected_coords[k] for k in source_coordinates.dims], source_coordinates.dims, crs=source_coordinates.crs, validate_crs=False
         )
         if index_type == "numpy":
             selected_coords_idx2 = np.ix_(*[np.ravel(selected_coords_idx[k]) for k in source_coordinates.dims])

--- a/podpac/core/interpolation/xarray_interpolator.py
+++ b/podpac/core/interpolation/xarray_interpolator.py
@@ -116,7 +116,8 @@ class XarrayInterpolator(Interpolator):
             for d in source_coordinates.dims:
                 if not np.any(np.isnan(source_data)):
                     break
-                source_data = source_data.interpolate_na(method=self.method, dim=d)
+                #use_coordinate=False allows for interpolation when dimension is not monotonically increasing
+                source_data = source_data.interpolate_na(method=self.method, dim=d, use_coordinate=False)
 
         if self.method == "bilinear":
             self.method = "linear"

--- a/podpac/core/interpolation/xarray_interpolator.py
+++ b/podpac/core/interpolation/xarray_interpolator.py
@@ -116,7 +116,7 @@ class XarrayInterpolator(Interpolator):
             for d in source_coordinates.dims:
                 if not np.any(np.isnan(source_data)):
                     break
-                #use_coordinate=False allows for interpolation when dimension is not monotonically increasing
+                # use_coordinate=False allows for interpolation when dimension is not monotonically increasing
                 source_data = source_data.interpolate_na(method=self.method, dim=d, use_coordinate=False)
 
         if self.method == "bilinear":

--- a/podpac/core/node.py
+++ b/podpac/core/node.py
@@ -587,7 +587,7 @@ class Node(tl.HasTraits):
 
         return json.dumps(self.definition, indent=4, cls=JSONEncoder)
 
-    @property
+    @cached_property
     def hash(self):
         """ hash for this node, used in caching and to determine equality. """
 

--- a/podpac/core/utils.py
+++ b/podpac/core/utils.py
@@ -476,6 +476,7 @@ def resolve_bbox_order(bbox, crs, size):
 
     return {"lat": [lat_start, lat_stop, size[0]], "lon": [lon_start, lon_stop, size[1]]}
 
+
 def probe_node(node, lat=None, lon=None, time=None, alt=None, crs=None, nested=False):
     """Evaluates every part of a node / pipeline at a point and records
     which nodes are actively being used.


### PR DESCRIPTION
A few performance optimizations and bug fixes.

This PR also add the following features:
* `Compositers.eval_serial`: For some compositors, it's important to actually evaluate the nodes in serial for performance reasons. So, even when multi-threading is used, when this flag is `True` the datasources will be serially evaluated.
* `RasterioSource.prefer_overview_closests`: when selecting overview levels, we can either select the coarsest overview smaller than the user-specified step size (based on eval coordinates) OR we can select the overview with the closest step size to the eval coordinates... this may be coarser than the specified coordinates. Setting this attr to `True` will select the closest overview instead of the closests higher resolution overview. 