### PR TITLE
Bugfix/interpolation dimensions

### DIFF
--- a/podpac/core/coordinates/stacked_coordinates.py
+++ b/podpac/core/coordinates/stacked_coordinates.py
@@ -329,7 +329,7 @@ class StackedCoordinates(BaseCoordinates):
             dtype = dtypes[0]
         else:
             dtype = object
-        return np.dstack([c.coordinates.astype(dtype) for c in self._coords]).squeeze()
+        return np.stack([c.coordinates.astype(dtype) for c in self._coords], axis=-1)
 
     @property
     def xcoords(self):
@@ -468,7 +468,6 @@ class StackedCoordinates(BaseCoordinates):
                 start = index.start
             return stop - start
         return len(index)
-
 
     def _and_indices(self, indices: List["Coordinates"]):
         """logical AND of the selection in each dimension"""

--- a/podpac/core/coordinates/test/test_stacked_coordinates.py
+++ b/podpac/core/coordinates/test/test_stacked_coordinates.py
@@ -783,12 +783,14 @@ class TestStackedCoordinatesMethods(object):
         sc_3 = StackedCoordinates([lat[::-1], lon], name="lat_lon")  # same coordinates, paired differently
         sc_t = sc.transpose("lon", "lat")
         sc_time = StackedCoordinates([lat, lon, time], name="lat_lon_time")
+        sc_single_value = StackedCoordinates([lat[0], lon[0]], name="lat_lon")
 
         assert sc.issubset(sc)
         assert sc[:2].issubset(sc)
         assert not sc.issubset(sc[:2])
         assert not sc_2.issubset(sc)
         assert not sc_3.issubset(sc)
+        assert sc_single_value.issubset(sc_single_value)
 
         assert sc_t.issubset(sc)
 

--- a/podpac/core/coordinates/test/test_stacked_coordinates.py
+++ b/podpac/core/coordinates/test/test_stacked_coordinates.py
@@ -791,6 +791,7 @@ class TestStackedCoordinatesMethods(object):
         assert not sc_2.issubset(sc)
         assert not sc_3.issubset(sc)
         assert sc_single_value.issubset(sc_single_value)
+        assert sc_single_value.issubset(sc)
 
         assert sc_t.issubset(sc)
 

--- a/podpac/core/interpolation/interpolation.py
+++ b/podpac/core/interpolation/interpolation.py
@@ -122,12 +122,12 @@ class Interpolate(Node):
 
     @property
     def outputs(self):
-        """ Pass through outputs from source """
+        """Pass through outputs from source"""
         return self.source.outputs
 
     @property
     def coordinates(self):
-        """ Pass through coordinates from source """
+        """Pass through coordinates from source"""
         return self.source.coordinates
 
     @property
@@ -247,7 +247,7 @@ class Interpolate(Node):
         # if requested crs is differented than coordinates,
         # fabricate a new output with the original coordinates and new values
         if self._evaluated_coordinates.crs != coordinates.crs:
-            output = self.create_output_array(self._evaluated_coordinates.drop(extra_dims), data=output[:].values)
+            output = self.create_output_array(self._evaluated_coordinates.udrop(extra_dims), data=output[:].values)
 
         # save output to private for debugging
         if settings["DEBUG"]:

--- a/podpac/core/interpolation/rasterio_interpolator.py
+++ b/podpac/core/interpolation/rasterio_interpolator.py
@@ -98,12 +98,12 @@ class RasterioInterpolator(Interpolator):
 
         with rasterio.Env():
             src_transform = transform.Affine.from_gdal(*source_coordinates.geotransform)
-            src_crs = rasterio.crs.CRS.from_proj4(source_coordinates.crs)
+            src_crs = rasterio.crs.CRS.from_string(source_coordinates.crs)
             # Need to make sure array is c-contiguous
             source = np.ascontiguousarray(source_data.data)
 
             dst_transform = transform.Affine.from_gdal(*eval_coordinates.geotransform)
-            dst_crs = rasterio.crs.CRS.from_proj4(eval_coordinates.crs)
+            dst_crs = rasterio.crs.CRS.from_string(eval_coordinates.crs)
             # Need to make sure array is c-contiguous
             if not output_data.data.flags["C_CONTIGUOUS"]:
                 destination = np.ascontiguousarray(output_data.data)

--- a/podpac/core/interpolation/test/test_interpolation.py
+++ b/podpac/core/interpolation/test/test_interpolation.py
@@ -120,6 +120,26 @@ class TestInterpolationBehavior(object):
         o3 = node.eval(Coordinates(["2018-01-01"], dims=["time"]))
         assert o3.data[0] == 0
 
+    def test_stacked_coordinates_with_extra_dimension_and_non_default_crs(self):
+        """
+        Test interpolation for a request with stacked coordinates containing an extra dimension and non-default CRS.
+        Interpolation is set to "none" to ensure the _fix_coordinates_for_none_interp method is invoked.
+        """
+        node = Array(
+            source=[0, 1, 2],
+            coordinates=Coordinates([[[0, 2, 1], [10, 12, 11]]], dims=["lat_lon"]),
+        ).interpolate(interpolation="none")
+
+        o1 = node.eval(
+            coordinates=Coordinates(
+                [[[0, 2, 1], [10, 12, 11], ["2018-01-01", "2018-01-02", "2018-01-03"]]],
+                dims=["lat_lon_time"],
+                crs="EPSG:4326",
+            )
+        )
+
+        assert_array_equal(o1.data, [0, 1, 2])
+
     def test_ignored_interpolation_params_issue340(self, caplog):
         node = Array(source=[0, 1, 2], coordinates=Coordinates([[0, 2, 1]], dims=["time"])).interpolate(
             interpolation={"method": "nearest", "params": {"fake_param": 1.1, "spatial_tolerance": 1}}


### PR DESCRIPTION
### Changes

- Remove squeeze from Stacked Coordinates to avoid issues with axes being removed unintentionally in the case of single value coordinates.
- Use _udrop_ instead of _drop_ for extra dimensions as the dimensions are found using _udims_ method.
- Allow rasterio interpolator to handle additional CRS formats as coordinates can use PROJ4 or WKT according to documentation.
```
crs : str, optional
            Coordinate reference system. Supports PROJ4 and WKT.
```