### PR TITLE
Feature: get_source_data

### DIFF
--- a/doc/source/overview.md
+++ b/doc/source/overview.md
@@ -59,6 +59,16 @@ node = podpac.datalib.TerrainTiles(tile_format='geotiff', zoom=8)
 # ... and more each release
 ```
 
+Retrieve the raw source data array at full/native resolution.
+
+```python
+# retrieve full source data
+node.get_source_data()
+
+# retrieve bounded source data
+node.get_source_data(bounds={'lat': (40, 45), 'lon': (-70, -75)})
+```
+
 ## Coordinates
 
 Define geospatial and temporal dataset coordinates.

--- a/doc/source/overview.md
+++ b/doc/source/overview.md
@@ -59,7 +59,7 @@ node = podpac.datalib.TerrainTiles(tile_format='geotiff', zoom=8)
 # ... and more each release
 ```
 
-Retrieve the raw source data array at full/native resolution.
+Retrieve the raw source data array at full/native resolution. **Note**: Some data source are too large to fit in RAM, and calling this function can crash Python. 
 
 ```python
 # retrieve full source data

--- a/podpac/core/compositor/tile_compositor.py
+++ b/podpac/core/compositor/tile_compositor.py
@@ -83,7 +83,7 @@ class TileCompositorRaw(BaseCompositor):
         """
 
         if any(not hasattr(source, "get_source_data") for source in self.sources):
-            raise ValueError("Cannot get composited source data; all sources must be a DataSource or TileCompositor")
+            raise ValueError("Cannot get composited source data; all sources must have `get_source_data` implemented (such as nodes derived from a DataSource or TileCompositor node).")
 
         coords = None  # n/a
         source_data_arrays = (source.get_source_data(bounds) for source in self.sources)  # generator

--- a/podpac/core/compositor/tile_compositor.py
+++ b/podpac/core/compositor/tile_compositor.py
@@ -67,6 +67,28 @@ class TileCompositorRaw(BaseCompositor):
             return result
         return res
 
+    def get_source_data(self, bounds={}):
+        """
+        Get composited source data, without interpolation.
+
+        Arguments
+        ---------
+        bounds : dict
+            Dictionary of bounds by dimension, optional.
+
+        Returns
+        -------
+        data : UnitsDataArray
+            Source data
+        """
+
+        if any(not hasattr(source, "get_source_data") for source in self.sources):
+            raise ValueError("Cannot get composited source data; all sources must be a DataSource or TileCompositor")
+
+        coords = None  # n/a
+        source_data_arrays = (source.get_source_data(bounds) for source in self.sources)  # generator
+        return self.composite(coords, source_data_arrays)
+
 
 class TileCompositor(InterpolationMixin, TileCompositorRaw):
     pass

--- a/podpac/core/compositor/tile_compositor.py
+++ b/podpac/core/compositor/tile_compositor.py
@@ -75,6 +75,7 @@ class TileCompositorRaw(BaseCompositor):
         ---------
         bounds : dict
             Dictionary of bounds by dimension, optional.
+            Keys must be dimension names, and values are (min, max) tuples, e.g. ``{'lat': (10, 20)}``.
 
         Returns
         -------
@@ -83,7 +84,9 @@ class TileCompositorRaw(BaseCompositor):
         """
 
         if any(not hasattr(source, "get_source_data") for source in self.sources):
-            raise ValueError("Cannot get composited source data; all sources must have `get_source_data` implemented (such as nodes derived from a DataSource or TileCompositor node).")
+            raise ValueError(
+                "Cannot get composited source data; all sources must have `get_source_data` implemented (such as nodes derived from a DataSource or TileCompositor node)."
+            )
 
         coords = None  # n/a
         source_data_arrays = (source.get_source_data(bounds) for source in self.sources)  # generator

--- a/podpac/core/data/datasource.py
+++ b/podpac/core/data/datasource.py
@@ -289,6 +289,7 @@ class DataSource(Node):
         ---------
         bounds : dict
             Dictionary of bounds by dimension, optional.
+            Keys must be dimension names, and values are (min, max) tuples, e.g. ``{'lat': (10, 20)}``.
 
         Returns
         -------

--- a/podpac/core/data/datasource.py
+++ b/podpac/core/data/datasource.py
@@ -281,6 +281,12 @@ class DataSource(Node):
     # Methods
     # ------------------------------------------------------------------------------------------------------------------
 
+    def get_source_data(self, bounds={}):
+        """"""
+
+        coords = self.coordinates.select(bounds)
+        return self.eval(coords)
+
     def eval(self, coordinates, **kwargs):
         """
         Wraps the super Node.eval method in order to cache with the correct coordinates.

--- a/podpac/core/data/datasource.py
+++ b/podpac/core/data/datasource.py
@@ -284,8 +284,8 @@ class DataSource(Node):
     def get_source_data(self, bounds={}):
         """"""
 
-        coords = self.coordinates.select(bounds)
-        return self.eval(coords)
+        coords, I = self.coordinates.select(bounds, return_index=True)
+        return self._get_data(coords, I)
 
     def eval(self, coordinates, **kwargs):
         """

--- a/podpac/core/data/datasource.py
+++ b/podpac/core/data/datasource.py
@@ -282,7 +282,19 @@ class DataSource(Node):
     # ------------------------------------------------------------------------------------------------------------------
 
     def get_source_data(self, bounds={}):
-        """"""
+        """
+        Get source data, without interpolation.
+
+        Arguments
+        ---------
+        bounds : dict
+            Dictionary of bounds by dimension, optional.
+
+        Returns
+        -------
+        data : UnitsDataArray
+            Source data
+        """
 
         coords, I = self.coordinates.select(bounds, return_index=True)
         return self._get_data(coords, I)

--- a/podpac/core/data/ogr.py
+++ b/podpac/core/data/ogr.py
@@ -51,6 +51,26 @@ class OGRRaw(Node):
         layer = self.datasource.GetLayerByName(self.layer)
         return layer.GetExtent()
 
+    def get_source_data(self, bounds={}):
+        """
+        Raise a user-friendly exception when calling get_source_data for this node.
+
+        Arguments
+        ---------
+        bounds : dict
+            Dictionary of bounds by dimension, optional.
+            Keys must be dimension names, and values are (min, max) tuples, e.g. ``{'lat': (10, 20)}``.
+
+        raises
+        ------
+        AttributeError : Cannot get source data for OGR datasources
+        """
+
+        raise AttributeError(
+            "Cannot get source data for OGR datasources. "
+            "The source data is a vector-based shapefile without a native resolution."
+        )
+
     @common_doc(COMMON_NODE_DOC)
     def _eval(self, coordinates, output=None, _selector=None):
         if "lat" not in coordinates.udims or "lon" not in coordinates.udims:

--- a/podpac/core/data/test/test_datasource.py
+++ b/podpac/core/data/test/test_datasource.py
@@ -564,6 +564,24 @@ class TestDataSource(object):
             node.eval(node.coordinates.transform("EPSG:4326"))
             assert node._from_cache
 
+    def test_get_source_data(self):
+        node = podpac.data.Array(
+            source=np.ones((3, 4)),
+            coordinates=podpac.Coordinates([range(3), range(4)], ["lat", "lon"]),
+        )
+
+        data = node.get_source_data()
+        np.testing.assert_array_equal(data, node.source)
+
+    def test_get_source_data_with_bounds(self):
+        node = podpac.data.Array(
+            source=np.ones((3, 4)),
+            coordinates=podpac.Coordinates([range(3), range(4)], ["lat", "lon"]),
+        )
+
+        data = node.get_source_data({"lon": (1.5, 4.5)})
+        np.testing.assert_array_equal(data, node.source[:, 2:])
+
 
 class TestDataSourceWithMultipleOutputs(object):
     def test_evaluate_no_overlap_with_output_extract_output(self):


### PR DESCRIPTION
### Datasource

```python3
>>> node = podpac.data.Array(
...             source=np.ones((3, 4)),
...             coordinates=podpac.Coordinates([range(3), range(4)], ["lat", "lon"]),
...         )
>>> 
>>> node.get_source_data()
<xarray.UnitsDataArray (lat: 3, lon: 4)>
array([[1., 1., 1., 1.],
       [1., 1., 1., 1.],
       [1., 1., 1., 1.]])
Coordinates:
  * lat      (lat) float64 0.0 1.0 2.0
  * lon      (lon) float64 0.0 1.0 2.0 3.0
Attributes:
    layer_style:   <podpac.core.style.Style object at 0x7f7c09fcb730>
    crs:           +proj=longlat +datum=WGS84 +no_defs +vunits=m
    geotransform:  (-0.5, 1.0, 0.0, -0.5, 0.0, 1.0)

```

### TileCompositor

```python3
>>> a = ArrayRaw(source=np.arange(5) + 100, coordinates=podpac.Coordinates([[0, 1, 2, 3, 4]], dims=["lat"]))
>>> b = ArrayRaw(source=np.arange(5) + 200, coordinates=podpac.Coordinates([[5, 6, 7, 8, 9]], dims=["lat"]))
>>> c = ArrayRaw(source=np.arange(5) + 300, coordinates=podpac.Coordinates([[10, 11, 12, 13, 14]], dims=["lat"]))
>>> node = TileCompositorRaw(sources=[a, b, c])
>>> node.get_source_data()
<xarray.UnitsDataArray (lat: 15)>
array([100., 101., 102., 103., 104., 200., 201., 202., 203., 204., 300.,
       301., 302., 303., 304.])
Coordinates:
  * lat      (lat) float64 0.0 1.0 2.0 3.0 4.0 5.0 ... 10.0 11.0 12.0 13.0 14.0
Attributes:
    layer_style:  <podpac.core.style.Style object at 0x7f7bb627a340>
    crs:          +proj=longlat +datum=WGS84 +no_defs +vunits=m
```


### Bounds

```python3
>>> node.get_source_data({"lon": (1.5, 4.5)})
<xarray.UnitsDataArray (lat: 3, lon: 2)>
array([[1., 1.],
       [1., 1.],
       [1., 1.]])
Coordinates:
  * lat      (lat) float64 0.0 1.0 2.0
  * lon      (lon) float64 2.0 3.0
Attributes:
    layer_style:   <podpac.core.style.Style object at 0x7f7bb6566190>
    crs:           +proj=longlat +datum=WGS84 +no_defs +vunits=m
    geotransform:  (1.5, 1.0, 0.0, -0.5, 0.0, 1.0)
```

closes #468 