### PR TITLE
Fix sonarqube findings

### DIFF
--- a/podpac/core/cache/file_cache_store.py
+++ b/podpac/core/cache/file_cache_store.py
@@ -308,7 +308,7 @@ class FileCacheStore(CacheStore):
     # file storage abstraction
     # -----------------------------------------------------------------------------------------------------------------
 
-    def _save(self, path, s):
+    def _save(self, path, s, metadata=None):
         raise NotImplementedError
 
     def _load(self, path):

--- a/podpac/core/coordinates/coordinates.py
+++ b/podpac/core/coordinates/coordinates.py
@@ -682,7 +682,7 @@ class Coordinates(tl.HasTraits):
 
         # properties
         # TODO check transform instead
-        if self.CRS != other.CRS:
+        if self.pyproj_crs != other.pyproj_crs:
             return False
 
         # full check of underlying coordinates
@@ -799,12 +799,13 @@ class Coordinates(tl.HasTraits):
         return xcoords
 
     @property
-    def CRS(self):
+    def pyproj_crs(self):
+        """Get the pyproj.CRS version of self.crs field"""
         return pyproj.CRS(self.crs)
 
     @property
     def alt_units(self):
-        CRS = self.CRS
+        CRS = self.pyproj_crs
 
         if not has_alt_units(CRS):
             return None
@@ -815,7 +816,7 @@ class Coordinates(tl.HasTraits):
             return d["vunits"]
 
         # get from axis info (is this is ever useful)
-        for axis in self.CRS.axis_info:
+        for axis in self.pyproj_crs.axis_info:
             if axis.direction == "up":
                 return axis.unit_name  # may need to be converted, e.g. "centimetre" > "cm"
 
@@ -845,7 +846,7 @@ class Coordinates(tl.HasTraits):
         d = OrderedDict()
         d["coords"] = [c.full_definition for c in self._coords.values()]
         # "wkt" is suggested as best format: https://proj.org/faq.html#what-is-the-best-format-for-describing-coordinate-reference-systems
-        d["crs"] = self.CRS.to_wkt()
+        d["crs"] = self.pyproj_crs.to_wkt()
         return d
 
     @property
@@ -1379,7 +1380,7 @@ class Coordinates(tl.HasTraits):
         ValueError
             Coordinates must have both lat and lon dimensions if either is defined
         """
-        from_crs = self.CRS
+        from_crs = self.pyproj_crs
         to_crs = pyproj.CRS(crs)
 
         # no transform needed
@@ -1565,9 +1566,9 @@ class Coordinates(tl.HasTraits):
 
         # ellipsoid tuple to pass to geodesic
         ellipsoid_tuple = (
-            self.CRS.ellipsoid.semi_major_metre / 1000,
-            self.CRS.ellipsoid.semi_minor_metre / 1000,
-            1 / self.CRS.ellipsoid.inverse_flattening,
+            self.pyproj_crs.ellipsoid.semi_major_metre / 1000,
+            self.pyproj_crs.ellipsoid.semi_minor_metre / 1000,
+            1 / self.pyproj_crs.ellipsoid.inverse_flattening,
         )
 
         # main execution loop
@@ -1576,23 +1577,23 @@ class Coordinates(tl.HasTraits):
             if dim.is_stacked:
                 if "lat" in dim.dims and "lon" in dim.dims:
                     resolutions[name] = dim.horizontal_resolution(
-                        None, ellipsoid_tuple, self.CRS.coordinate_system.name, restype, units
+                        None, ellipsoid_tuple, self.pyproj_crs.coordinate_system.name, restype, units
                     )
                 elif "lat" in dim.dims:
                     # Calling self['lat'] forces UniformCoordinates1d, even if stacked
                     resolutions["lat"] = self["lat"].horizontal_resolution(
-                        self["lat"], ellipsoid_tuple, self.CRS.coordinate_system.name, restype, units
+                        self["lat"], ellipsoid_tuple, self.pyproj_crs.coordinate_system.name, restype, units
                     )
                 elif "lon" in dim.dims:
                     # Calling self['lon'] forces UniformCoordinates1d, even if stacked
                     resolutions["lon"] = self["lon"].dim.horizontal_resolution(
-                        self["lat"], ellipsoid_tuple, self.CRS.coordinate_system.name, restype, units
+                        self["lat"], ellipsoid_tuple, self.pyproj_crs.coordinate_system.name, restype, units
                     )
             elif (
                 name == "lat" or name == "lon"
             ):  # need to do this inside of loop in case of stacked [[alt,time]] but unstacked [lat, lon]
                 resolutions[name] = dim.horizontal_resolution(
-                    self["lat"], ellipsoid_tuple, self.CRS.coordinate_system.name, restype, units
+                    self["lat"], ellipsoid_tuple, self.pyproj_crs.coordinate_system.name, restype, units
                 )
 
         return resolutions

--- a/podpac/core/coordinates/group_coordinates.py
+++ b/podpac/core/coordinates/group_coordinates.py
@@ -29,14 +29,12 @@ class GroupCoordinates(tl.HasTraits):
     @tl.validate("_items")
     def _validate_items(self, d):
         items = d["value"]
-        if not items:
-            return items
-
-        # unstacked dims must match, but not necessarily in order
-        udims = items[0].udims
-        for c in items:
-            if set(c.udims) != set(udims):
-                raise ValueError("Mismatching dims: %s !~ %s" % (udims, c.udims))
+        if items:
+            # unstacked dims must match, but not necessarily in order
+            udims = items[0].udims
+            for c in items:
+                if set(c.udims) != set(udims):
+                    raise ValueError("Mismatching dims: %s !~ %s" % (udims, c.udims))
 
         return items
 
@@ -50,7 +48,7 @@ class GroupCoordinates(tl.HasTraits):
             list of :class:`Coordinates`
         """
 
-        return super(GroupCoordinates, self).__init__(_items=coords_list)
+        super(GroupCoordinates, self).__init__(_items=coords_list)
 
     def __repr__(self):
         rep = self.__class__.__name__

--- a/podpac/core/coordinates/test/test_coordinates.py
+++ b/podpac/core/coordinates/test/test_coordinates.py
@@ -611,11 +611,11 @@ class TestCoordinateCreation(object):
         with pytest.raises(ValueError):
             Coordinates([alt], crs="EPSG:2193")
 
-    def test_CRS(self):
+    def test_pyproj_crs(self):
         lat = ArrayCoordinates1d([0, 1, 2], "lat")
         lon = ArrayCoordinates1d([0, 1, 2], "lon")
         c = Coordinates([lat, lon])
-        assert isinstance(c.CRS, pyproj.CRS)
+        assert isinstance(c.pyproj_crs, pyproj.CRS)
 
     def test_alt_units(self):
         lat = ArrayCoordinates1d([0, 1, 2], "lat")

--- a/podpac/core/node.py
+++ b/podpac/core/node.py
@@ -587,7 +587,7 @@ class Node(tl.HasTraits):
                         elif isinstance(value, dict):
                             d["inputs"][key] = {k: add_node(v) for k, v in value.items()}
                         else:
-                            raise TypeError("Invalid input '%s' of type '%s': %s" % (key, type(value)))
+                            raise TypeError("Invalid input '%s' of type '%s': %r" % (key, type(value), value))
 
                 if "attrs" in d:
                     # sort and shallow copy

--- a/podpac/core/test/test_authentication.py
+++ b/podpac/core/test/test_authentication.py
@@ -19,9 +19,6 @@ class TestAuthentication(object):
                 del settings["password@test.com"]
 
             # require hostname
-            with pytest.raises(TypeError):
-                set_credentials()
-
             with pytest.raises(ValueError):
                 set_credentials(None, uname="test", password="test")
 

--- a/podpac/core/units.py
+++ b/podpac/core/units.py
@@ -664,9 +664,9 @@ def to_geotiff(fp, data, geotransform=None, crs=None, **kwargs):
     if "lat" not in dims or "lon" not in dims:
         raise NotImplementedError("Cannot export GeoTIFF for dataset with lat/lon coordinates.")
     if "time" in dims and len(data.coords["time"]) > 1:
-        raise NotImplemented("Cannot export GeoTIFF for dataset with multiple times,")
+        raise NotImplementedError("Cannot export GeoTIFF for dataset with multiple times,")
     if "alt" in dims and len(data.coords["alt"]) > 1:
-        raise NotImplemented("Cannot export GeoTIFF for dataset with multiple altitudes.")
+        raise NotImplementedError("Cannot export GeoTIFF for dataset with multiple altitudes.")
 
     # TODO: add proper checks, etc. to make sure we handle edge cases and throw errors when we cannot support
     #       i.e. do work to remove this warning.


### PR DESCRIPTION
This PR fixes some "blocker" level findings in SonarQube.  

The most contentious change here is probably the change to `coordinates.py`.  Sonarqube [took issue with](https://sonarcloud.io/project/issues?impactSeverities=BLOCKER&issueStatuses=OPEN%2CCONFIRMED&id=creare-com_podpac&open=AZFxutjSkYO_0R1F0Oz-) having both a property called `CRS` and a data member called `crs` (differing only by case).  I could not find anything in Creare code referencing the `CRS` property.  So I changed the `CRS` property to `pyproj_crs` and  updated its test. 

We should think a little about whether this counts as an API change.  Depending on how closely we want to follow the [semantic versioning guidelines](https://semver.org/), we might want to update the major version number in whatever release includes this PR.

I think we will have PRs following this one to address Sonarqube findings that are categorized as High or Medium, so we may have more changes like this later that affect our decision to bump the major version number or not.