### PR TITLE
Change fake access key ID to avoid tripping Trufflehog

### DIFF
--- a/podpac/core/managers/test/test_aws.py
+++ b/podpac/core/managers/test/test_aws.py
@@ -60,8 +60,8 @@ class _MockBoto3Session(boto3_real.Session):
 
     def __init__(self):
         super().__init__(
-            aws_access_key_id="AKIAIOSFODNN7EXAMPLE",
-            aws_secret_access_key="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            aws_access_key_id="example key id",
+            aws_secret_access_key="example key",
             region_name="us-east-1",
         )
         self._clients = {}

--- a/setup.py
+++ b/setup.py
@@ -40,12 +40,11 @@ extras_require = {
     "datatype": [
         "beautifulsoup4>=4.6",
         "h5py>=2.9",
-        "lxml>=4.2",
+        "lxml>=6.1.0",
         "rasterio>=1.0",
         "zarr>=2.3,<3",
         "owslib",
         "h5netcdf",
-        "intake>=0.5.1",
     ],
     "aws": ["awscli>=1.16", "boto3>=1.9.200", "s3fs>=0.4"],
     "algorithms": ["numexpr>=2.6"],


### PR DESCRIPTION
Trufflehog thinks this is a secret because it matches a regular expression:

https://github.com/trufflesecurity/trufflehog/blob/main/pkg/detectors/aws/access_keys/accesskey.go#L78

(At some point in the future maybe we want trufflehog to be part of our CI pipeline)