### PR TITLE
Fixed bug in rasterio_source.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 3.5.0
+
+### Features
+* Allows users to specify the name of a node when serializing to json #517
+* Allows users to specify custom style class in json node definition #517
+
+### Bugfixes
+* Matplotlib colormap deprecation fix #518
+* Fixed incorrect overview selection in rasterio #519
+
 ## 3.4.1 Point Probe Value Format for Enumerated Legends HOTFIX
 
 ### Hotfix

--- a/podpac/core/data/rasterio_source.py
+++ b/podpac/core/data/rasterio_source.py
@@ -219,7 +219,7 @@ class RasterioRaw(S3Mixin, BaseFileSource):
             new_coords = Coordinates.from_geotransform(
                 dataset.transform.to_gdal(), dataset.shape, crs=self.coordinates.crs
             )
-            window,new_coords = self._get_window_coords_slc(self,coordinates,new_coords)
+            window,new_coords = self._get_window_coords(coordinates,new_coords)
             missing_coords = self.coordinates.drop(["lat", "lon"])
             new_coords = merge_dims([new_coords, missing_coords])
             new_coords = new_coords.transpose(*self.coordinates.dims)

--- a/podpac/core/data/rasterio_source.py
+++ b/podpac/core/data/rasterio_source.py
@@ -151,7 +151,7 @@ class RasterioRaw(S3Mixin, BaseFileSource):
     def get_data(self, coordinates, coordinates_index):
         """{get_data}"""
         if self.prefer_overviews:
-            return self.get_data_overviews(coordinates, coordinates_index)
+            return self.get_data_overviews(coordinates)
 
         data = self.create_output_array(coordinates)
         slc = coordinates_index
@@ -169,7 +169,12 @@ class RasterioRaw(S3Mixin, BaseFileSource):
         data.data.ravel()[:] = raster_data.ravel()
         return data
 
-    def get_data_overviews(self, coordinates, coordinates_index):
+    def _get_window_coords(self,coordinates,new_coords):
+        new_coords,slc = new_coords.intersect(coordinates,return_index=True,outer=True)
+        window = ((slc[0].start,slc[0].stop),(slc[1].start,slc[1].stop))
+        return window,new_coords
+
+    def get_data_overviews(self, coordinates):
         # Figure out how much coarser the request is than the actual data
         reduction_factor = np.inf
         for c in ["lat", "lon"]:
@@ -204,7 +209,6 @@ class RasterioRaw(S3Mixin, BaseFileSource):
             overview = self.overviews[np.argmin(diffs)]
 
         # Now read the data
-        inds = coordinates_index
         if overview_level is None:
             dataset = self.dataset
         else:
@@ -215,8 +219,7 @@ class RasterioRaw(S3Mixin, BaseFileSource):
             new_coords = Coordinates.from_geotransform(
                 dataset.transform.to_gdal(), dataset.shape, crs=self.coordinates.crs
             )
-            new_coords,slc = new_coords.intersect(coordinates,return_index=True,outer=True)
-            window = ((slc[0].start,slc[0].stop),(slc[1].start,slc[1].stop))
+            window,new_coords = self._get_window_coords_slc(self,coordinates,new_coords)
             missing_coords = self.coordinates.drop(["lat", "lon"])
             new_coords = merge_dims([new_coords, missing_coords])
             new_coords = new_coords.transpose(*self.coordinates.dims)

--- a/podpac/core/data/test/test_datasource.py
+++ b/podpac/core/data/test/test_datasource.py
@@ -109,7 +109,7 @@ class TestDataSource(object):
         assert node.get_coordinates_called == 1
 
         # can't set coordinates attribute
-        with pytest.raises(AttributeError, match="can't set attribute"):
+        with pytest.raises(AttributeError):
             node.coordinates = Coordinates([])
 
     def test_dims(self):
@@ -169,7 +169,7 @@ class TestDataSource(object):
 
     def test_set_coordinates(self):
         node = MockDataSource()
-        node.set_coordinates(Coordinates([]))
+        node.set_coordinates(Coordinates([]), force=True)
         assert node.coordinates == Coordinates([])
         assert node.coordinates != node.get_coordinates()
 

--- a/podpac/core/test/test_node.py
+++ b/podpac/core/test/test_node.py
@@ -957,14 +957,8 @@ class TestSerialization(object):
             r"&CRS=EPSG%3A3857&BBOX=-20037508.342789244,10018754.171394618,-10018754.171394622,20037508.34278071&"
             r'PARAMS={"plugin": "podpac.algorithm"}'
         )
-        url1 = (
-            r"https://mobility-devel.crearecomputing.com/geowatch?&SERVICE=WMS&REQUEST=GetMap&VERSION=1.3.0&"
-            r"LAYERS=datalib.terraintiles.TerrainTiles&STYLES=&FORMAT=image%2Fpng&TRANSPARENT=true&HEIGHT=256&WIDTH=256&"
-            r"TIME=2021-03-01T12%3A00%3A00.000Z&CRS=EPSG%3A3857&BBOX=-10018754.171394622,5009377.08569731,-9392582.035682458,5635549.221409475"
-            r'&PARAMS={"style": {"name": "Aspect (Composited 30-90 m)","units": "radians","colormap": "hsv","clim": [0,6.283185307179586]}}'
-        )
+
         node = Node.from_url(url0)
-        node = Node.from_url(url1)
 
     def test_from_name_params(self):
         # Normal

--- a/podpac/core/utils.py
+++ b/podpac/core/utils.py
@@ -157,9 +157,9 @@ class ArrayTrait(tl.TraitType):
         if ndim is not None and shape is not None and len(shape) != ndim:
             raise ValueError("Incompatible ndim and shape (ndim=%d, shape=%s)" % (ndim, shape))
         if dtype is not None and not isinstance(dtype, type):
-            if dtype not in np.typeDict:
+            if dtype not in np.sctypeDict:
                 raise ValueError("Unknown dtype '%s'" % dtype)
-            dtype = np.typeDict[dtype]
+            dtype = np.sctypeDict[dtype]
         self.ndim = ndim
         self.shape = shape
         self.dtype = dtype

--- a/podpac/version.py
+++ b/podpac/version.py
@@ -16,8 +16,8 @@ from collections import OrderedDict
 ## UPDATE VERSION HERE
 ##############
 MAJOR = 3
-MINOR = 4
-HOTFIX = 1
+MINOR = 5
+HOTFIX = 0
 ##############
 
 

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ extras_require = {
     ],
     "aws": ["awscli>=1.16", "boto3>=1.9.200", "s3fs>=0.4"],
     "algorithms": ["numexpr>=2.6"],
-    "datalib": ["podpacdatalib"],
+    # "datalib": ["podpacdatalib"],
     "notebook": [
         "jupyterlab",
         "ipyleaflet",


### PR DESCRIPTION
Was getting this exception, with a fully transparent tile rendered:

```
ERROR:podpac.core.data.rasterio_source:Error occurred when reading overview with Rasterio: 'TerrainTiles30mElev00' object has no attribute '_get_window_coords_slc'
Traceback (most recent call last):
  File "/app/podpac/podpac/core/data/rasterio_source.py", line 222, in get_data_overviews
    window,new_coords = self._get_window_coords_slc(self,coordinates,new_coords)
AttributeError: 'TerrainTiles30mElev00' object has no attribute '_get_window_coords_slc'
WARNING:/app/geowatch/GeoWATCH/utils.py:Compositor could not evalute node <TerrainTiles30mElev00(source='s3://creare-weatherground-large-data/terrain/terrain_tiles_elev_cog_00.tiff', interpolation='nearest') attrs: aws_https, band, boundary, crs, interpolation, nan_val, output, outputs, prefer_overviews_closest, units> with exception local variable 'data' referenced before assignment
Traceback (most recent call last):
  File "/app/geowatch/GeoWATCH/utils.py", line 555, in iteroutputs
    yield src.eval(coordinates, _selector=_selector)
  File "/app/podpac/podpac/core/data/datasource.py", line 353, in eval
    output = super().eval(coordinates, **kwargs)
  File "/app/podpac/podpac/core/node.py", line 299, in eval
    data = self._eval(coordinates, **kwargs)
  File "/app/podpac/podpac/core/interpolation/interpolation.py", line 45, in _eval
    node._source_xr = super()._eval(coordinates, _selector=selector)
  File "/app/podpac/podpac/core/data/datasource.py", line 441, in _eval
    rsd = self._get_data(rsc, rsci)
  File "/app/podpac/podpac/core/data/datasource.py", line 264, in _get_data
    data = self.get_data(rc, rci)
  File "/app/geowatch/GeoWATCH/utils.py", line 54, in get_data
    data = super().get_data(*args, **kwargs)
  File "/app/podpac/podpac/core/data/rasterio_source.py", line 154, in get_data
    return self.get_data_overviews(coordinates)
  File "/app/podpac/podpac/core/data/rasterio_source.py", line 244, in get_data_overviews
    return data
UnboundLocalError: local variable 'data' referenced before assignment
ERROR:podpac.core.data.rasterio_source:Error occurred when reading overview with Rasterio: 'TerrainTiles30mElev02' object has no attribute '_get_window_coords_slc
```