### PR TITLE
Fixing zarr3 issue for S3

### DIFF
--- a/podpac/core/data/test/test_zarr_compat.py
+++ b/podpac/core/data/test/test_zarr_compat.py
@@ -51,16 +51,77 @@ class TestZarrV3Detection:
         assert zarr_compat._zarr_v3() is True
 
 
+class FakeS3FileSystem:
+    """Duck-typed stand-in for an async-capable fsspec-cached filesystem class
+    (e.g. a reasonably modern s3fs.S3FileSystem, which always subclasses
+    fsspec.asyn.AsyncFileSystem regardless of how it was instantiated)."""
+
+    async_impl = True
+
+    def __init__(self, *args, asynchronous=False, **kwargs):
+        self.asynchronous = asynchronous
+        self.storage_args = args
+        self.storage_options = kwargs
+
+
+class FakeNonAsyncFileSystem:
+    """Duck-typed stand-in for a filesystem class that never implemented the async
+    protocol at all -- e.g. s3fs versions predating fsspec.asyn.AsyncFileSystem,
+    which podpac's own "s3fs>=0.4" floor still technically allows."""
+
+    async_impl = False
+    asynchronous = False
+    protocol = "file"
+
+
 class TestGetS3Store:
-    def test_v3_uses_fsspec_store(self, monkeypatch):
+    def test_v3_converts_sync_async_capable_fs_to_async(self, monkeypatch):
+        # zarr 3's FsspecStore requires (and works best with) an async-native fs;
+        # a sync-mode instance of an async-capable class must be rebuilt as an
+        # async instance, not passed through.
         monkeypatch.setattr(zarr_compat, "_zarr_v3", lambda: True)
         mock_zarr = MagicMock()
         monkeypatch.setattr(zarr_compat, "zarr", mock_zarr)
 
-        fake_s3 = object()
+        fake_s3 = FakeS3FileSystem(key="abc", asynchronous=False)
+        store = get_s3_store(fake_s3, "my-bucket/my-key.zarr")
+
+        args, kwargs = mock_zarr.storage.FsspecStore.call_args
+        used_fs = args[0]
+        assert used_fs is not fake_s3
+        assert used_fs.asynchronous is True
+        assert used_fs.storage_options["key"] == "abc"
+        assert kwargs == {"path": "my-bucket/my-key.zarr"}
+        assert store is mock_zarr.storage.FsspecStore.return_value
+
+    def test_v3_reuses_already_async_fs(self, monkeypatch):
+        monkeypatch.setattr(zarr_compat, "_zarr_v3", lambda: True)
+        mock_zarr = MagicMock()
+        monkeypatch.setattr(zarr_compat, "zarr", mock_zarr)
+
+        fake_s3 = FakeS3FileSystem(key="abc", asynchronous=True)
         store = get_s3_store(fake_s3, "my-bucket/my-key.zarr")
 
         mock_zarr.storage.FsspecStore.assert_called_once_with(fake_s3, path="my-bucket/my-key.zarr")
+        assert store is mock_zarr.storage.FsspecStore.return_value
+
+    def test_v3_wraps_non_async_capable_fs(self, monkeypatch):
+        # A filesystem whose class never implemented the async protocol at all can't be
+        # "reconstructed" into an async instance -- it must be wrapped instead. Without
+        # this, zarr 3's FsspecStore.__init__ raises
+        # TypeError("Filesystem needs to support async operations.").
+        monkeypatch.setattr(zarr_compat, "_zarr_v3", lambda: True)
+        mock_zarr = MagicMock()
+        monkeypatch.setattr(zarr_compat, "zarr", mock_zarr)
+
+        fake_s3 = FakeNonAsyncFileSystem()
+        store = get_s3_store(fake_s3, "my-bucket/my-key.zarr")
+
+        args, kwargs = mock_zarr.storage.FsspecStore.call_args
+        used_fs = args[0]
+        assert used_fs is not fake_s3
+        assert type(used_fs).__name__ == "AsyncFileSystemWrapper"
+        assert kwargs == {"path": "my-bucket/my-key.zarr"}
         assert store is mock_zarr.storage.FsspecStore.return_value
 
     def test_v2_uses_s3map(self, monkeypatch):

--- a/podpac/core/data/test/test_zarr_compat.py
+++ b/podpac/core/data/test/test_zarr_compat.py
@@ -7,6 +7,7 @@ import zarr
 
 from podpac.core.data import zarr_compat
 from podpac.core.data.zarr_compat import (
+    _ensure_async_fs,
     create_zarr_array,
     get_s3_store,
 )
@@ -72,6 +73,29 @@ class FakeNonAsyncFileSystem:
     async_impl = False
     asynchronous = False
     protocol = "file"
+
+
+class TestEnsureAsyncFs:
+    def test_returns_already_async_fs_unchanged(self):
+        fake_s3 = FakeS3FileSystem(key="abc", asynchronous=True)
+        assert _ensure_async_fs(fake_s3) is fake_s3
+
+    def test_rebuilds_async_capable_sync_fs_as_async(self):
+        fake_s3 = FakeS3FileSystem("arg1", key="abc", asynchronous=False)
+        result = _ensure_async_fs(fake_s3)
+
+        assert result is not fake_s3
+        assert isinstance(result, FakeS3FileSystem)
+        assert result.asynchronous is True
+        assert result.storage_args == ("arg1",)
+        assert result.storage_options == {"key": "abc"}
+
+    def test_wraps_non_async_capable_fs(self):
+        fake_s3 = FakeNonAsyncFileSystem()
+        result = _ensure_async_fs(fake_s3)
+
+        assert result is not fake_s3
+        assert type(result).__name__ == "AsyncFileSystemWrapper"
 
 
 class TestGetS3Store:

--- a/podpac/core/data/zarr_compat.py
+++ b/podpac/core/data/zarr_compat.py
@@ -31,7 +31,7 @@ def create_zarr_array(group, name, chunks=None, **kwargs):
     return group.create_dataset(name, **kwargs)
 
 
-def _ensure_async_fs(fs: Any) -> Any:
+def _ensure_async_fs(fs: fsspec.spec.AbstractFileSystem) -> fsspec.spec.AbstractFileSystem:
     """Coerce an fsspec filesystem instance into one zarr 3's FsspecStore accepts.
 
     `S3Mixin` builds a synchronous `s3fs` instance, but zarr 3's `FsspecStore`
@@ -57,12 +57,8 @@ def _ensure_async_fs(fs: Any) -> Any:
         of `type(fs)` constructed with `asynchronous=True` if the class
         supports it; otherwise `fs` wrapped in an `AsyncFileSystemWrapper`.
     """
-    if getattr(fs, "asynchronous", False):
-        return fs
-    if getattr(fs, "async_impl", False):
-        return type(fs)(*fs.storage_args, **{**fs.storage_options, "asynchronous": True})
     from fsspec.implementations.asyn_wrapper import AsyncFileSystemWrapper
-
+    
     return AsyncFileSystemWrapper(fs, asynchronous=True)
 
 

--- a/podpac/core/data/zarr_compat.py
+++ b/podpac/core/data/zarr_compat.py
@@ -5,6 +5,8 @@ zarr 3 removed `Group.create_dataset` in favor of `Group.create_array`, and no
 longer accepts fsspec `MutableMapping` stores (like `s3fs.S3Map`) directly.
 """
 
+from typing import Any
+
 from lazy_import import lazy_module
 
 zarr = lazy_module("zarr")
@@ -29,13 +31,32 @@ def create_zarr_array(group, name, chunks=None, **kwargs):
     return group.create_dataset(name, **kwargs)
 
 
-def _ensure_async_fs(fs):
-    # S3Mixin builds a synchronous s3fs instance, but zarr 3's FsspecStore requires
-    # an async-native filesystem: it raises TypeError if the filesystem's class never
-    # implemented the async protocol (e.g. s3fs versions predating fsspec.asyn.AsyncFileSystem,
-    # which podpac's own "s3fs>=0.4" floor still technically allows), and warns even when the
-    # class is async-capable but this particular instance wasn't created with asynchronous=True.
-    # This mirrors zarr's own internal `_make_async` helper (used by FsspecStore.from_url/from_mapper).
+def _ensure_async_fs(fs: Any) -> Any:
+    """Coerce an fsspec filesystem instance into one zarr 3's FsspecStore accepts.
+
+    `S3Mixin` builds a synchronous `s3fs` instance, but zarr 3's `FsspecStore`
+    requires an async-native filesystem: it raises `TypeError` if the
+    filesystem's class never implemented the async protocol (e.g. s3fs
+    versions predating `fsspec.asyn.AsyncFileSystem`, which podpac's own
+    "s3fs>=0.4" floor still technically allows), and warns even when the class
+    is async-capable but this particular instance wasn't created with
+    `asynchronous=True`. This mirrors zarr's own internal `_make_async` helper
+    (used by `FsspecStore.from_url`/`from_mapper`).
+
+    Parameters
+    ----------
+    fs : fsspec.spec.AbstractFileSystem
+        The filesystem instance to coerce, e.g. an `s3fs.S3FileSystem`. May
+        already be async, async-capable but synchronous, or not async-capable
+        at all.
+
+    Returns
+    -------
+    fsspec.spec.AbstractFileSystem
+        `fs` itself if it is already asynchronous; otherwise a new instance
+        of `type(fs)` constructed with `asynchronous=True` if the class
+        supports it; otherwise `fs` wrapped in an `AsyncFileSystemWrapper`.
+    """
     if getattr(fs, "asynchronous", False):
         return fs
     if getattr(fs, "async_impl", False):

--- a/podpac/core/data/zarr_compat.py
+++ b/podpac/core/data/zarr_compat.py
@@ -29,8 +29,24 @@ def create_zarr_array(group, name, chunks=None, **kwargs):
     return group.create_dataset(name, **kwargs)
 
 
+def _ensure_async_fs(fs):
+    # S3Mixin builds a synchronous s3fs instance, but zarr 3's FsspecStore requires
+    # an async-native filesystem: it raises TypeError if the filesystem's class never
+    # implemented the async protocol (e.g. s3fs versions predating fsspec.asyn.AsyncFileSystem,
+    # which podpac's own "s3fs>=0.4" floor still technically allows), and warns even when the
+    # class is async-capable but this particular instance wasn't created with asynchronous=True.
+    # This mirrors zarr's own internal `_make_async` helper (used by FsspecStore.from_url/from_mapper).
+    if getattr(fs, "asynchronous", False):
+        return fs
+    if getattr(fs, "async_impl", False):
+        return type(fs)(*fs.storage_args, **{**fs.storage_options, "asynchronous": True})
+    from fsspec.implementations.asyn_wrapper import AsyncFileSystemWrapper
+
+    return AsyncFileSystemWrapper(fs, asynchronous=True)
+
+
 def get_s3_store(s3, root):
     if _zarr_v3():
-        return zarr.storage.FsspecStore(s3, path=root)
+        return zarr.storage.FsspecStore(_ensure_async_fs(s3), path=root)
     s3fs = lazy_module("s3fs")
     return s3fs.S3Map(root=root, s3=s3, check=False)

--- a/podpac/core/data/zarr_compat.py
+++ b/podpac/core/data/zarr_compat.py
@@ -5,6 +5,8 @@ zarr 3 removed `Group.create_dataset` in favor of `Group.create_array`, and no
 longer accepts fsspec `MutableMapping` stores (like `s3fs.S3Map`) directly.
 """
 
+from typing import Any
+
 from lazy_import import lazy_module
 
 zarr = lazy_module("zarr")
@@ -29,7 +31,7 @@ def create_zarr_array(group, name, chunks=None, **kwargs):
     return group.create_dataset(name, **kwargs)
 
 
-def _ensure_async_fs(fs: fsspec.spec.AbstractFileSystem) -> fsspec.spec.AbstractFileSystem:
+def _ensure_async_fs(fs: Any) -> Any:
     """Coerce an fsspec filesystem instance into one zarr 3's FsspecStore accepts.
 
     `S3Mixin` builds a synchronous `s3fs` instance, but zarr 3's `FsspecStore`
@@ -55,8 +57,12 @@ def _ensure_async_fs(fs: fsspec.spec.AbstractFileSystem) -> fsspec.spec.Abstract
         of `type(fs)` constructed with `asynchronous=True` if the class
         supports it; otherwise `fs` wrapped in an `AsyncFileSystemWrapper`.
     """
+    if getattr(fs, "asynchronous", False):
+        return fs
+    if getattr(fs, "async_impl", False):
+        return type(fs)(*fs.storage_args, **{**fs.storage_options, "asynchronous": True})
     from fsspec.implementations.asyn_wrapper import AsyncFileSystemWrapper
-    
+
     return AsyncFileSystemWrapper(fs, asynchronous=True)
 
 

--- a/podpac/core/data/zarr_compat.py
+++ b/podpac/core/data/zarr_compat.py
@@ -5,8 +5,6 @@ zarr 3 removed `Group.create_dataset` in favor of `Group.create_array`, and no
 longer accepts fsspec `MutableMapping` stores (like `s3fs.S3Map`) directly.
 """
 
-from typing import Any
-
 from lazy_import import lazy_module
 
 zarr = lazy_module("zarr")


### PR DESCRIPTION
Fixing a type error (Filesystem needs to support async operations) related to zarr3 upgrade. Unit tests added as well.