### PR TITLE
Remove coverage exclusions for more accurate coverage computation

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,5 +12,5 @@ filterwarnings =
   ignore:The truth value of an empty array is ambiguous:DeprecationWarning:xarray
   ignore:dropping variables using `drop` will be deprecated:PendingDeprecationWarning:xarray
 
-[coverage:run]
-omit=*/test/*,podpac/datalib/*,podpac/core/managers/aws*
+# [coverage:run]
+# omit=*/test/*,podpac/datalib/*,podpac/core/managers/aws*


### PR DESCRIPTION
In the deployment environment I've been working with lately, coverage exclusions are ignored by the SonarQube instance.  But the `coverage` tool does pay attention to the exclusions.  So when computing the overall fraction of code covered, SonarQube doesn't find them in the coverage report, and credits the excluded files with 0% coverage.

I figure that, if we remove these exclusions from `podpac`, it not only fixes my problem above, but it also makes future coverage reporting more "honest".  But I can be talked into finding another solution if you have a preference!