### PR TITLE
Switch from relative to absolute pathing for coverage reports

### DIFF
--- a/.github/workflows/gitlab-python-worflow.yml
+++ b/.github/workflows/gitlab-python-worflow.yml
@@ -62,7 +62,7 @@ jobs:
           -m pytest -m "not integration" --continue-on-collection-errors || \
           { echo "WARNING: Some tests have failed. (Temporarily ignored)"; true; }
           coverage xml -o coverage.xml
-
+          sed -i 's,filename="/home/runner/work/podpac/,filename=",g' coverage.xml
       - name: Artifact Coverage Document
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/gitlab-python-worflow.yml
+++ b/.github/workflows/gitlab-python-worflow.yml
@@ -62,7 +62,7 @@ jobs:
           -m pytest -m "not integration" --continue-on-collection-errors || \
           { echo "WARNING: Some tests have failed. (Temporarily ignored)"; true; }
           coverage xml -o coverage.xml
-          sed -i 's,filename="/home/runner/work/podpac/,filename=",g' coverage.xml
+          sed -i 's,filename="/home/runner/work/podpac/,filename="/nonexistent_dir/,g' coverage.xml
       - name: Artifact Coverage Document
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/gitlab-python-worflow.yml
+++ b/.github/workflows/gitlab-python-worflow.yml
@@ -62,7 +62,7 @@ jobs:
           -m pytest -m "not integration" --continue-on-collection-errors || \
           { echo "WARNING: Some tests have failed. (Temporarily ignored)"; true; }
           coverage xml -o coverage.xml
-          sed -i 's,filename="/home/runner/work/podpac/,filename="/nonexistent_dir/,g' coverage.xml
+          sed -i 's,<source>.*/podpac</source>,<source>podpac</source>' coverage.xml
       - name: Artifact Coverage Document
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/gitlab-python-worflow.yml
+++ b/.github/workflows/gitlab-python-worflow.yml
@@ -62,7 +62,7 @@ jobs:
           -m pytest -m "not integration" --continue-on-collection-errors || \
           { echo "WARNING: Some tests have failed. (Temporarily ignored)"; true; }
           coverage xml -o coverage.xml
-          sed -i 's,<source>.*/podpac</source>,<source>podpac</source>' coverage.xml
+          sed -i 's,<source>.*/podpac</source>,<source>podpac</source>,' coverage.xml
       - name: Artifact Coverage Document
         uses: actions/upload-artifact@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,6 @@
 line-length = 120
 
 [tool.coverage.run]
-relative_files = true
+relative_files = false
 source = ["podpac/"]
 branch = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,6 @@
 line-length = 120
 
 [tool.coverage.run]
-relative_files = false
+relative_files = false # For reasoning, see https://github.com/creare-com/podpac/pull/546
 source = ["podpac/"]
 branch = true


### PR DESCRIPTION
Short reason: To help with certain deployments that use podpac as a submodule, working around a limitation in the `coverage` tool.

Long reason:

* SonarQube ingests an XML report, which we name `coverage.xml`
* We generate `coverage.xml` by first running the tests with the `coverage run ` command, which outputs a binary report (`coverage.bin`), then by converting that binary report to XML with the `coverage xml` command.
* SonarQube needs to be able to find the sources referenced in the report.  It runs on a different machine, so it works best and makes sense to send SonarQube a coverage report with relative paths in this XML report.
* Configuration for the `coverage` tool is done in `pyproject.toml`.  Every repo has its own choices about which folders contain source and which ones should be ignored, so it makes sense to keep this configuration on a per-repo basis.
* The `coverage` command can be configured to use absolute or relative paths by this file.  There is not (that I have found) any way to override this at the command line.  The choice of absolute or relative paths applies to all `coverage` subcommands, notably `run`, `combine`, and `xml`.
* So, when you run `coverage run` with relative paths, `coverage xml` must be run at the same working directory, or `coverage xml` won't find the source and will fail.  (I don't know why `coverage xml` requires access to the source files)
* That's not a problem at all when scanning an individual repository.  Since SonarQube requires relative paths, it makes sense to just configure `coverage` to always use relative paths.
* In certain deployments, we structure the repository as follows:

```
root_project_repo
└podpac (as submodule)
└ogc (as submodule)
└other repos (as submodules)
```

For those repos, we wish to compute coverage, and combine them into one summary XML report.  We have to run `coverage run` in each submodule separately, to use each repo's coverage settings from its `pyproject.toml`.  That's not a problem - `coverage combine` will combine binary coverage reports.  But if we use relative paths, then each call to `coverage xml` has to occur with the same working directory as the initial `coverage run`, or `coverage xml` won't find the source files it needs.  That's incompatible with running `coverage run` several times with different working directories.

So the solution I lean toward is to run `coverage run` and `coverage xml` with absolute paths.  SonarQube requires relative paths. It's pretty easy to convert an absolute path to a relative path in an XML file by using `sed`.  So there's a required `sed` command for each CI job, to get it back to relative paths.

An alternative would be to generate one XML report for each submodule, and then stitch them together later.  That's a much more involved level of text postprocessing, so I prefer this solution.

Since this is all a workaround for a limitation in `coverage`, if someone finds a better workaround, or if there is an improvement to the `coverage` tool so that we don't need to do this, we should switch back to relative paths.