### PR TITLE
FIX: corrected issue where window did not fully contain evaluation coordinates

### DIFF
--- a/podpac/core/data/rasterio_source.py
+++ b/podpac/core/data/rasterio_source.py
@@ -212,15 +212,11 @@ class Rasterio(S3Mixin, BaseFileSource):
         try:
             # read data within coordinates_index window at the resolution of the overview
             # Rasterio will then automatically pull from the overview
-            window = (
-                ((inds[0].min() // overview), int(np.ceil(inds[0].max() / overview) + 1)),
-                ((inds[1].min() // overview), int(np.ceil(inds[1].max() / overview) + 1)),
-            )
-            slc = (slice(window[0][0], window[0][1], 1), slice(window[1][0], window[1][1], 1))
             new_coords = Coordinates.from_geotransform(
                 dataset.transform.to_gdal(), dataset.shape, crs=self.coordinates.crs
             )
-            new_coords = new_coords[slc]
+            new_coords,slc = new_coords.intersect(coordinates,return_index=True,outer=True)
+            window = ((slc[0].start,slc[0].stop),(slc[1].start,slc[1].stop))
             missing_coords = self.coordinates.drop(["lat", "lon"])
             new_coords = merge_dims([new_coords, missing_coords])
             new_coords = new_coords.transpose(*self.coordinates.dims)

--- a/podpac/core/data/rasterio_source.py
+++ b/podpac/core/data/rasterio_source.py
@@ -151,7 +151,7 @@ class Rasterio(S3Mixin, BaseFileSource):
     def get_data(self, coordinates, coordinates_index):
         """{get_data}"""
         if self.prefer_overviews:
-            return self.get_data_overviews(coordinates, coordinates_index)
+            return self.get_data_overviews(coordinates)
 
         data = self.create_output_array(coordinates)
         slc = coordinates_index
@@ -169,7 +169,12 @@ class Rasterio(S3Mixin, BaseFileSource):
         data.data.ravel()[:] = raster_data.ravel()
         return data
 
-    def get_data_overviews(self, coordinates, coordinates_index):
+    def _get_window_coords(self,coordinates,new_coords):
+        new_coords,slc = new_coords.intersect(coordinates,return_index=True,outer=True)
+        window = ((slc[0].start,slc[0].stop),(slc[1].start,slc[1].stop))
+        return window,new_coords
+
+    def get_data_overviews(self, coordinates):
         # Figure out how much coarser the request is than the actual data
         reduction_factor = np.inf
         for c in ["lat", "lon"]:
@@ -204,7 +209,6 @@ class Rasterio(S3Mixin, BaseFileSource):
             overview = self.overviews[np.argmin(diffs)]
 
         # Now read the data
-        inds = coordinates_index
         if overview_level is None:
             dataset = self.dataset
         else:
@@ -215,8 +219,7 @@ class Rasterio(S3Mixin, BaseFileSource):
             new_coords = Coordinates.from_geotransform(
                 dataset.transform.to_gdal(), dataset.shape, crs=self.coordinates.crs
             )
-            new_coords,slc = new_coords.intersect(coordinates,return_index=True,outer=True)
-            window = ((slc[0].start,slc[0].stop),(slc[1].start,slc[1].stop))
+            window,new_coords = self._get_window_coords_slc(self,coordinates,new_coords)
             missing_coords = self.coordinates.drop(["lat", "lon"])
             new_coords = merge_dims([new_coords, missing_coords])
             new_coords = new_coords.transpose(*self.coordinates.dims)


### PR DESCRIPTION
In the `get_data_overviews` function of `rasterio_source`, the determination of source coordinates was susceptible to error for specific source data coordinates (not often encountered).