### PR TITLE
Option to use AWS defaults to login to S3

### DIFF
--- a/podpac/core/authentication.py
+++ b/podpac/core/authentication.py
@@ -190,6 +190,7 @@ class S3Mixin(tl.HasTraits):
     """Mixin to add S3 credentials and access to a Node."""
 
     anon = tl.Bool(False).tag(attr=True)
+    aws_get_auth_from_env = tl.Bool()
     aws_access_key_id = tl.Unicode(allow_none=True)
     aws_secret_access_key = tl.Unicode(allow_none=True)
     aws_region_name = tl.Unicode(allow_none=True)
@@ -213,12 +214,24 @@ class S3Mixin(tl.HasTraits):
     def _get_requester_pays(self):
         return settings["AWS_REQUESTER_PAYS"]
 
+    @tl.default("aws_get_auth_from_env")
+    def _get_aws_get_auth_from_env(self):
+        """
+        Should this class obtain its authentication
+        information from environment variables?
+        Pulls from settings, and if not present in settings,
+        defaults to False.
+        """
+        return settings.get("AWS_GET_AUTH_FROM_ENV", False)
+
     @cached_property
     def s3(self):
         # this has to be done here for multithreading to work
         s3fs = lazy_module("s3fs")
 
-        if self.anon:
+        if self.aws_get_auth_from_env:
+            return s3fs.S3FileSystem()
+        elif self.anon:
             return s3fs.S3FileSystem(anon=True, client_kwargs=self.aws_client_kwargs)
         else:
             return s3fs.S3FileSystem(

--- a/podpac/core/data/rasterio_source.py
+++ b/podpac/core/data/rasterio_source.py
@@ -82,13 +82,16 @@ class RasterioRaw(S3Mixin, BaseFileSource):
         if overview_level is not None:
             kwargs = {"overview_level": overview_level}
         if source.startswith("s3://"):
-            envargs["session"] = rasterio.session.AWSSession(
-                aws_access_key_id=self.aws_access_key_id,
-                aws_secret_access_key=self.aws_secret_access_key,
-                region_name=self.aws_region_name,
-                requester_pays=self.aws_requester_pays,
-                aws_unsigned=self.anon,
-            )
+            if self.aws_get_auth_from_env:
+                envargs["session"] = rasterio.session.AWSSession()
+            else:
+                envargs["session"] = rasterio.session.AWSSession(
+                    aws_access_key_id=self.aws_access_key_id,
+                    aws_secret_access_key=self.aws_secret_access_key,
+                    region_name=self.aws_region_name,
+                    requester_pays=self.aws_requester_pays,
+                    aws_unsigned=self.anon,
+                )
 
             with rasterio.env.Env(**envargs) as env:
                 _logger.debug("Rasterio environment options: {}".format(env.options))


### PR DESCRIPTION
This PR introduces a podpac config file option called `AWS_GET_AUTH_FROM_ENV`, affecting the S3-backed node types `ZarrRaw` and `RasterioRaw` (as well as their derivatives).  If absent or set to `false`, authentication behaves exactly as it did before. If present and set to `true`, S3 authentication will fall back to the `boto3` default methods for finding authentication.  These methods are detailed [in the boto3 documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html) - in short, `boto3` will check the system environment variables, then fall back through several AWS CLI configuration files.

I found that when I used `rasterio` version 1.3.8, `RasterioRaw` was unable to access S3 even when the credentials were working fine.  Upgrading to `rasterio` version 1.4.3 solved the issue.