### PR TITLE
Use pytest's built-in tmp_path

### DIFF
--- a/podpac/core/test/test_settings.py
+++ b/podpac/core/test/test_settings.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 
 from podpac.core.settings import PodpacSettings
 
@@ -6,33 +7,25 @@ _SETTINGS_FILENAME = "settings.json"
 
 
 class TestSettingsFile(object):
-    def tmp_dir_path(self):
-        basedir = os.path.dirname(os.path.realpath(__file__))
-        path = os.path.join(basedir, ".__tmp__")
-        return path
 
-    def make_settings_tmp_dir(self):
-        path = self.tmp_dir_path()
+    @pytest.fixture
+    def settings_tmp_dir(self, tmp_path):
+        path = os.path.join(tmp_path, ".__tmp__")
         os.mkdir(path)  # intentionally fails if this folder already exists as it will be deleted
-        return path
-
-    def teardown_method(self):
-        path = self.tmp_dir_path()
+        yield path
         try:
             os.remove(os.path.join(path, _SETTINGS_FILENAME))
         except OSError:  # FileNotFoundError in py 3
             pass
-
         os.rmdir(path)  # intentionally fails if anything else is in this folder
 
     def test_settings_file_defaults_to_home_dir(self):
-        self.make_settings_tmp_dir()  # so teardown method has something ot tear down
         settings = PodpacSettings()
         path = os.environ.get("XDG_CACHE_HOME", os.path.expanduser("~"))
         assert settings.settings_path == os.path.join(path, ".config", "podpac", _SETTINGS_FILENAME)
 
-    def test_single_saved_setting_persists(self):
-        path = self.make_settings_tmp_dir()
+    def test_single_saved_setting_persists(self, settings_tmp_dir):
+        path = settings_tmp_dir
 
         key = "key"
         value = "value"
@@ -45,8 +38,8 @@ class TestSettingsFile(object):
         new_settings.load(path=path)
         assert new_settings[key] == value
 
-    def test_multiple_saved_settings_persist(self):
-        path = self.make_settings_tmp_dir()
+    def test_multiple_saved_settings_persist(self, settings_tmp_dir):
+        path = settings_tmp_dir
 
         key1 = "key1"
         value1 = "value1"
@@ -64,8 +57,8 @@ class TestSettingsFile(object):
         assert new_settings[key1] == value1
         assert new_settings[key2] == value2
 
-    def test_misconfigured_settings_file_fall_back_on_default(self):
-        path = self.make_settings_tmp_dir()
+    def test_misconfigured_settings_file_fall_back_on_default(self, settings_tmp_dir):
+        path = settings_tmp_dir
 
         with open(os.path.join(path, _SETTINGS_FILENAME), "w") as f:
             f.write("not proper json")


### PR DESCRIPTION
There are a few tests that create a temporary directory within the PODPAC package itself. These tests can't pass if the package's location is not writeable.  I've updated these tests to use pytest's built-in `tmp_path` instead.