### PR TITLE
Fixed to follow method rename

### DIFF
--- a/podpac/core/data/rasterio_source.py
+++ b/podpac/core/data/rasterio_source.py
@@ -219,7 +219,7 @@ class RasterioRaw(S3Mixin, BaseFileSource):
             new_coords = Coordinates.from_geotransform(
                 dataset.transform.to_gdal(), dataset.shape, crs=self.coordinates.crs
             )
-            window,new_coords = self._get_window_coords_slc(self,coordinates,new_coords)
+            window,new_coords = self._get_window_coords(coordinates,new_coords)
             missing_coords = self.coordinates.drop(["lat", "lon"])
             new_coords = merge_dims([new_coords, missing_coords])
             new_coords = new_coords.transpose(*self.coordinates.dims)


### PR DESCRIPTION
In my test configuration, I was getting fully transparent terrain tiles.  I turned on `exc_info` for some of the debug statements and found the exception below.  I turned `exc_info` back off after, so that is not part of this pull request.

```
ERROR:podpac.core.data.rasterio_source:Error occurred when reading overview with Rasterio: 'TerrainTiles30mElev00' object has no attribute '_get_window_coords_slc'
Traceback (most recent call last):
  File "/app/podpac/podpac/core/data/rasterio_source.py", line 222, in get_data_overviews
    window,new_coords = self._get_window_coords_slc(self,coordinates,new_coords)
AttributeError: 'TerrainTiles30mElev00' object has no attribute '_get_window_coords_slc'
WARNING:/app/geowatch/GeoWATCH/utils.py:Compositor could not evalute node <TerrainTiles30mElev00(source='s3://creare-weatherground-large-data/terrain/terrain_tiles_elev_cog_00.tiff', interpolation='nearest') attrs: aws_https, band, boundary, crs, interpolation, nan_val, output, outputs, prefer_overviews_closest, units> with exception local variable 'data' referenced before assignment
Traceback (most recent call last):
  File "/app/geowatch/GeoWATCH/utils.py", line 555, in iteroutputs
    yield src.eval(coordinates, _selector=_selector)
  File "/app/podpac/podpac/core/data/datasource.py", line 353, in eval
    output = super().eval(coordinates, **kwargs)
  File "/app/podpac/podpac/core/node.py", line 299, in eval
    data = self._eval(coordinates, **kwargs)
  File "/app/podpac/podpac/core/interpolation/interpolation.py", line 45, in _eval
    node._source_xr = super()._eval(coordinates, _selector=selector)
  File "/app/podpac/podpac/core/data/datasource.py", line 441, in _eval
    rsd = self._get_data(rsc, rsci)
  File "/app/podpac/podpac/core/data/datasource.py", line 264, in _get_data
    data = self.get_data(rc, rci)
  File "/app/geowatch/GeoWATCH/utils.py", line 54, in get_data
    data = super().get_data(*args, **kwargs)
  File "/app/podpac/podpac/core/data/rasterio_source.py", line 154, in get_data
    return self.get_data_overviews(coordinates)
  File "/app/podpac/podpac/core/data/rasterio_source.py", line 244, in get_data_overviews
    return data
UnboundLocalError: local variable 'data' referenced before assignment
ERROR:podpac.core.data.rasterio_source:Error occurred when reading overview with Rasterio: 'TerrainTiles30mElev02' object has no attribute '_get_window_coords_slc
```